### PR TITLE
Fix EZP-24581: Creating a new content type failed with error: Failed …

### DIFF
--- a/lib/Data/ContentTypeData.php
+++ b/lib/Data/ContentTypeData.php
@@ -21,6 +21,11 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct;
 class ContentTypeData extends ContentTypeUpdateStruct
 {
     /**
+     * Trait which provides isNew(), and mandates getIdentifier().
+     */
+    use NewnessChecker;
+
+    /**
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
     protected $contentTypeDraft;
@@ -29,6 +34,11 @@ class ContentTypeData extends ContentTypeUpdateStruct
      * @var \EzSystems\RepositoryForms\Data\FieldDefinitionData[]
      */
     protected $fieldDefinitionsData = [];
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
 
     public function addFieldDefinitionData(FieldDefinitionData $fieldDefinitionData)
     {

--- a/lib/Data/Mapper/ContentTypeDraftMapper.php
+++ b/lib/Data/Mapper/ContentTypeDraftMapper.php
@@ -26,20 +26,20 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
      */
     public function mapToFormData(ValueObject $contentTypeDraft, array $params = [])
     {
-        $contentTypeData = new ContentTypeData([
-            'contentTypeDraft' => $contentTypeDraft,
-            'identifier' => $contentTypeDraft->identifier,
-            'remoteId' => $contentTypeDraft->remoteId,
-            'urlAliasSchema' => $contentTypeDraft->urlAliasSchema,
-            'nameSchema' => $contentTypeDraft->nameSchema,
-            'isContainer' => $contentTypeDraft->isContainer,
-            'mainLanguageCode' => $contentTypeDraft->mainLanguageCode,
-            'defaultSortField' => $contentTypeDraft->defaultSortField,
-            'defaultSortOrder' => $contentTypeDraft->defaultSortOrder,
-            'defaultAlwaysAvailable' => $contentTypeDraft->defaultAlwaysAvailable,
-            'names' => $contentTypeDraft->getNames(),
-            'descriptions' => $contentTypeDraft->getDescriptions(),
-        ]);
+        $contentTypeData = new ContentTypeData(['contentTypeDraft' => $contentTypeDraft]);
+        if (!$contentTypeData->isNew()) {
+            $contentTypeData->identifier = $contentTypeDraft->identifier;
+            $contentTypeData->remoteId = $contentTypeDraft->remoteId;
+            $contentTypeData->urlAliasSchema = $contentTypeDraft->urlAliasSchema;
+            $contentTypeData->nameSchema = $contentTypeDraft->nameSchema;
+            $contentTypeData->isContainer = $contentTypeDraft->isContainer;
+            $contentTypeData->mainLanguageCode = $contentTypeDraft->mainLanguageCode;
+            $contentTypeData->defaultSortField = $contentTypeDraft->defaultSortField;
+            $contentTypeData->defaultSortOrder = $contentTypeDraft->defaultSortOrder;
+            $contentTypeData->defaultAlwaysAvailable = $contentTypeDraft->defaultAlwaysAvailable;
+            $contentTypeData->names = $contentTypeDraft->getNames();
+            $contentTypeData->descriptions = $contentTypeDraft->getDescriptions();
+        }
 
         foreach ($contentTypeDraft->fieldDefinitions as $fieldDef) {
             $contentTypeData->addFieldDefinitionData(new FieldDefinitionData([

--- a/lib/Data/NewnessChecker.php
+++ b/lib/Data/NewnessChecker.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data;
+
+/**
+ * Trait for repository data objects, provides a test for if they are newly created, based on identifier.
+ */
+trait NewnessChecker
+{
+    /**
+     * Whether the Data object is considered new, based on the identifier
+     * If it isn't new, one can e.g. use the identifier from the underlying value object.
+     */
+    public function isNew()
+    {
+        return strpos($this->getIdentifier(), '__new__') === 0;
+    }
+
+    /**
+     * The value of the property which is the identifier of the value object.
+     */
+    abstract public function getIdentifier();
+}


### PR DESCRIPTION
…to load '/contenttype/create/1'

Followup to platformui fix, adds trait for isNew()
https://github.com/ezsystems/PlatformUIBundle/pull/291

https://jira.ez.no/browse/EZP-24581