### PR TITLE
Fix EZP-24446: Implement ezrelation FieldDefinition form mapper

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
     ezrepoforms.field_type.form_mapper.ezinteger.class: EzSystems\RepositoryForms\FieldType\Mapper\IntegerFormMapper
     ezrepoforms.field_type.form_mapper.ezisbn.class: EzSystems\RepositoryForms\FieldType\Mapper\ISBNFormMapper
     ezrepoforms.field_type.form_mapper.ezmedia.class: EzSystems\RepositoryForms\FieldType\Mapper\MediaFormMapper
+    ezrepoforms.field_type.form_mapper.ezobjectrelation.class: EzSystems\RepositoryForms\FieldType\Mapper\RelationFormMapper
     ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class: EzSystems\RepositoryForms\FieldType\Mapper\RelationListFormMapper
     ezrepoforms.field_type.form_mapper.ezpage.class: EzSystems\RepositoryForms\FieldType\Mapper\PageFormMapper
     ezrepoforms.field_type.form_mapper.ezrichtext.class: EzSystems\RepositoryForms\FieldType\Mapper\RichTextFormMapper
@@ -94,6 +95,11 @@ services:
         class: %ezrepoforms.field_type.form_mapper.ezmedia.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezmedia }
+
+    ezrepoforms.field_type.form_mapper.ezobjectrelation:
+        class: %ezrepoforms.field_type.form_mapper.ezobjectrelation.class%
+        tags:
+            - { name: ez.fieldType.formMapper, fieldType: ezobjectrelation }
 
     ezrepoforms.field_type.form_mapper.ezobjectrelationlist:
         class: %ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class%

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -303,6 +303,18 @@
                 <source>field_definition.ezdatetime.date_interval</source>
                 <target>Current date and time adjusted by</target>
             </trans-unit>
+            <trans-unit id="148">
+                <source>field_definition.ezobjectrelation.selection_root</source>
+                <target>Default selection item</target>
+            </trans-unit>
+            <trans-unit id="149">
+                <source>field_definition.ezobjectrelation.selection_root_udw_title</source>
+                <target>Select a start location for browsing for relations</target>
+            </trans-unit>
+            <trans-unit id="150">
+                <source>field_definition.ezobjectrelation.selection_root_udw_button</source>
+                <target>Select item</target>
+            </trans-unit>
             <trans-unit id="151">
                 <source>field_definition.ezobjectrelationlist.selection_default_location</source>
                 <target>Default location</target>

--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -116,6 +116,23 @@
     </div>
 {% endblock %}
 
+{% block ezobjectrelation_field_definition_edit %}
+    <div class="ezobjectrelation-settings selection-root">
+        {{- form_label(form.selectionRoot) -}}
+        {{- form_errors(form.selectionRoot) -}}
+        {{- form_widget(form.selectionRoot) -}}
+
+        <button data-universaldiscovery-title="{{"field_definition.ezobjectrelation.selection_root_udw_title"|trans({}, "ezrepoforms_content_type")}}"
+                class="ez-button-tree pure-button ez-font-icon ez-button ez-relation-pick-root-button"
+                data-relation-root-input-selector="#{{form.selectionRoot.vars.id}}"
+                data-relation-selected-root-name-selector="#{{form.selectionRoot.vars.id}}-selected-root-name"
+                >{{"field_definition.ezobjectrelation.selection_root_udw_button"|trans({}, "ezrepoforms_content_type")}}</button>
+        <div id="{{form.selectionRoot.vars.id}}-selected-root-name">
+            {{ render( controller( "ez_content:viewLocation", {'locationId': form.selectionRoot.vars.value, 'viewType': '_platformui_content_name'} ) ) }}
+        </div>
+    </div>
+{% endblock %}
+
 {% block ezobjectrelationlist_field_definition_edit %}
     <div class="ezobjectrelationlist-settings selection-default-location">
         {{- form_label(form.selectionDefaultLocation) -}}

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\RepositoryForms\FieldType\Mapper;
+
+use eZ\Publish\Core\FieldType\Relation\Type;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+class RelationFormMapper implements FieldTypeFormMapperInterface
+{
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $fieldDefinitionForm
+            ->add('selectionRoot', 'text', [ // TODO: Replace 'text' with 'hidden' when the UDW is ready to use
+                'required' => false,
+                'property_path' => 'fieldSettings[selectionRoot]',
+                'label' => 'field_definition.ezobjectrelation.selection_root',
+            ]);
+    }
+}


### PR DESCRIPTION
It's unclear how the field for "Default selection item" should be set up. In legacy this lets you browse for a node, and stores a node ID: https://github.com/ezsystems/ezpublish-legacy/blob/master/design/standard/templates/class/datatype/edit/ezobjectrelation.tpl#L16

In the Type, the setting is a string, and the validator accepts strings:
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Relation/Type.php#L91

However, the Converter then stores this in dataInt2, so any actual string value is lost:
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php#L72

The doc agrees it is a string, doesn't specify how it should be used, but says it is for future use:
https://doc.ez.no/display/EZP/The+Relation+FieldType

I have implemented it as a text field, with a UDW button to start the browsing action, and a todo notice to change it to hidden when the UDW is available (not yet, says @dpobel). Before then the text field can be used for manual testing.

https://jira.ez.no/browse/EZP-24446