### PR TITLE
Fix EZP-24390: Implement FieldDefinition form mapper for ezdatetime

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ parameters:
     ezrepoforms.field_type.form_mapper.ezbinaryfile.class: EzSystems\RepositoryForms\FieldType\Mapper\BinaryFileFormMapper
     ezrepoforms.field_type.form_mapper.ezcountry.class: EzSystems\RepositoryForms\FieldType\Mapper\CountryFormMapper
     ezrepoforms.field_type.form_mapper.ezdate.class: EzSystems\RepositoryForms\FieldType\Mapper\DateFormMapper
+    ezrepoforms.field_type.form_mapper.ezdatetime.class: EzSystems\RepositoryForms\FieldType\Mapper\DateTimeFormMapper
     ezrepoforms.field_type.form_mapper.ezfloat.class: EzSystems\RepositoryForms\FieldType\Mapper\FloatFormMapper
     ezrepoforms.field_type.form_mapper.ezimage.class: EzSystems\RepositoryForms\FieldType\Mapper\ImageFormMapper
     ezrepoforms.field_type.form_mapper.ezinteger.class: EzSystems\RepositoryForms\FieldType\Mapper\IntegerFormMapper
@@ -62,6 +63,11 @@ services:
         class: %ezrepoforms.field_type.form_mapper.ezdate.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezdate }
+
+    ezrepoforms.field_type.form_mapper.ezdatetime:
+        class: %ezrepoforms.field_type.form_mapper.ezdatetime.class%
+        tags:
+            - { name: ez.fieldType.formMapper, fieldType: ezdatetime }
 
     ezrepoforms.field_type.form_mapper.ezfloat:
         class: %ezrepoforms.field_type.form_mapper.ezfloat.class%

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -279,6 +279,30 @@
                 <source>field_definition.ezimage.max_file_size</source>
                 <target>Maximum file size (byte)</target>
             </trans-unit>
+            <trans-unit id="142">
+                <source>field_definition.ezdatetime.use_seconds</source>
+                <target>Use seconds</target>
+            </trans-unit>
+            <trans-unit id="143">
+                <source>field_definition.ezdatetime.default_type</source>
+                <target>Default value</target>
+            </trans-unit>
+            <trans-unit id="144">
+                <source>field_definition.ezdatetime.default_type_empty</source>
+                <target>Empty</target>
+            </trans-unit>
+            <trans-unit id="145">
+                <source>field_definition.ezdatetime.default_type_current</source>
+                <target>Current datetime</target>
+            </trans-unit>
+            <trans-unit id="146">
+                <source>field_definition.ezdatetime.default_type_adjusted</source>
+                <target>Adjusted current datetime</target>
+            </trans-unit>
+            <trans-unit id="147">
+                <source>field_definition.ezdatetime.date_interval</source>
+                <target>Current date and time adjusted by</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/views/ContentType/field_definition_row.html.twig
+++ b/bundle/Resources/views/ContentType/field_definition_row.html.twig
@@ -70,3 +70,13 @@
         {% endfor %}
     </div>
 {% endblock %}
+
+{% block datetimeinterval_widget %}
+    {% for child in form %}
+        <div>
+            {{- form_label(child) -}}
+            {{- form_errors(child) -}}
+            {{- form_widget(child) -}}
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -38,6 +38,26 @@
     </div>
 {% endblock %}
 
+{% block ezdatetime_field_definition_edit %}
+    <div class="ezdatetime-settings use-seconds">
+        {{- form_label(form.useSeconds) -}}
+        {{- form_errors(form.useSeconds) -}}
+        {{- form_widget(form.useSeconds) -}}
+    </div>
+
+    <div class="ezdatetime-settings default-type">
+        {{- form_label(form.defaultType) -}}
+        {{- form_errors(form.defaultType) -}}
+        {{- form_widget(form.defaultType) -}}
+    </div>
+
+    <div class="ezdatetime-settings date-interval">
+        {{- form_label(form.dateInterval) -}}
+        {{- form_errors(form.dateInterval) -}}
+        {{- form_widget(form.dateInterval) -}}
+    </div>
+{% endblock %}
+
 {% block ezfloat_field_definition_edit %}
     <div class="ezfloat-validator min-value">
         {{- form_label(form.minValue) -}}

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\FieldType\Mapper;
+
+use eZ\Publish\Core\FieldType\DateAndTime\Type;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\Form\Type\DateTimeIntervalType;
+use Symfony\Component\Form\FormInterface;
+
+class DateTimeFormMapper implements FieldTypeFormMapperInterface
+{
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $fieldDefinitionForm
+            ->add('useSeconds', 'checkbox', [
+                'required' => false,
+                'property_path' => 'fieldSettings[useSeconds]',
+                'label' => 'field_definition.ezdatetime.use_seconds',
+            ])
+            ->add('defaultType', 'choice', [
+                'choices' => [
+                    Type::DEFAULT_EMPTY => 'field_definition.ezdatetime.default_type_empty',
+                    Type::DEFAULT_CURRENT_DATE => 'field_definition.ezdatetime.default_type_current',
+                    Type::DEFAULT_CURRENT_DATE_ADJUSTED => 'field_definition.ezdatetime.default_type_adjusted'
+                ],
+                'expanded' => true,
+                'required' => true,
+                'property_path' => 'fieldSettings[defaultType]',
+                'label' => 'field_definition.ezdatetime.default_type',
+            ])
+            ->add('dateInterval', new DateTimeIntervalType(), [
+                'required' => false,
+                'property_path' => 'fieldSettings[dateInterval]',
+                'label' => 'field_definition.ezdatetime.date_interval',
+            ]);
+    }
+}

--- a/lib/Form/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/lib/Form/DataTransformer/DateIntervalToArrayTransformer.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Form\DataTransformer;
+
+use DateInterval;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Data transformer from PHP DateInterval to array for form inputs
+ */
+class DateIntervalToArrayTransformer implements DataTransformerInterface
+{
+    /**
+     * Transforms a date interval into an array of date interval elements
+     *
+     * @param DateInterval $dateInterval Date interval.
+     *
+     * @return array Date interval elements.
+     *
+     * @throws TransformationFailedException If the given value is not an instance of DateInterval
+     */
+    public function transform($dateInterval)
+    {
+        if ($dateInterval === null) {
+            return [
+                'year' => '0',
+                'month' => '0',
+                'day' => '0',
+                'hour' => '0',
+                'minute' => '0',
+                'second' => '0',
+            ];
+        }
+
+        if (!$dateInterval instanceof DateInterval) {
+            throw new TransformationFailedException('Expected a DateInterval.');
+        }
+
+        $result = [
+            'year' => $dateInterval->format('%y'),
+            'month' => $dateInterval->format('%m'),
+            'day' => $dateInterval->format('%d'),
+            'hour' => $dateInterval->format('%h'),
+            'minute' => $dateInterval->format('%i'),
+            'second' => $dateInterval->format('%s'),
+        ];
+
+        return $result;
+    }
+
+    /**
+     * Transforms an array of date interval elements into a date interval
+     *
+     * @param array $value Date interval elements.
+     *
+     * @return DateInterval Date interval.
+     *
+     * @throws TransformationFailedException If the given value is not an array,
+     *                                       or if the value could not be transformed.
+     */
+    public function reverseTransform($value)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!is_array($value)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if ('' === implode('', $value)) {
+            return;
+        }
+
+        // List the fields that are not set as keys in $value
+        $emptyFields = array_diff(
+            ['year', 'month', 'day', 'hour', 'minute', 'second'],
+            array_keys($value)
+        );
+
+        if (count($emptyFields) > 0) {
+            throw new TransformationFailedException(
+                sprintf('The fields "%s" should not be empty', implode('", "', $emptyFields))
+            );
+        }
+
+        if (isset($value['month']) && !ctype_digit((string)$value['month'])) {
+            throw new TransformationFailedException('This month is invalid');
+        }
+
+        if (isset($value['day']) && !ctype_digit((string)$value['day'])) {
+            throw new TransformationFailedException('This day is invalid');
+        }
+
+        if (isset($value['year']) && !ctype_digit((string)$value['year'])) {
+            throw new TransformationFailedException('This year is invalid');
+        }
+
+        if (!empty( $value['month']) && !empty($value['day']) && !empty($value['year']) &&
+            false === checkdate($value['month'], $value['day'], $value['year'])) {
+            throw new TransformationFailedException('This is an invalid date');
+        }
+
+        if (isset($value['hour']) && !ctype_digit((string)$value['hour'])) {
+            throw new TransformationFailedException('This hour is invalid');
+        }
+
+        if (isset($value['minute']) && !ctype_digit((string)$value['minute'])) {
+            throw new TransformationFailedException('This minute is invalid');
+        }
+
+        if (isset($value['second']) && !ctype_digit((string)$value['second'])) {
+            throw new TransformationFailedException('This second is invalid');
+        }
+
+        try {
+            $dateInterval = new DateInterval(
+                sprintf(
+                    'P%sY%sM%sDT%sH%sM%sS',
+                    empty($value['year']) ? '0' : $value['year'],
+                    empty($value['month']) ? '0' : $value['month'],
+                    empty($value['day']) ? '0' : $value['day'],
+                    empty($value['hour']) ? '0' : $value['hour'],
+                    empty($value['minute']) ? '0' : $value['minute'],
+                    empty($value['second']) ? '0' : $value['second']
+                )
+            );
+        } catch (\Exception $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return $dateInterval;
+    }
+}

--- a/lib/Form/Type/DateTimeIntervalType.php
+++ b/lib/Form/Type/DateTimeIntervalType.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Form\Type;
+
+use EzSystems\RepositoryForms\Form\DataTransformer\DateIntervalToArrayTransformer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\ReversedTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\DataTransformerChain;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ArrayToPartsTransformer;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Form type for ContentType update.
+ */
+class DateTimeIntervalType extends AbstractType
+{
+    public function getParent()
+    {
+        return 'form';
+    }
+
+    public function getName()
+    {
+        return 'datetimeinterval';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->addViewTransformer(new DateIntervalToArrayTransformer())
+            ->add('year', 'integer')
+            ->add('month', 'integer')
+            ->add('day', 'integer')
+            ->add('hour', 'integer')
+            ->add('minute', 'integer')
+            ->add('second', 'integer');
+    }
+}

--- a/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
+
+use DateInterval;
+use EzSystems\RepositoryForms\Form\DataTransformer\DateIntervalToArrayTransformer;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class DateIntervalToArrayTransformerTest extends PHPUnit_Framework_TestCase
+{
+    public function transformProvider()
+    {
+        return [
+            [['P1Y2M3DT4H5M6S' => ['year' => '1', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5', 'second' => '6']]],
+            [['P42D' => ['year' => '0', 'month' => '0', 'day' => '42', 'hour' => '0', 'minute' => '0', 'second' => '0']]],
+            [['PT12H5M' => ['year' => '0', 'month' => '0', 'day' => '0', 'hour' => '12', 'minute' => '5', 'second' => '0']]],
+            [['P0Y' => ['year' => '0', 'month' => '0', 'day' => '0', 'hour' => '0', 'minute' => '0', 'second' => '0']]],
+            [['PT0S' => ['year' => '0', 'month' => '0', 'day' => '0', 'hour' => '0', 'minute' => '0', 'second' => '0']]],
+        ];
+    }
+
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testTransform($valueAsArray)
+    {
+        $transformer = new DateIntervalToArrayTransformer();
+        $value = new DateInterval(array_keys($valueAsArray)[0]);
+        self::assertSame($valueAsArray[array_keys($valueAsArray)[0]], $transformer->transform($value));
+    }
+
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testReverseTransform($valueAsArray)
+    {
+        $transformer = new DateIntervalToArrayTransformer();
+        $expectedValue = new DateInterval(array_keys($valueAsArray)[0]);
+        self::assertEquals($expectedValue, $transformer->reverseTransform($valueAsArray[array_keys($valueAsArray)[0]]));
+    }
+
+    public function testTransformNull()
+    {
+        $transformer = new DateIntervalToArrayTransformer();
+        self::assertSame(
+            ['year' => '0', 'month' => '0', 'day' => '0', 'hour' => '0', 'minute' => '0', 'second' => '0'],
+            $transformer->transform(null)
+        );
+    }
+
+    public function reverseTransformNullProvider()
+    {
+        return [
+            [null],
+            [['']],
+            [['','','']],
+            [['',null,'']],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformNullProvider
+     */
+    public function testReverseTransformNull($value)
+    {
+        $transformer = new DateIntervalToArrayTransformer();
+        self::assertNull($transformer->reverseTransform($value));
+    }
+}


### PR DESCRIPTION
Symfony forms don't support DateInterval. This adds a custom form field type.

- [x] Basic form
- [x] Get DateInterval handling working
- [x] Add screenshot
- [x] Implement template
- [x] PSR-2 and short array notation
- [x] Import DateInterval
- [x] Tests

![Screenshot](http://i.imgur.com/DKe40n9.png)

https://jira.ez.no/browse/EZP-24390