### PR TITLE
[req] Changed branch-alias to 0.2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "0.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
As we're gonna tag 0.1.0.
Shouldn't require changes to ezplatform, as it requires repository-forms: ~0.1@dev, meaning that it should pick the branch alias instead, right ?