### PR TITLE
Fix EZP-24381: As a RepositoryForms user, I want to be able to publish a content type draft

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -14,6 +14,9 @@ parameters:
 
     ezrepoforms.twig.field_edit_rendering_extension.class: EzSystems\RepositoryForms\Twig\FieldEditRenderingExtension
     ezrepoforms.form_processor.content_type.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeFormProcessor
+    ezrepoforms.form_processor.content_type.options.redirect_route_after_publish: ~
+    ezrepoforms.form_processor.content_type.options:
+        redirectRouteAfterPublish: %ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -85,6 +88,6 @@ services:
 
     ezrepoforms.form_processor.content_type:
         class: %ezrepoforms.form_processor.content_type.class%
-        arguments: [@ezpublish.api.service.content_type]
+        arguments: [@ezpublish.api.service.content_type, @router, %ezrepoforms.form_processor.content_type.options%]
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -1,4 +1,6 @@
 EzSystems\RepositoryForms\Data\ContentTypeData:
+    constraints:
+        - EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier: ~
     properties:
         identifier:
             - NotBlank: ~
@@ -7,7 +9,6 @@ EzSystems\RepositoryForms\Data\ContentTypeData:
             - Regex:
                 pattern: "/^[[:alnum:]_]+$/"
                 message: "ez.content_type.identifier.pattern"
-            - EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier: ~
         urlAliasSchema:
             - Length:
                 max: 255

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -62,6 +62,10 @@
                 <source>content_type.publish</source>
                 <target>OK</target>
             </trans-unit>
+            <trans-unit id="16">
+                <source>content_type.remove_field_definitions</source>
+                <target>Remove selected field definitions</target>
+            </trans-unit>
             <!-- Field definition -->
             <trans-unit id="101">
                 <source>field_definition.name</source>

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -58,6 +58,10 @@
                 <source>content_type.edit_title</source>
                 <target>Edit &lt;%contentTypeName%&gt;</target>
             </trans-unit>
+            <trans-unit id="15">
+                <source>content_type.publish</source>
+                <target>OK</target>
+            </trans-unit>
             <!-- Field definition -->
             <trans-unit id="101">
                 <source>field_definition.name</source>

--- a/bundle/Resources/views/ContentType/field_definition_row.html.twig
+++ b/bundle/Resources/views/ContentType/field_definition_row.html.twig
@@ -1,7 +1,10 @@
 {# @var value \EzSystems\RepositoryForms\Data\FieldDefinitionData #}
 {% block form_row %}
     <div class="field-definition-edit field-type-{{ value.fieldTypeIdentifier }}">
-        <h3>{{ value.names[languageCode] }} [{{ value.fieldTypeIdentifier }}] (id: {{ value.fieldDefinition.id }})</h3>
+        <h3>
+            {{ form_widget(form.selected) }}
+            {{ value.names[languageCode] }} [{{ value.fieldTypeIdentifier }}] (id: {{ value.fieldDefinition.id }})
+        </h3>
 
         <div class="field-definition-position">
             {{ form_label(form.position) }}

--- a/lib/Event/RepositoryFormEvents.php
+++ b/lib/Event/RepositoryFormEvents.php
@@ -11,7 +11,18 @@ namespace EzSystems\RepositoryForms\Event;
 
 final class RepositoryFormEvents
 {
+    /**
+     * Base name for ContentType update processing events.
+     */
     const CONTENT_TYPE_UPDATE = 'contentType.update';
 
+    /**
+     * Triggered when adding a FieldDefinition to the ContentTypeDraft.
+     */
     const CONTENT_TYPE_ADD_FIELD_DEFINITION = 'contentType.update.addFieldDefinition';
+
+    /**
+     * Triggered when saving the draft + publishing the ContentType.
+     */
+    const CONTENT_TYPE_PUBLISH = 'contentType.update.publishContentType';
 }

--- a/lib/Event/RepositoryFormEvents.php
+++ b/lib/Event/RepositoryFormEvents.php
@@ -22,6 +22,11 @@ final class RepositoryFormEvents
     const CONTENT_TYPE_ADD_FIELD_DEFINITION = 'contentType.update.addFieldDefinition';
 
     /**
+     * Triggered when removing a FieldDefinition from the ContentTypeDraft.
+     */
+    const CONTENT_TYPE_REMOVE_FIELD_DEFINITION = 'contentType.update.removeFieldDefinition';
+
+    /**
      * Triggered when saving the draft + publishing the ContentType.
      */
     const CONTENT_TYPE_PUBLISH = 'contentType.update.publishContentType';

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -14,6 +14,9 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 class ContentTypeFormProcessor implements EventSubscriberInterface
 {
@@ -22,15 +25,33 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
      */
     private $contentTypeService;
 
-    public function __construct(ContentTypeService $contentTypeService)
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(ContentTypeService $contentTypeService, RouterInterface $router, array $options = [])
     {
         $this->contentTypeService = $contentTypeService;
+        $this->router = $router;
+        $this->setOptions($options);
+    }
+
+    public function setOptions(array $options = [])
+    {
+        $this->options = $options + ['redirectRouteAfterPublish' => null];
     }
 
     public static function getSubscribedEvents()
     {
         return [
             RepositoryFormEvents::CONTENT_TYPE_ADD_FIELD_DEFINITION => 'processAddFieldDefinition',
+            RepositoryFormEvents::CONTENT_TYPE_PUBLISH => 'processPublishContentType',
         ];
     }
 
@@ -44,5 +65,16 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
             'names' => [$event->getLanguageCode() => 'New FieldDefinition'],
         ]);
         $this->contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreateStruct);
+    }
+
+    public function processPublishContentType(FormActionEvent $event)
+    {
+        $contentTypeDraft = $event->getData()->contentTypeDraft;
+        $this->contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        if (isset($this->options['redirectRouteAfterPublish'])) {
+            $event->setResponse(
+                new RedirectResponse($this->router->generate($this->options['redirectRouteAfterPublish']))
+            );
+        }
     }
 }

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -51,6 +51,7 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
     {
         return [
             RepositoryFormEvents::CONTENT_TYPE_ADD_FIELD_DEFINITION => 'processAddFieldDefinition',
+            RepositoryFormEvents::CONTENT_TYPE_REMOVE_FIELD_DEFINITION => 'processRemoveFieldDefinition',
             RepositoryFormEvents::CONTENT_TYPE_PUBLISH => 'processPublishContentType',
         ];
     }
@@ -65,6 +66,21 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
             'names' => [$event->getLanguageCode() => 'New FieldDefinition'],
         ]);
         $this->contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreateStruct);
+    }
+
+    public function processRemoveFieldDefinition(FormActionEvent $event)
+    {
+        /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft */
+        $contentTypeDraft = $event->getData()->contentTypeDraft;
+
+        // Accessing FieldDefinition user selection through the form and not the data,
+        // as "selected" is not a property of FieldDefinitionData.
+        /** @var \Symfony\Component\Form\FormInterface $fieldDefForm */
+        foreach ($event->getForm()->get('fieldDefinitionsData') as $fieldDefForm) {
+            if ($fieldDefForm->get('selected')->getData() === true) {
+                $this->contentTypeService->removeFieldDefinition($contentTypeDraft, $fieldDefForm->getData()->fieldDefinition);
+            }
+        }
     }
 
     public function processPublishContentType(FormActionEvent $event)

--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -111,6 +111,7 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.field_type_selection',
             ])
             ->add('addFieldDefinition', 'submit', ['label' => 'content_type.add_field_definition'])
+            ->add('removeFieldDefinition', 'submit', ['label' => 'content_type.remove_field_definitions'])
             ->add('saveContentType', 'submit', ['label' => 'content_type.save'])
             ->add('publishContentType', 'submit', ['label' => 'content_type.publish']);
     }

--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -111,7 +111,8 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.field_type_selection',
             ])
             ->add('addFieldDefinition', 'submit', ['label' => 'content_type.add_field_definition'])
-            ->add('saveContentType', 'submit', ['label' => 'content_type.save']);
+            ->add('saveContentType', 'submit', ['label' => 'content_type.save'])
+            ->add('publishContentType', 'submit', ['label' => 'content_type.publish']);
     }
 
     /**

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -69,7 +69,8 @@ class FieldDefinitionType extends AbstractType
             ->add('isRequired', 'checkbox', ['required' => false, 'label' => 'field_definition.is_required'])
             ->add('isTranslatable', 'checkbox', ['required' => false, 'label' => 'field_definition.is_translatable'])
             ->add('fieldGroup', 'choice', ['choices' => []], ['required' => false, 'label' => 'field_definition.field_group'])
-            ->add('position', 'integer', ['label' => 'field_definition.position']);
+            ->add('position', 'integer', ['label' => 'field_definition.position'])
+            ->add('selected', 'checkbox', ['required' => false, 'mapped' => false]);
 
         // Hook on form generation for specific FieldType needs
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
@@ -27,4 +27,9 @@ class UniqueContentTypeIdentifier extends Constraint
     {
         return 'ezrepoforms.validator.unique_content_type_identifier';
     }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
 }

--- a/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
+++ b/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
@@ -27,6 +27,11 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
     private $contentTypeService;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $router;
+
+    /**
      * @var ContentTypeFormProcessor
      */
     private $formProcessor;
@@ -35,13 +40,15 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->contentTypeService = $this->getMock('\eZ\Publish\API\Repository\ContentTypeService');
-        $this->formProcessor = new ContentTypeFormProcessor($this->contentTypeService);
+        $this->router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $this->formProcessor = new ContentTypeFormProcessor($this->contentTypeService, $this->router);
     }
 
     public function testSubscribedEvents()
     {
         self::assertSame([
             RepositoryFormEvents::CONTENT_TYPE_ADD_FIELD_DEFINITION => 'processAddFieldDefinition',
+            RepositoryFormEvents::CONTENT_TYPE_PUBLISH => 'processPublishContentType',
         ], ContentTypeFormProcessor::getSubscribedEvents());
     }
 

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
@@ -25,4 +25,10 @@ class UniqueContentTypeIdentifierTest extends PHPUnit_Framework_TestCase
         $constraint = new UniqueContentTypeIdentifier();
         self::assertSame('ezrepoforms.validator.unique_content_type_identifier', $constraint->validatedBy());
     }
+
+    public function testGetTargets()
+    {
+        $constraint = new UniqueContentTypeIdentifier();
+        self::assertSame(UniqueContentTypeIdentifier::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
 }

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
@@ -10,9 +10,11 @@
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use EzSystems\RepositoryForms\Data\ContentTypeData;
 use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier;
 use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator;
 use PHPUnit_Framework_TestCase;
+use stdClass;
 
 class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCase
 {
@@ -40,9 +42,23 @@ class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCas
         $this->validator->initialize($this->executionContext);
     }
 
+    public function testNotContentTypeData()
+    {
+        $value = new stdClass();
+        $this->contentTypeService
+            ->expects($this->never())
+            ->method('loadContentTypeByIdentifier');
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($value, new UniqueContentTypeIdentifier());
+    }
+
     public function testValid()
     {
         $identifier = 'foo_identifier';
+        $value = new ContentTypeData(['identifier' => $identifier]);
         $this->contentTypeService
             ->expects($this->once())
             ->method('loadContentTypeByIdentifier')
@@ -52,23 +68,58 @@ class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCas
             ->expects($this->never())
             ->method('buildVioloation');
 
-        $this->validator->validate($identifier, new UniqueContentTypeIdentifier());
+        $this->validator->validate($value, new UniqueContentTypeIdentifier());
+    }
+
+    public function testEditingContentTypeDraftFromExistingContentTypeIsValid()
+    {
+        $identifier = 'foo_identifier';
+        $contentTypeId = 123;
+        $contentTypeDraft = $this->getMockBuilder('\eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft')
+            ->setConstructorArgs([['id' => $contentTypeId]])
+            ->getMockForAbstractClass();
+        $value = new ContentTypeData(['identifier' => $identifier, 'contentTypeDraft' => $contentTypeDraft]);
+        $returnedContentType = $this->getMockBuilder('\eZ\Publish\API\Repository\Values\ContentType\ContentType')
+            ->setConstructorArgs([['id' => $contentTypeId]])
+            ->getMockForAbstractClass();
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($identifier)
+            ->willReturn($returnedContentType);
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildVioloation');
+
+        $this->validator->validate($value, new UniqueContentTypeIdentifier());
     }
 
     public function testInvalid()
     {
         $identifier = 'foo_identifier';
+        $contentTypeDraft = $this->getMockBuilder('\eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft')
+            ->setConstructorArgs([['id' => 456]])
+            ->getMockForAbstractClass();
+        $value = new ContentTypeData(['identifier' => $identifier, 'contentTypeDraft' => $contentTypeDraft]);
         $constraint = new UniqueContentTypeIdentifier();
         $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+        $returnedContentType = $this->getMockBuilder('\eZ\Publish\API\Repository\Values\ContentType\ContentType')
+            ->setConstructorArgs([['id' => 123]])
+            ->getMockForAbstractClass();
         $this->contentTypeService
             ->expects($this->once())
             ->method('loadContentTypeByIdentifier')
             ->with($identifier)
-            ->willReturn($this->getMockForAbstractClass('\eZ\Publish\API\Repository\Values\ContentType\ContentType'));
+            ->willReturn($returnedContentType);
         $this->executionContext
             ->expects($this->once())
             ->method('buildViolation')
             ->with($constraint->message)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('atPath')
+            ->with('identifier')
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
             ->expects($this->once())
@@ -79,6 +130,6 @@ class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCas
             ->expects($this->once())
             ->method('addViolation');
 
-        $this->validator->validate($identifier, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24381

This PR simply adds the possibility to *publish* a ContentTypeDraft.
It also:
* Makes it possible to create a ContentTypeDraft out of an existing ContentType if it doesn't exist yet.
* Fixes ContentType identifier uniqueness validator to allow edition of an existing ContentType.

## TODO
* [x] Fix UniqueContentTypeIdentifierValidatorTest