### PR TITLE
Fix EZP-24309: Implement validation for ContentType forms

### DIFF
--- a/bundle/Controller/TestController.php
+++ b/bundle/Controller/TestController.php
@@ -61,6 +61,7 @@ class TestController extends Controller
         foreach ($contentTypeDraft->fieldDefinitions as $fieldDef) {
             $formData->addFieldDefinitionData(new FieldDefinitionData([
                 'fieldDefinition' => $fieldDef,
+                'contentTypeData' => $formData,
                 'identifier' => $fieldDef->identifier,
                 'names' => $fieldDef->getNames(),
                 'descriptions' => $fieldDef->getDescriptions(),

--- a/bundle/Controller/TestController.php
+++ b/bundle/Controller/TestController.php
@@ -44,7 +44,7 @@ class TestController extends Controller
         $contentTypeDraft = $contentTypeService->loadContentTypeDraft($contentTypeId);
 
         // TODO: This must be done in a dedicated service
-        $formData = new ContentTypeData([
+        $contentTypeData = new ContentTypeData([
             'contentTypeDraft' => $contentTypeDraft,
             'identifier' => $contentTypeDraft->identifier,
             'remoteId' => $contentTypeDraft->remoteId,
@@ -59,9 +59,9 @@ class TestController extends Controller
             'descriptions' => $contentTypeDraft->getDescriptions(),
         ]);
         foreach ($contentTypeDraft->fieldDefinitions as $fieldDef) {
-            $formData->addFieldDefinitionData(new FieldDefinitionData([
+            $contentTypeData->addFieldDefinitionData(new FieldDefinitionData([
                 'fieldDefinition' => $fieldDef,
-                'contentTypeData' => $formData,
+                'contentTypeData' => $contentTypeData,
                 'identifier' => $fieldDef->identifier,
                 'names' => $fieldDef->getNames(),
                 'descriptions' => $fieldDef->getDescriptions(),
@@ -77,7 +77,7 @@ class TestController extends Controller
             ]));
         }
 
-        $form = $this->createForm('ezrepoforms_contenttype_update', $formData, [
+        $form = $this->createForm('ezrepoforms_contenttype_update', $contentTypeData, [
             'languageCode' => $languageCode,
         ]);
 
@@ -100,10 +100,10 @@ class TestController extends Controller
                     break;
 
                 case 'saveContentType':
-                    foreach ($formData->fieldDefinitionsData as $fieldDefData) {
+                    foreach ($contentTypeData->fieldDefinitionsData as $fieldDefData) {
                         $contentTypeService->updateFieldDefinition($contentTypeDraft, $fieldDefData->fieldDefinition, $fieldDefData);
                     }
-                    $contentTypeService->updateContentTypeDraft($contentTypeDraft, $formData);
+                    $contentTypeService->updateContentTypeDraft($contentTypeDraft, $contentTypeData);
                     break;
             }
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ parameters:
     ezrepoforms.field_type.form_mapper.ezstring.class: EzSystems\RepositoryForms\FieldType\Mapper\TextLineFormMapper
 
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
+    ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -35,3 +36,14 @@ services:
         arguments: [@ezpublish.api.service.content_type]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_content_type_identifier }
+
+    ezrepoforms.validator.field_type.abstract:
+        class: EzSystems\RepositoryForms\Validator\Constraints\FieldTypeValidator
+        arguments: [@ezpublish.api.service.field_type]
+        abstract: true
+
+    ezrepoforms.validator.validator_configuration:
+        parent: ezrepoforms.validator.field_type.abstract
+        class: %ezrepoforms.validator.validator_configuration.class%
+        tags:
+            - { name: validator.constraint_validator, alias: ezrepoforms.validator.validator_configuration }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ parameters:
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
     ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
     ezrepoforms.validator.field_settings.class: EzSystems\RepositoryForms\Validator\Constraints\FieldSettingsValidator
+    ezrepoforms.validator.default_field_value.class: EzSystems\RepositoryForms\Validator\Constraints\FieldDefinitionDefaultValueValidator
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -54,3 +55,9 @@ services:
         class: %ezrepoforms.validator.field_settings.class%
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.field_settings }
+
+    ezrepoforms.validator.default_field_value:
+        parent: ezrepoforms.validator.field_type.abstract
+        class: %ezrepoforms.validator.default_field_value.class%
+        tags:
+            - { name: validator.constraint_validator, alias: ezrepoforms.validator.default_field_value }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ parameters:
 
     ezrepoforms.field_type.form_mapper.ezstring.class: EzSystems\RepositoryForms\FieldType\Mapper\TextLineFormMapper
 
+    ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
+
 services:
     ezrepoforms.field_type_form_mapper.registry:
         class: %ezrepoforms.field_type_form_mapper.registry.class%
@@ -26,3 +28,10 @@ services:
         class: %ezrepoforms.field_type.form_mapper.ezstring.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezstring }
+
+    # Validators
+    ezrepoforms.validator.unique_content_type_identifier:
+        class: %ezrepoforms.validator.unique_content_type_identifier.class%
+        arguments: [@ezpublish.api.service.content_type]
+        tags:
+            - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_content_type_identifier }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
 
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
     ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
+    ezrepoforms.validator.field_settings.class: EzSystems\RepositoryForms\Validator\Constraints\FieldSettingsValidator
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -47,3 +48,9 @@ services:
         class: %ezrepoforms.validator.validator_configuration.class%
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.validator_configuration }
+
+    ezrepoforms.validator.field_settings:
+        parent: ezrepoforms.validator.field_type.abstract
+        class: %ezrepoforms.validator.field_settings.class%
+        tags:
+            - { name: validator.constraint_validator, alias: ezrepoforms.validator.field_settings }

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -38,6 +38,7 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
         - EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier: ~
         - EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration: ~
         - EzSystems\RepositoryForms\Validator\Constraints\FieldSettings: ~
+        - EzSystems\RepositoryForms\Validator\Constraints\FieldDefinitionDefaultValue: ~
     properties:
         identifier:
             - NotBlank: ~
@@ -57,4 +58,3 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
         position:
             - Type:
                 type: integer
-        # TODO: default value validation

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -28,7 +28,7 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
                 message: "ez.content_type.names"
         descriptions:
             - Expression:
-                expression: "value and value[this.mainLanguageCode] matches '/^.{0,255}$/'"
+                expression: "!value or value[this.mainLanguageCode] matches '/^.{0,255}$/'"
                 message: "ez.content_type.descriptions"
 
 EzSystems\RepositoryForms\Data\FieldDefinitionData:
@@ -47,7 +47,7 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
                 message: "ez.field_definition.names"
         descriptions:
             - Expression:
-                expression: "value and value[this.contentTypeData.mainLanguageCode] matches '/^.{0,255}$/'"
+                expression: "!value or value[this.contentTypeData.mainLanguageCode] matches '/^.{0,255}$/'"
                 message: "ez.field_definition.descriptions"
         position:
             - Type:

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -29,3 +29,27 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
             - Expression:
                 expression: "value and value[this.mainLanguageCode] matches '/^.{0,255}$/'"
                 message: "ez.content_type.descriptions"
+
+EzSystems\RepositoryForms\Data\FieldDefinitionData:
+    properties:
+        identifier:
+            - NotBlank: ~
+            - Length:
+                max: 50
+            - Regex:
+                pattern: "/^[[:alnum:]_]+$/"
+                message: "ez.content_type.identifier.pattern"
+            # TODO: Check each field is unique within a ContentType
+        names:
+            - Expression:
+                expression: "value and value[this.contentTypeData.mainLanguageCode] matches '/^.{1,255}$/'"
+                message: "ez.field_definition.names"
+        descriptions:
+            - Expression:
+                expression: "value and value[this.contentTypeData.mainLanguageCode] matches '/^.{0,255}$/'"
+                message: "ez.field_definition.descriptions"
+        position:
+            - Type:
+                type: integer
+        # TODO: Implement a custom validation constraint to use a dedicated service to validate validatorConfiguration and fieldSettings
+        # TODO: default value validation

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -1,0 +1,31 @@
+EzSystems\RepositoryForms\Data\ContentTypeData:
+    properties:
+        identifier:
+            - NotBlank: ~
+            - Length:
+                max: 50
+            - Regex:
+                pattern: "/^[[:alnum:]_]+$/"
+                message: "ez.content_type.identifier.pattern"
+        urlAliasSchema:
+            - Length:
+                max: 255
+        nameSchema:
+            - Length:
+                max: 255
+        defaultSortField:
+            - Choice:
+                # See eZ\Publish\API\Repository\Values\Content\Location::SORT_FIELD_*
+                choices: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        defaultSortOrder:
+            - Choice:
+                # See eZ\Publish\API\Repository\Values\Content\Location::SORT_ORDER_*
+                choices: [0, 1]
+        names:
+            - Expression:
+                expression: "value and value[this.mainLanguageCode] matches '/^.{1,255}$/'"
+                message: "ez.content_type.names"
+        descriptions:
+            - Expression:
+                expression: "value and value[this.mainLanguageCode] matches '/^.{0,255}$/'"
+                message: "ez.content_type.descriptions"

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -37,6 +37,7 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
     constraints:
         - EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier: ~
         - EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration: ~
+        - EzSystems\RepositoryForms\Validator\Constraints\FieldSettings: ~
     properties:
         identifier:
             - NotBlank: ~
@@ -56,5 +57,4 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
         position:
             - Type:
                 type: integer
-        # TODO: Implement a custom validation constraint to use a dedicated service to validate validatorConfiguration and fieldSettings
         # TODO: default value validation

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -30,6 +30,8 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
             - Expression:
                 expression: "!value or value[this.mainLanguageCode] matches '/^.{0,255}$/'"
                 message: "ez.content_type.descriptions"
+        fieldDefinitionsData:
+            - Valid: ~
 
 EzSystems\RepositoryForms\Data\FieldDefinitionData:
     properties:

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -34,6 +34,8 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
             - Valid: ~
 
 EzSystems\RepositoryForms\Data\FieldDefinitionData:
+    constraints:
+        - EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier: ~
     properties:
         identifier:
             - NotBlank: ~
@@ -42,7 +44,6 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
             - Regex:
                 pattern: "/^[[:alnum:]_]+$/"
                 message: "ez.content_type.identifier.pattern"
-            # TODO: Check each field is unique within a ContentType
         names:
             - Expression:
                 expression: "value and value[this.contentTypeData.mainLanguageCode] matches '/^.{1,255}$/'"

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -7,6 +7,7 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
             - Regex:
                 pattern: "/^[[:alnum:]_]+$/"
                 message: "ez.content_type.identifier.pattern"
+            - EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier: ~
         urlAliasSchema:
             - Length:
                 max: 255

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -36,6 +36,7 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
 EzSystems\RepositoryForms\Data\FieldDefinitionData:
     constraints:
         - EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier: ~
+        - EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration: ~
     properties:
         identifier:
             - NotBlank: ~

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -15,10 +15,14 @@
                 <target>Content type description cannot exceed 255 characters.</target>
             </trans-unit>
             <trans-unit id="4">
+                <source>ez.content_type.identifier.unique</source>
+                <target>Identifier "%identifier%" already exists. Content type identifier must be unique.</target>
+            </trans-unit>
+            <trans-unit id="10">
                 <source>ez.field_definition.names</source>
                 <target>Field definition name cannot be blank cannot exceed 255 characters.</target>
             </trans-unit>
-            <trans-unit id="5">
+            <trans-unit id="11">
                 <source>ez.field_definition.descriptions</source>
                 <target>Field definition description cannot exceed 255 characters.</target>
             </trans-unit>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -26,6 +26,10 @@
                 <source>ez.field_definition.descriptions</source>
                 <target>Field definition description cannot exceed 255 characters.</target>
             </trans-unit>
+            <trans-unit id="12">
+                <source>ez.field_definition.identifier.unique</source>
+                <target>Identifier "%identifier%" already exists in current Content type.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>ez.content_type.identifier.pattern</source>
+                <target>Content type identifier may only contain letters, numbers and underscores.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>ez.content_type.names</source>
+                <target>Content type name cannot be blank and cannot exceed 255 characters.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>ez.content_type.descriptions</source>
+                <target>Content type description cannot exceed 255 characters.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -34,6 +34,10 @@
                 <source>ez.field_definition.validator_configuration</source>
                 <target>Validator configuration is invalid.</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>ez.field_definition.field_settings</source>
+                <target>Field settings are invalid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -30,6 +30,10 @@
                 <source>ez.field_definition.identifier.unique</source>
                 <target>Identifier "%identifier%" already exists in current Content type.</target>
             </trans-unit>
+            <trans-unit id="13">
+                <source>ez.field_definition.validator_configuration</source>
+                <target>Validator configuration is invalid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -38,6 +38,10 @@
                 <source>ez.field_definition.field_settings</source>
                 <target>Field settings are invalid.</target>
             </trans-unit>
+            <trans-unit id="15">
+                <source>ez.field_definition.default_field_value</source>
+                <target>Default field value is invalid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -14,6 +14,14 @@
                 <source>ez.content_type.descriptions</source>
                 <target>Content type description cannot exceed 255 characters.</target>
             </trans-unit>
+            <trans-unit id="4">
+                <source>ez.field_definition.names</source>
+                <target>Field definition name cannot be blank cannot exceed 255 characters.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>ez.field_definition.descriptions</source>
+                <target>Field definition description cannot exceed 255 characters.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "ezsystems/ezpublish-kernel": "dev-master",
-        "symfony/form": "~2.6"
+        "symfony/form": "~2.6",
+        "symfony/validator": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"

--- a/lib/Data/FieldDefinitionData.php
+++ b/lib/Data/FieldDefinitionData.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
  * Base class for FieldDefinition forms, with corresponding FieldDefinition object.
  *
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+ * @property-read \EzSystems\RepositoryForms\Data\ContentTypeData $contentTypeData
  */
 class FieldDefinitionData extends FieldDefinitionUpdateStruct
 {
@@ -22,6 +23,14 @@ class FieldDefinitionData extends FieldDefinitionUpdateStruct
      * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
     protected $fieldDefinition;
+
+    /**
+     * ContentTypeData holding current FieldDefinitionData.
+     * Mainly used for validation.
+     *
+     * @var \EzSystems\RepositoryForms\Data\ContentTypeData
+     */
+    protected $contentTypeData;
 
     public function getFieldTypeIdentifier()
     {

--- a/lib/Validator/Constraints/FieldDefinitionDefaultValue.php
+++ b/lib/Validator/Constraints/FieldDefinitionDefaultValue.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class FieldDefinitionDefaultValue extends Constraint
+{
+    public $message = 'ez.field_definition.default_field_value';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy()
+    {
+        return 'ezrepoforms.validator.default_field_value';
+    }
+}

--- a/lib/Validator/Constraints/FieldDefinitionDefaultValueValidator.php
+++ b/lib/Validator/Constraints/FieldDefinitionDefaultValueValidator.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validator for default value from FieldDefinitionData.
+ */
+class FieldDefinitionDefaultValueValidator extends FieldValueValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof FieldDefinitionData) {
+            return;
+        }
+
+        parent::validate($value, $constraint);
+    }
+
+    /**
+     * Returns the field value to validate.
+     *
+     * @param FieldDefinitionData|ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @throws \InvalidArgumentException If field value cannot be retrieved.
+     *
+     * @return \eZ\Publish\SPI\FieldType\Value
+     */
+    protected function getFieldValue(ValueObject $value)
+    {
+        return $value->defaultValue;
+    }
+
+    /**
+     * Returns the field definition $value refers to.
+     * FieldDefinition object is needed to validate field value against field settings.
+     *
+     * @param FieldDefinitionData|ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @throws \InvalidArgumentException If field definition cannot be retrieved.
+     *
+     * @return \eZ\Publish\SPI\FieldType\Value
+     */
+    protected function getFieldDefinition(ValueObject $value)
+    {
+        return $value->fieldDefinition;
+    }
+
+    /**
+     * Returns the fieldTypeIdentifier for the field value to validate.
+     *
+     * @param FieldDefinitionData|ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @return string
+     */
+    protected function getFieldTypeIdentifier(ValueObject $value)
+    {
+        return $value->getFieldTypeIdentifier();
+    }
+}

--- a/lib/Validator/Constraints/FieldSettings.php
+++ b/lib/Validator/Constraints/FieldSettings.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class FieldSettings extends Constraint
+{
+    public $message = 'ez.field_definition.field_settings';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy()
+    {
+        return 'ezrepoforms.validator.field_settings';
+    }
+}

--- a/lib/Validator/Constraints/FieldSettingsValidator.php
+++ b/lib/Validator/Constraints/FieldSettingsValidator.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Will check if field settings for FieldDefinition are valid.
+ */
+class FieldSettingsValidator extends FieldTypeValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof FieldDefinitionData) {
+            return;
+        }
+
+        $fieldType = $this->fieldTypeService->getFieldType($value->getFieldTypeIdentifier());
+        $this->processValidationErrors($fieldType->validateFieldSettings($value->fieldSettings));
+    }
+}

--- a/lib/Validator/Constraints/FieldTypeValidator.php
+++ b/lib/Validator/Constraints/FieldTypeValidator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\Values\Translation\Plural;
+use Symfony\Component\Validator\ConstraintValidator;
+
+abstract class FieldTypeValidator extends ConstraintValidator
+{
+    /**
+     * @var FieldTypeService
+     */
+    protected $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\FieldType\ValidationError[] $validationErrors
+     */
+    protected function processValidationErrors(array $validationErrors)
+    {
+        if (empty($validationErrors)) {
+            return;
+        }
+
+        foreach ($validationErrors as $error) {
+            $message = $error->getTranslatableMessage();
+            /** @var \Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface $violationBuilder */
+            $violationBuilder = $this->context->buildViolation($message instanceof Plural ? $message->plural : $message->message);
+            foreach ($message->values as $parameter => $parameterValue) {
+                $violationBuilder->setParameter("%$parameter%", $parameterValue);
+            }
+
+            $violationBuilder
+                // TODO: We need a target under validatorConfigurationHash to clearly identify the field violation is for.
+                // Needs to be defined in each FieldType as part of ValidationError (e.g. "target" property containing the property path)
+                //->atPath('validatorConfiguration[StringLengthValidator][minStringLength]')
+                ->addViolation();
+        }
+    }
+}

--- a/lib/Validator/Constraints/FieldValueValidator.php
+++ b/lib/Validator/Constraints/FieldValueValidator.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Base class for field value validators.
+ */
+abstract class FieldValueValidator extends FieldTypeValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof ValueObject) {
+            return;
+        }
+
+        $fieldValue = $this->getFieldValue($value);
+        if (!$fieldValue) {
+            return;
+        }
+
+        $fieldTypeIdentifier = $this->getFieldTypeIdentifier($value);
+        $fieldDefinition = $this->getFieldDefinition($value);
+        $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
+        $this->processValidationErrors($fieldType->validateValue($fieldDefinition, $fieldValue));
+    }
+
+    /**
+     * Returns the field value to validate, or null if there is nothing to validate (e.g. empty default value)
+     *
+     * @param ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @throws \InvalidArgumentException If field value cannot be retrieved.
+     *
+     * @return \eZ\Publish\SPI\FieldType\Value|null
+     */
+    abstract protected function getFieldValue(ValueObject $value);
+
+    /**
+     * Returns the field definition $value refers to.
+     * FieldDefinition object is needed to validate field value against field settings.
+     *
+     * @param ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @throws \InvalidArgumentException If field definition cannot be retrieved.
+     *
+     * @return \eZ\Publish\SPI\FieldType\Value
+     */
+    abstract protected function getFieldDefinition(ValueObject $value);
+
+    /**
+     * Returns the fieldTypeIdentifier for the field value to validate.
+     *
+     * @param ValueObject $value ValueObject holding the field value to validate, e.g. FieldDefinitionData.
+     *
+     * @return string
+     */
+    abstract protected function getFieldTypeIdentifier(ValueObject $value);
+}

--- a/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class UniqueContentTypeIdentifier extends Constraint
+{
+    /**
+     * %identifier% placeholder is passed.
+     *
+     * @var string
+     */
+    public $message = 'ez.content_type.identifier.unique';
+
+    public function validatedBy()
+    {
+        return 'ezrepoforms.validator.unique_content_type_identifier';
+    }
+}

--- a/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Will check if ContentType identifier is not already used in the content repository.
+ */
+class UniqueContentTypeIdentifierValidator extends ConstraintValidator
+{
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        try {
+            $this->contentTypeService->loadContentTypeByIdentifier($value);
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('%identifier%', $value)
+                ->addViolation();
+        } catch (NotFoundException $e) {
+            // Do nothing
+        }
+    }
+}

--- a/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
+++ b/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class UniqueFieldDefinitionIdentifier extends Constraint
+{
+    /**
+     * %identifier% placeholder is passed.
+     *
+     * @var string
+     */
+    public $message = 'ez.field_definition.identifier.unique';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/lib/Validator/Constraints/UniqueFieldDefinitionIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueFieldDefinitionIdentifierValidator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Will check if FieldDefinition identifier is not already used within ContentType.
+ */
+class UniqueFieldDefinitionIdentifierValidator extends ConstraintValidator
+{
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param FieldDefinitionData $value The value that should be validated
+     * @param Constraint|UniqueFieldDefinitionIdentifier $constraint The constraint for the validation
+     *
+     * @api
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof FieldDefinitionData) {
+            return;
+        }
+
+        $contentTypeData = $value->contentTypeData;
+        foreach ($contentTypeData->fieldDefinitionsData as $fieldDefData) {
+            if ($fieldDefData === $value) {
+                continue;
+            }
+
+            if ($value->identifier === $fieldDefData->identifier) {
+                $this->context->buildViolation($constraint->message)
+                    ->atPath('identifier')
+                    ->setParameter('%identifier%', $value->identifier)
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/lib/Validator/Constraints/ValidatorConfiguration.php
+++ b/lib/Validator/Constraints/ValidatorConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class ValidatorConfiguration extends Constraint
+{
+    public $message = 'ez.field_definition.validator_configuration';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy()
+    {
+        return 'ezrepoforms.validator.validator_configuration';
+    }
+}

--- a/lib/Validator/Constraints/ValidatorConfigurationValidator.php
+++ b/lib/Validator/Constraints/ValidatorConfigurationValidator.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Will check if validator configuration for FieldDefinition is valid.
+ */
+class ValidatorConfigurationValidator extends FieldTypeValidator
+{
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param FieldDefinitionData $value The value that should be validated
+     * @param Constraint $constraint The constraint for the validation
+     *
+     * @api
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof FieldDefinitionData) {
+            return;
+        }
+
+        $fieldType = $this->fieldTypeService->getFieldType($value->getFieldTypeIdentifier());
+        $this->processValidationErrors($fieldType->validateValidatorConfiguration($value->validatorConfiguration));
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/FieldDefinitionDefaultValueTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldDefinitionDefaultValueTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\FieldDefinitionDefaultValue;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Validator\Constraint;
+
+class FieldDefinitionDefaultValueTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new FieldDefinitionDefaultValue();
+        self::assertSame('ez.field_definition.default_field_value', $constraint->message);
+    }
+
+    public function testValidatedBy()
+    {
+        $constraint = new FieldDefinitionDefaultValue();
+        self::assertSame('ezrepoforms.validator.default_field_value', $constraint->validatedBy());
+    }
+
+    public function testGetTargets()
+    {
+        $constraint = new FieldDefinitionDefaultValue();
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\FieldSettings;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Validator\Constraint;
+
+class FieldSettingsTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new FieldSettings();
+        self::assertSame('ez.field_definition.field_settings', $constraint->message);
+    }
+
+    public function testValidatedBy()
+    {
+        $constraint = new FieldSettings();
+        self::assertSame('ezrepoforms.validator.field_settings', $constraint->validatedBy());
+    }
+
+    public function testGetTargets()
+    {
+        $constraint = new FieldSettings();
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\Validator\Constraints\FieldSettings;
+use EzSystems\RepositoryForms\Validator\Constraints\FieldSettingsValidator;
+use PHPUnit_Framework_TestCase;
+
+class FieldSettingsValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $executionContext;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldTypeService;
+
+    /**
+     * @var FieldSettingsValidator
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->executionContext = $this->getMock('\Symfony\Component\Validator\Context\ExecutionContextInterface');
+        $this->fieldTypeService = $this->getMock('\eZ\Publish\API\Repository\FieldTypeService');
+        $this->validator = new FieldSettingsValidator($this->fieldTypeService);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testNotFieldDefinitionData()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate('foo', new FieldSettings());
+    }
+
+    public function testValid()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $fieldTypeIdentifier = 'ezstring';
+        $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
+        $fieldSettings = ['foo' => 'bar'];
+        $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'fieldSettings' => $fieldSettings]);
+        $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
+        $this->fieldTypeService
+            ->expects($this->once())
+            ->method('getFieldType')
+            ->with($fieldTypeIdentifier)
+            ->willReturn($fieldType);
+        $fieldType
+            ->expects($this->once())
+            ->method('validateFieldSettings')
+            ->with($fieldSettings)
+            ->willReturn([]);
+
+        $this->validator->validate($fieldDefData, new FieldSettings());
+    }
+
+    public function testInvalid()
+    {
+        $fieldTypeIdentifier = 'ezstring';
+        $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
+        $fieldSettings = ['foo' => 'bar'];
+        $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'fieldSettings' => $fieldSettings]);
+        $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
+        $this->fieldTypeService
+            ->expects($this->once())
+            ->method('getFieldType')
+            ->with($fieldTypeIdentifier)
+            ->willReturn($fieldType);
+
+        $errorParameter = 'bar';
+        $errorMessage = 'error';
+        $fieldType
+            ->expects($this->once())
+            ->method('validateFieldSettings')
+            ->with($fieldSettings)
+            ->willReturn([new ValidationError($errorMessage, null, ['foo' => $errorParameter])]);
+
+        $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->willReturn($constraintViolationBuilder);
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($errorMessage)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('%foo%', $errorParameter)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($fieldDefData, new FieldSettings());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier;
+use PHPUnit_Framework_TestCase;
+
+class UniqueContentTypeIdentifierTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new UniqueContentTypeIdentifier();
+        self::assertSame('ez.content_type.identifier.unique', $constraint->message);
+    }
+
+    public function testValidatedBy()
+    {
+        $constraint = new UniqueContentTypeIdentifier();
+        self::assertSame('ezrepoforms.validator.unique_content_type_identifier', $constraint->validatedBy());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator;
+use PHPUnit_Framework_TestCase;
+
+class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contentTypeService;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $executionContext;
+
+    /**
+     * @var UniqueContentTypeIdentifierValidator
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->contentTypeService = $this->getMock('\eZ\Publish\API\Repository\ContentTypeService');
+        $this->executionContext = $this->getMock('\Symfony\Component\Validator\Context\ExecutionContextInterface');
+        $this->validator = new UniqueContentTypeIdentifierValidator($this->contentTypeService);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testValid()
+    {
+        $identifier = 'foo_identifier';
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($identifier)
+            ->willThrowException(new NotFoundException('foo', 'bar'));
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildVioloation');
+
+        $this->validator->validate($identifier, new UniqueContentTypeIdentifier());
+    }
+
+    public function testInvalid()
+    {
+        $identifier = 'foo_identifier';
+        $constraint = new UniqueContentTypeIdentifier();
+        $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($identifier)
+            ->willReturn($this->getMockForAbstractClass('\eZ\Publish\API\Repository\Values\ContentType\ContentType'));
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('%identifier%', $identifier)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($identifier, $constraint);
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Validator\Constraint;
+
+class UniqueFieldDefinitionIdentifierTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new UniqueFieldDefinitionIdentifier();
+        self::assertSame('ez.field_definition.identifier.unique', $constraint->message);
+    }
+
+    public function testGetTartes()
+    {
+        $constraint = new UniqueFieldDefinitionIdentifier();
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierValidatorTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Data\ContentTypeData;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifierValidator;
+use PHPUnit_Framework_TestCase;
+
+class UniqueFieldDefinitionIdentifierValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $executionContext;
+
+    /**
+     * @var UniqueFieldDefinitionIdentifierValidator
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->executionContext = $this->getMock('\Symfony\Component\Validator\Context\ExecutionContextInterface');
+        $this->validator = new UniqueFieldDefinitionIdentifierValidator();
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testNotFieldDefinitionData()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate('foo', new UniqueFieldDefinitionIdentifier());
+    }
+
+    public function testValid()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $contentTypeData = new ContentTypeData();
+        $fieldDefData1 = new FieldDefinitionData(['identifier' => 'foo', 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData1);
+        $fieldDefData2 = new FieldDefinitionData(['identifier' => 'bar', 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData2);
+        $fieldDefData3 = new FieldDefinitionData(['identifier' => 'baz', 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData3);
+
+        $this->validator->validate($fieldDefData1, new UniqueFieldDefinitionIdentifier());
+    }
+
+    public function testInvalid()
+    {
+        $identifier = 'foo';
+        $constraint = new UniqueFieldDefinitionIdentifier();
+        $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('atPath')
+            ->with('identifier')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('%identifier%', $identifier)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $contentTypeData = new ContentTypeData();
+        $fieldDefData1 = new FieldDefinitionData(['identifier' => $identifier, 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData1);
+        $fieldDefData2 = new FieldDefinitionData(['identifier' => 'bar', 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData2);
+        $fieldDefData3 = new FieldDefinitionData(['identifier' => $identifier, 'contentTypeData' => $contentTypeData]);
+        $contentTypeData->addFieldDefinitionData($fieldDefData3);
+
+        $this->validator->validate($fieldDefData1, $constraint);
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Validator\Constraint;
+
+class ValidatorConfigurationTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new ValidatorConfiguration();
+        self::assertSame('ez.field_definition.validator_configuration', $constraint->message);
+    }
+
+    public function testValidatedBy()
+    {
+        $constraint = new ValidatorConfiguration();
+        self::assertSame('ezrepoforms.validator.validator_configuration', $constraint->validatedBy());
+    }
+
+    public function testGetTargets()
+    {
+        $constraint = new ValidatorConfiguration();
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration;
+use EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator;
+use PHPUnit_Framework_TestCase;
+
+class ValidatorConfigurationValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $executionContext;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldTypeService;
+
+    /**
+     * @var ValidatorConfigurationValidator
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->executionContext = $this->getMock('\Symfony\Component\Validator\Context\ExecutionContextInterface');
+        $this->fieldTypeService = $this->getMock('\eZ\Publish\API\Repository\FieldTypeService');
+        $this->validator = new ValidatorConfigurationValidator($this->fieldTypeService);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testNotFieldDefinitionData()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate('foo', new ValidatorConfiguration());
+    }
+
+    public function testValid()
+    {
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $fieldTypeIdentifier = 'ezstring';
+        $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
+        $validatorConfiguration = ['foo' => 'bar'];
+        $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'validatorConfiguration' => $validatorConfiguration]);
+        $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
+        $this->fieldTypeService
+            ->expects($this->once())
+            ->method('getFieldType')
+            ->with($fieldTypeIdentifier)
+            ->willReturn($fieldType);
+        $fieldType
+            ->expects($this->once())
+            ->method('validateValidatorConfiguration')
+            ->with($validatorConfiguration)
+            ->willReturn([]);
+
+        $this->validator->validate($fieldDefData, new ValidatorConfiguration());
+    }
+
+    public function testInvalid()
+    {
+        $fieldTypeIdentifier = 'ezstring';
+        $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
+        $validatorConfiguration = ['foo' => 'bar'];
+        $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'validatorConfiguration' => $validatorConfiguration]);
+        $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
+        $this->fieldTypeService
+            ->expects($this->once())
+            ->method('getFieldType')
+            ->with($fieldTypeIdentifier)
+            ->willReturn($fieldType);
+
+        $errorParameter = 'bar';
+        $errorMessage = 'error';
+        $fieldType
+            ->expects($this->once())
+            ->method('validateValidatorConfiguration')
+            ->with($validatorConfiguration)
+            ->willReturn([new ValidationError($errorMessage, null, ['foo' => $errorParameter])]);
+
+        $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->willReturn($constraintViolationBuilder);
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($errorMessage)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('%foo%', $errorParameter)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($fieldDefData, new ValidatorConfiguration());
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24309

Adds validation for ContentTypeData and FieldDefinitionData.

* [x] Add validation for ContentTypeData fields
* [x] Add validation for common FieldDefinitionData fields
* [x] Translate custom validation messages
* [x] Ensure inner FieldDefinitionData fields are validated in cascade when validating ContentTypeData
* [x] Add validation for FieldDefinitionData validator configuration
* [x] Add validation for FieldDefinitionData field settings configuration
* [x] Add validation for FieldDefinitionData default value when needed (should also be usable for content field Value validation)
* [x] Tests for validators and constraints

Follow ups:
* Add a target property/getter to `\eZ\Publish\SPI\FieldType\ValidationError` so that we can easily identify on which field validation errors occur (at field type level)