### PR TITLE
EZP-24304: Provide a way to customize field definition form views

### DIFF
--- a/bundle/Controller/TestController.php
+++ b/bundle/Controller/TestController.php
@@ -109,8 +109,12 @@ class TestController extends Controller
             return $this->redirectToRoute('contenttype/update', ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]);
         }
 
-        return $this->render('EzSystemsRepositoryFormsBundle::update_content_type.html.twig', [
-            'form' => $form->createView()
+        return $this->render('EzSystemsRepositoryFormsBundle:ContentType:update_content_type.html.twig', [
+            'form' => $form->createView(),
+            'contentTypeName' => $contentTypeDraft->getName($languageCode),
+            'contentTypeDraft' => $contentTypeDraft,
+            'languageCode' => $languageCode,
+            'fieldTypeMapperRegistry' => $this->get('ezrepoforms.field_type_form_mapper.registry')
         ]);
     }
 }

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -99,6 +99,10 @@
                 <source>field_definition.ezstring.max_length</source>
                 <target>Maximum length</target>
             </trans-unit>
+            <trans-unit id="25">
+                <source>field_definition.ezstring.default_value</source>
+                <target>Default value</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>content_type.name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>content_type.identifier</source>
+                <target>Identifier</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>content_type.description</source>
+                <target>Description</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>content_type.name_schema</source>
+                <target>Content name pattern</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>content_type.url_alias_schema</source>
+                <target>URL alias name pattern</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>content_type.is_container</source>
+                <target>Container</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>content_type.default_sort_field</source>
+                <target>Default field for sorting children</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>content_type.default_sort_order</source>
+                <target>Default sort order</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>content_type.default_always_available</source>
+                <target>Default content availability</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>content_type.field_definitions_data</source>
+                <target>Content field definitions</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>content_type.field_type_selection</source>
+                <target>Field type selection</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>content_type.add_field_definition</source>
+                <target>Add field definition</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>content_type.save</source>
+                <target>Apply</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>content_type.edit_title</source>
+                <target>Edit &lt;%contentTypeName%&gt;</target>
+            </trans-unit>
+            <!-- Field definition -->
+            <trans-unit id="15">
+                <source>field_definition.name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>field_definition.identifier</source>
+                <target>Identifier</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>field_definition.description</source>
+                <target>Description</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>field_definition.is_required</source>
+                <target>Required</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>field_definition.is_translatable</source>
+                <target>Translatable</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>field_definition.field_group</source>
+                <target>Category</target>
+            </trans-unit>
+            <trans-unit id="21">
+                <source>field_definition.position</source>
+                <target>Position</target>
+            </trans-unit>
+            <trans-unit id="22">
+                <source>field_definition.is_searchable</source>
+                <target>Searchable</target>
+            </trans-unit>
+            <trans-unit id="23">
+                <source>field_definition.ezstring.min_length</source>
+                <target>Minimum length</target>
+            </trans-unit>
+            <trans-unit id="24">
+                <source>field_definition.ezstring.max_length</source>
+                <target>Maximum length</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/bundle/Resources/views/ContentType/field_definition_row.html.twig
+++ b/bundle/Resources/views/ContentType/field_definition_row.html.twig
@@ -1,0 +1,71 @@
+{# @var value \EzSystems\RepositoryForms\Data\FieldDefinitionData #}
+{% block form_row %}
+    <div class="field-definition-edit field-type-{{ value.fieldTypeIdentifier }}">
+        <h3>{{ value.names[languageCode] }} [{{ value.fieldTypeIdentifier }}] (id: {{ value.fieldDefinition.id }})</h3>
+
+        <div class="field-definition-position">
+            {{ form_label(form.position) }}
+            {{ form_errors(form.position) }}
+            {{ form_widget(form.position) }}
+        </div>
+
+        <div class="field-definition-name">
+            {{ form_label(form.name) }}
+            {{ form_errors(form.name) }}
+            {{ form_widget(form.name) }}
+        </div>
+
+        <div class="field-definition-identifier">
+            {{ form_label(form.identifier) }}
+            {{ form_errors(form.identifier) }}
+            {{ form_widget(form.identifier) }}
+        </div>
+
+        <div class="field-definition-description">
+            {{ form_label(form.description) }}
+            {{ form_errors(form.description) }}
+            {{ form_widget(form.description) }}
+        </div>
+
+        <div class="field-definition-isRequired">
+            {{ form_label(form.isRequired) }}
+            {{ form_errors(form.isRequired) }}
+            {{ form_widget(form.isRequired) }}
+        </div>
+
+        <div class="field-definition-isSearchable">
+            {{ form_label(form.isSearchable) }}
+            {{ form_errors(form.isSearchable) }}
+            {{ form_widget(form.isSearchable) }}
+        </div>
+
+        <div class="field-definition-isTranslatable">
+            {{ form_label(form.isTranslatable) }}
+            {{ form_errors(form.isTranslatable) }}
+            {{ form_widget(form.isTranslatable) }}
+        </div>
+
+        <div class="field-definition-fieldGroup">
+            {{ form_label(form.fieldGroup) }}
+            {{ form_errors(form.fieldGroup) }}
+            {{ form_widget(form.fieldGroup) }}
+        </div>
+
+        {# Field type specific fields below #}
+        {# Use field type config, if provided. #}
+        {% if fieldTypeConfig["template"] is defined %}
+            {% set includeVars = {"data": value, "languageCode": languageCode, "contentTypeDraft": contentTypeDraft, "form": form} %}
+            {% set configVars = fieldTypeConfig["vars"]|default({}) %}
+            {{ include(fieldTypeConfig["template"], includeVars|merge(configVars), with_context = false) }}
+        {% else %}
+            {# Default rendering #}
+            {% for child in form %}
+                {% if not child.rendered %}
+                    {{ form_label(child) }}
+                    {{ form_errors(child) }}
+                    {{ form_widget(child) }}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/bundle/Resources/views/ContentType/update_content_type.html.twig
+++ b/bundle/Resources/views/ContentType/update_content_type.html.twig
@@ -1,0 +1,75 @@
+{# @var contentTypeDraft \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft #}
+{# @var fieldTypeMapper \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface #}
+<h1>{{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, 'ezrepoforms_content_type') }}</h1>
+Last modified: {{ contentTypeDraft.modificationDate|localizeddate('medium', 'medium', app.request.locale) }}
+
+{{ form_start(form) }}
+    {{ form_errors(form) }}
+
+    <div>
+        {{ form_label(form.name) }}
+        {{ form_errors(form.name) }}
+        {{ form_widget(form.name) }}
+    </div>
+
+    <div>
+        {{ form_label(form.identifier) }}
+        {{ form_errors(form.identifier) }}
+        {{ form_widget(form.identifier) }}
+    </div>
+
+    <div>
+        {{ form_label(form.description) }}
+        {{ form_errors(form.description) }}
+        {{ form_widget(form.description) }}
+    </div>
+
+    <div>
+        {{ form_label(form.nameSchema) }}
+        {{ form_errors(form.nameSchema) }}
+        {{ form_widget(form.nameSchema) }}
+    </div>
+
+    <div>
+        {{ form_label(form.urlAliasSchema) }}
+        {{ form_errors(form.urlAliasSchema) }}
+        {{ form_widget(form.urlAliasSchema) }}
+    </div>
+
+    <div>
+        {{ form_label(form.isContainer) }}
+        {{ form_errors(form.isContainer) }}
+        {{ form_widget(form.isContainer) }}
+    </div>
+
+    <div>
+        {{ form_label(form.defaultSortField) }}
+        {{ form_errors(form.defaultSortField) }}
+        {{ form_widget(form.defaultSortField) }}
+    </div>
+
+    <div>
+        {{ form_label(form.defaultSortOrder) }}
+        {{ form_errors(form.defaultSortOrder) }}
+        {{ form_widget(form.defaultSortOrder) }}
+    </div>
+
+    <div>
+        {{ form_label(form.defaultAlwaysAvailable) }}
+        {{ form_errors(form.defaultAlwaysAvailable) }}
+        {{ form_widget(form.defaultAlwaysAvailable) }}
+    </div>
+
+    <h2>{{ form_label(form.fieldDefinitionsData) }}</h2>
+    {% for fieldDefForm in form.fieldDefinitionsData %}
+        {% form_theme fieldDefForm "EzSystemsRepositoryFormsBundle:ContentType:field_definition_row.html.twig" %}
+        {% set fieldTypeConfig, fieldTypeIdentifier = {}, fieldDefForm.vars.data.fieldTypeIdentifier %}
+
+        {% if fieldTypeMapperRegistry.hasMapper(fieldTypeIdentifier) %}
+            {% set fieldTypeConfig = fieldTypeMapperRegistry.getMapper(fieldTypeIdentifier).fieldDefinitionEditConfig %}
+        {% endif %}
+        {{ form_row(fieldDefForm, {'contentTypeDraft': contentTypeDraft, 'languageCode': languageCode, 'fieldTypeConfig': fieldTypeConfig}) }}
+        {% if not loop.last %}<hr>{% endif %}
+    {% endfor %}
+
+{{ form_end(form) }}

--- a/bundle/Resources/views/FieldDefinition/ezstring_edit.html.twig
+++ b/bundle/Resources/views/FieldDefinition/ezstring_edit.html.twig
@@ -9,3 +9,9 @@
     {{ form_errors(form.maxLength) }}
     {{ form_widget(form.maxLength) }}
 </div>
+
+<div class="ezstring-default-value">
+    {{ form_label(form.defaultValue) }}
+    {{ form_errors(form.defaultValue) }}
+    {{ form_widget(form.defaultValue) }}
+</div>

--- a/bundle/Resources/views/FieldDefinition/ezstring_edit.html.twig
+++ b/bundle/Resources/views/FieldDefinition/ezstring_edit.html.twig
@@ -1,0 +1,11 @@
+<div class="ezstring-validator min-length">
+    {{ form_label(form.minLength) }}
+    {{ form_errors(form.minLength) }}
+    {{ form_widget(form.minLength) }}
+</div>
+
+<div class="ezstring-validator max-length">
+    {{ form_label(form.maxLength) }}
+    {{ form_errors(form.maxLength) }}
+    {{ form_widget(form.maxLength) }}
+</div>

--- a/bundle/Resources/views/update_content_type.html.twig
+++ b/bundle/Resources/views/update_content_type.html.twig
@@ -1,2 +1,0 @@
-<h1>Content Type update</h1>
-{{ form(form) }}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-api": "dev-master",
+        "ezsystems/ezpublish-kernel": "dev-master",
         "symfony/form": "~2.6"
     },
     "require-dev": {

--- a/lib/FieldType/DataTransformer/TextLineValueTransformer.php
+++ b/lib/FieldType/DataTransformer/TextLineValueTransformer.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
+
+use eZ\Publish\Core\FieldType\TextLine\Value;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * DataTransformer for TextLine\Value.
+ * Needed to display the form field correctly and transform it back to an appropriate value object.
+ */
+class TextLineValueTransformer implements DataTransformerInterface
+{
+    public function transform($value)
+    {
+        if (!$value instanceof Value) {
+            return null;
+        }
+
+        return $value->text;
+    }
+
+    public function reverseTransform($value)
+    {
+        if (!$value) {
+            return null;
+        }
+
+        return new Value($value);
+    }
+}

--- a/lib/FieldType/FieldTypeFormMapperInterface.php
+++ b/lib/FieldType/FieldTypeFormMapperInterface.php
@@ -32,4 +32,21 @@ interface FieldTypeFormMapperInterface
      * @return void
      */
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data);
+
+    /**
+     * Returns a hash containing config for edit form.
+     * Can return an empty array if no config is required. In that case, fields defined in mapFieldDefinition()
+     * will be rendered with default label/errors/widget views.
+     *
+     * The hash may contain following keys:
+     * - "template": Template where specific form fields defined in mapFieldDefinitionForm() will be displayed.
+     *   Default passed variables are:
+     *     - "data": FieldDefinitionData object
+     *     - "languageCode": Language code as passed to the main form
+     *     - "contentTypeDraft": The ContentTypeDraft object
+     * - "vars": Hash of additional variables to pass to the template.
+     *
+     * @return array
+     */
+    public function getFieldDefinitionEditConfig();
 }

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -29,4 +29,9 @@ class TextLineFormMapper implements FieldTypeFormMapperInterface
                 'label' => 'field_definition.ezstring.max_length',
             ]);
     }
+
+    public function getFieldDefinitionEditConfig()
+    {
+        return ['template' => 'EzSystemsRepositoryFormsBundle:FieldDefinition:ezstring_edit.html.twig'];
+    }
 }

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -10,6 +10,7 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\TextLineValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -27,7 +28,18 @@ class TextLineFormMapper implements FieldTypeFormMapperInterface
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][maxStringLength]',
                 'label' => 'field_definition.ezstring.max_length',
-            ]);
+            ])
+            ->add(
+                // Creating from FormBuilder as we need to add a DataTransformer.
+                $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()
+                    ->create('defaultValue', 'text', [
+                        'required' => false,
+                        'label' => 'field_definition.ezstring.default_value'
+                    ])
+                    ->addModelTransformer(new TextLineValueTransformer())
+                    // Deactivate auto-initialize as we're not on the root form.
+                    ->setAutoInitialize(false)->getForm()
+            );
     }
 
     public function getFieldDefinitionEditConfig()

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -21,10 +21,12 @@ class TextLineFormMapper implements FieldTypeFormMapperInterface
             ->add('minLength', 'integer', [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][minStringLength]',
+                'label' => 'field_definition.ezstring.min_length',
             ])
             ->add('maxLength', 'integer', [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][maxStringLength]',
+                'label' => 'field_definition.ezstring.max_length',
             ]);
     }
 }

--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -47,7 +47,8 @@ class ContentTypeUpdateType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'data_class' => 'EzSystems\RepositoryForms\Data\ContentTypeData'
+                'data_class' => 'EzSystems\RepositoryForms\Data\ContentTypeData',
+                'translation_domain' => 'ezrepoforms_content_type',
             ])
             ->setRequired(['languageCode']);
     }
@@ -58,18 +59,22 @@ class ContentTypeUpdateType extends AbstractType
         $builder
             ->add(
                 $builder
-                    ->create('name', 'text', ['property_path' => 'names'])
+                    ->create('name', 'text', ['property_path' => 'names', 'label' => 'content_type.name'])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('identifier', 'text')
+            ->add('identifier', 'text', ['label' => 'content_type.identifier'])
             ->add(
                 $builder
-                    ->create('description', 'text', ['property_path' => 'descriptions', 'required' => false])
+                    ->create('description', 'text', [
+                        'property_path' => 'descriptions',
+                        'required' => false,
+                        'label' => 'content_type.description'
+                    ])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('nameSchema', 'text', ['required' => false])
-            ->add('urlAliasSchema', 'text', ['required' => false])
-            ->add('isContainer', 'checkbox', ['required' => false])
+            ->add('nameSchema', 'text', ['required' => false, 'label' => 'content_type.name_schema'])
+            ->add('urlAliasSchema', 'text', ['required' => false, 'label' => 'content_type.url_alias_schema'])
+            ->add('isContainer', 'checkbox', ['required' => false, 'label' => 'content_type.is_container'])
             ->add('defaultSortField', 'choice', [
                 'choices' => [
                     Location::SORT_FIELD_NAME => 'Content name',
@@ -81,25 +86,32 @@ class ContentTypeUpdateType extends AbstractType
                     Location::SORT_FIELD_MODIFIED => 'Modification date',
                     Location::SORT_FIELD_PUBLISHED => 'Publication date',
                     Location::SORT_FIELD_SECTION => 'Section',
-                ]
+                ],
+                'label' => 'content_type.default_sort_field',
             ])
             ->add('defaultSortOrder', 'choice', [
                 'choices' => [
                     Location::SORT_ORDER_ASC => 'Ascending',
                     Location::SORT_ORDER_DESC => 'Descending',
-                ]
+                ],
+                'label' => 'content_type.default_sort_order',
             ])
-            ->add('defaultAlwaysAvailable', 'checkbox', ['required' => false])
+            ->add('defaultAlwaysAvailable', 'checkbox', [
+                'required' => false,
+                'label' => 'content_type.default_always_available',
+            ])
             ->add('fieldDefinitionsData', 'collection', [
                 'type' => 'ezrepoforms_fielddefinition_update',
-                'options' => ['languageCode' => $options['languageCode']]
+                'options' => ['languageCode' => $options['languageCode']],
+                'label' => 'content_type.field_definitions_data',
             ])
             ->add('fieldTypeSelection', 'choice', [
                 'choices' => $this->getFieldTypeList(),
-                'mapped' => false
+                'mapped' => false,
+                'label' => 'content_type.field_type_selection',
             ])
-            ->add('addFieldDefinition', 'submit', ['label' => 'Add field definition'])
-            ->add('saveContentType', 'submit', ['label' => 'Update']);
+            ->add('addFieldDefinition', 'submit', ['label' => 'content_type.add_field_definition'])
+            ->add('saveContentType', 'submit', ['label' => 'content_type.save']);
     }
 
     /**

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -43,7 +43,8 @@ class FieldDefinitionType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'data_class' => 'EzSystems\RepositoryForms\Data\FieldDefinitionData'
+                'data_class' => 'EzSystems\RepositoryForms\Data\FieldDefinitionData',
+                'translation_domain' => 'ezrepoforms_content_type',
             ])
             ->setRequired(['languageCode']);
     }
@@ -52,20 +53,23 @@ class FieldDefinitionType extends AbstractType
     {
         $translatablePropertyTransformer = new TranslatablePropertyTransformer($options['languageCode']);
         $builder
-            ->add('fieldTypeIdentifier', 'hidden')
             ->add(
-                $builder->create('name', 'text', ['property_path' => 'names'])
+                $builder->create('name', 'text', ['property_path' => 'names', 'label' => 'field_definition.name'])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('identifier', 'text', ['required' => true])
+            ->add('identifier', 'text', ['label' => 'field_definition.identifier'])
             ->add(
-                $builder->create('description', 'text', ['property_path' => 'descriptions', 'required' => false])
+                $builder->create('description', 'text', [
+                    'property_path' => 'descriptions',
+                    'required' => false,
+                    'label' => 'field_definition.description'
+                ])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('isRequired', 'checkbox', ['required' => false])
-            ->add('isTranslatable', 'checkbox', ['required' => false])
-            ->add('fieldGroup', 'choice', ['choices' => []], ['required' => false])
-            ->add('position', 'integer');
+            ->add('isRequired', 'checkbox', ['required' => false, 'label' => 'field_definition.is_required'])
+            ->add('isTranslatable', 'checkbox', ['required' => false, 'label' => 'field_definition.is_translatable'])
+            ->add('fieldGroup', 'choice', ['choices' => []], ['required' => false, 'label' => 'field_definition.field_group'])
+            ->add('position', 'integer', ['label' => 'field_definition.position']);
 
         // Hook on form generation for specific FieldType needs
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
@@ -75,7 +79,11 @@ class FieldDefinitionType extends AbstractType
             $fieldTypeIdentifier = $data->getFieldTypeIdentifier();
             $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
             // isSearchable field should be present only if the FieldType allows it.
-            $form->add('isSearchable', 'checkbox', ['required' => false, 'disabled' => !$fieldType->isSearchable()]);
+            $form->add('isSearchable', 'checkbox', [
+                'required' => false,
+                'disabled' => !$fieldType->isSearchable(),
+                'label' => 'field_definition.is_searchable'
+            ]);
 
             // Let fieldType mappers do their jobs to complete the form.
             if ($this->fieldTypeMapperRegistry->hasMapper($fieldTypeIdentifier)) {

--- a/tests/RepositoryForms/FieldType/DataTransformer/TextLineValueTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/TextLineValueTransformerTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
+
+use eZ\Publish\Core\FieldType\TextLine\Value;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\TextLineValueTransformer;
+use PHPUnit_Framework_TestCase;
+
+class TextLineValueTransformerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testTransform($valueAsString)
+    {
+        $transformer = new TextLineValueTransformer();
+        $value = new Value($valueAsString);
+        self::assertSame($valueAsString, $transformer->transform($value));
+    }
+
+    public function transformProvider()
+    {
+        return [
+            ['foo'],
+            ['bar'],
+            ['bar biz boz'],
+            ["Les chaussettes de l'archiduchesse sont-elles sèches?"],
+        ];
+    }
+
+    /**
+     * @dataProvider transformNullProvider
+     */
+    public function testTransformNull($value)
+    {
+        $transformer = new TextLineValueTransformer();
+        self::assertNull($transformer->transform($value));
+    }
+
+    public function transformNullProvider()
+    {
+        return [
+            [new \eZ\Publish\Core\FieldType\DateAndTime\Value()],
+            [123],
+            [false],
+            [['foo']],
+        ];
+    }
+
+    public function testReverseTransformNull()
+    {
+        $transformer = new TextLineValueTransformer();
+        self::assertNull($transformer->reverseTransform(''));
+    }
+
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testReverseTransform($valueAsString)
+    {
+        $transformer = new TextLineValueTransformer();
+        $expectedValue = new Value($valueAsString);
+        self::assertEquals($expectedValue, $transformer->reverseTransform($valueAsString));
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24304

Added `getFieldDefinitionEditConfig()` to FieldTypeFormMapperInterface.
Returned value is a hash which may contain:
* `template`: template where specific form fields defined in mapFieldDefinitionForm() will be displayed.
* `vars`: Hash of additional variables to pass to the template.

Provided template will be included during FieldDefinition rendering, in order to add potential additional fields.
Variables passed to the form are:
* `data`: FieldDefinitionData object
* `languageCode`: Language code as passed to the main form
* `contentTypeDraft`: The ContentTypeDraft object
* `form`: Current FieldDefinition form

Note that it is *not mandatory* to provide a template. If a FieldType doesn't need additional form fields (i.e. no validator or field settings), there is no need to define a template.

Also moved update_content_type.html.twig to ContentType subdirectory

### Follow-up
* [EZP-24322](https://jira.ez.no/browse/EZP-24322): Use template blocks instead of including templates.