### PR TITLE
Fix EZP-24397: Implement FieldDefinition form mapper for ezinteger

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -4,6 +4,7 @@ parameters:
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
 
     ezrepoforms.field_type.form_mapper.ezfloat.class: EzSystems\RepositoryForms\FieldType\Mapper\FloatFormMapper
+    ezrepoforms.field_type.form_mapper.ezinteger.class: EzSystems\RepositoryForms\FieldType\Mapper\IntegerFormMapper
     ezrepoforms.field_type.form_mapper.ezstring.class: EzSystems\RepositoryForms\FieldType\Mapper\TextLineFormMapper
     ezrepoforms.field_type.form_mapper.eztext.class: EzSystems\RepositoryForms\FieldType\Mapper\TextBlockFormMapper
 
@@ -36,6 +37,11 @@ services:
         class: %ezrepoforms.field_type.form_mapper.ezfloat.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezfloat }
+
+    ezrepoforms.field_type.form_mapper.ezinteger:
+        class: %ezrepoforms.field_type.form_mapper.ezinteger.class%
+        tags:
+            - { name: ez.fieldType.formMapper, fieldType: ezinteger }
 
     ezrepoforms.field_type.form_mapper.ezstring:
         class: %ezrepoforms.field_type.form_mapper.ezstring.class%

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -115,6 +115,14 @@
                 <source>field_definition.ezfloat.max_value</source>
                 <target>Maximum value</target>
             </trans-unit>
+            <trans-unit id="115">
+                <source>field_definition.ezinteger.min_value</source>
+                <target>Minimum value</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>field_definition.ezinteger.max_value</source>
+                <target>Maximum value</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -22,6 +22,20 @@
     </div>
 {% endblock %}
 
+{% block ezinteger_field_definition_edit %}
+    <div class="ezinteger-validator min-value">
+        {{- form_label(form.minValue) -}}
+        {{- form_errors(form.minValue) -}}
+        {{- form_widget(form.minValue) -}}
+    </div>
+
+    <div class="ezinteger-validator max-value">
+        {{- form_label(form.maxValue) -}}
+        {{- form_errors(form.maxValue) -}}
+        {{- form_widget(form.maxValue) -}}
+    </div>
+{% endblock %}
+
 {% block ezstring_field_definition_edit %}
     <div class="ezstring-validator min-length">
         {{- form_label(form.minLength) -}}

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\FieldType\Mapper;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+class IntegerFormMapper implements FieldTypeFormMapperInterface
+{
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $fieldDefinitionForm
+            ->add(
+                'minValue', 'integer', [
+                    'required' => false,
+                    'property_path' => 'validatorConfiguration[IntegerValueValidator][minIntegerValue]',
+                    'label' => 'field_definition.ezinteger.min_value',
+                ]
+            )
+            ->add(
+                'maxValue', 'integer', [
+                    'required' => false,
+                    'property_path' => 'validatorConfiguration[IntegerValueValidator][maxIntegerValue]',
+                    'label' => 'field_definition.ezinteger.max_value',
+                ]
+            );
+    }
+}


### PR DESCRIPTION
Manual test. Requires this change in the fieldvalue converter to work: https://github.com/ezsystems/ezpublish-kernel/pull/1264

https://jira.ez.no/browse/EZP-24397