### PR TITLE
Fix EZP-24440: Filter FieldType selection in ContentType edition

### DIFF
--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -125,10 +125,11 @@ class ContentTypeUpdateType extends AbstractType
     private function getFieldTypeList()
     {
         $list = [];
-        foreach ($this->fieldTypeCollectionFactory->getFieldTypes() as $fieldTypeIdentifier => $fieldType) {
+        foreach ($this->fieldTypeCollectionFactory->getConcreteFieldTypesIdentifiers() as $fieldTypeIdentifier) {
             $list[$fieldTypeIdentifier] = $this->translator->trans("$fieldTypeIdentifier.name", [], 'fieldtypes');
         }
 
+        asort($list, SORT_NATURAL);
         return $list;
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24440

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/1293

In addition, FieldTypes are now sorted nicely :smile: 