### PR TITLE
Fix CS: phpdoc_inline_tag,phpdoc_scalar,phpdoc_short_description,sing…

### DIFF
--- a/bundle/DependencyInjection/Compiler/FieldTypeFormMapperPass.php
+++ b/bundle/DependencyInjection/Compiler/FieldTypeFormMapperPass.php
@@ -8,8 +8,7 @@
  *
  * @version //autogentag//
  */
-
-namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler;
+namespace EzSystems\RepositoryFormsbundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/bundle/DependencyInjection/EzSystemsRepositoryFormsExtension.php
+++ b/bundle/DependencyInjection/EzSystemsRepositoryFormsExtension.php
@@ -8,8 +8,7 @@
  *
  * @version //autogentag//
  */
-
-namespace EzSystems\RepositoryFormsBundle\DependencyInjection;
+namespace EzSystems\RepositoryFormsbundle\DependencyInjection;
 
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -8,8 +8,7 @@
  *
  * @version //autogentag//
  */
-
-namespace EzSystems\RepositoryFormsBundle;
+namespace EzSystems\RepositoryFormsbundle;
 
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/lib/Data/ContentTypeData.php
+++ b/lib/Data/ContentTypeData.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Data;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct;

--- a/lib/Data/FieldDefinitionData.php
+++ b/lib/Data/FieldDefinitionData.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Data;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;

--- a/lib/Data/Mapper/ContentTypeDraftMapper.php
+++ b/lib/Data/Mapper/ContentTypeDraftMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Data\Mapper;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Data/Mapper/FormDataMapperInterface.php
+++ b/lib/Data/Mapper/FormDataMapperInterface.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Data\Mapper;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Event/FormActionEvent.php
+++ b/lib/Event/FormActionEvent.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Event;
 
 use Symfony\Component\Form\FormEvent;

--- a/lib/Event/RepositoryFormEvents.php
+++ b/lib/Event/RepositoryFormEvents.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Event;
 
 final class RepositoryFormEvents

--- a/lib/FieldType/DataTransformer/CountryValueTransformer.php
+++ b/lib/FieldType/DataTransformer/CountryValueTransformer.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
 
 use eZ\Publish\Core\FieldType\Country\Value;

--- a/lib/FieldType/DataTransformer/TextLineValueTransformer.php
+++ b/lib/FieldType/DataTransformer/TextLineValueTransformer.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
 
 use eZ\Publish\Core\FieldType\TextLine\Value;

--- a/lib/FieldType/FieldTypeFormMapperInterface.php
+++ b/lib/FieldType/FieldTypeFormMapperInterface.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/FieldTypeFormMapperRegistry.php
+++ b/lib/FieldType/FieldTypeFormMapperRegistry.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/FieldTypeFormMapperRegistryInterface.php
+++ b/lib/FieldType/FieldTypeFormMapperRegistryInterface.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType;
 
 /**

--- a/lib/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/lib/FieldType/Mapper/BinaryFileFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Date\Type;

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\DateAndTime\Type;

--- a/lib/FieldType/Mapper/FloatFormMapper.php
+++ b/lib/FieldType/Mapper/FloatFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/ISBNFormMapper.php
+++ b/lib/FieldType/Mapper/ISBNFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/lib/FieldType/Mapper/ImageFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Media\Type;

--- a/lib/FieldType/Mapper/PageFormMapper.php
+++ b/lib/FieldType/Mapper/PageFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Page\PageService;

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\API\Repository\ContentTypeService;

--- a/lib/FieldType/Mapper/RichTextFormMapper.php
+++ b/lib/FieldType/Mapper/RichTextFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Time\Type;

--- a/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
+++ b/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Form/ActionDispatcher/ActionDispatcherInterface.php
+++ b/lib/Form/ActionDispatcher/ActionDispatcherInterface.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Form/ActionDispatcher/ContentTypeDispatcher.php
+++ b/lib/Form/ActionDispatcher/ContentTypeDispatcher.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
 
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;

--- a/lib/Form/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/lib/Form/DataTransformer/DateIntervalToArrayTransformer.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\DataTransformer;
 
 use DateInterval;

--- a/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
+++ b/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\Processor;
 
 use eZ\Publish\API\Repository\ContentTypeService;

--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\Type;
 
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/lib/Form/Type/DateTimeIntervalType.php
+++ b/lib/Form/Type/DateTimeIntervalType.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\Type;
 
 use EzSystems\RepositoryForms\Form\DataTransformer\DateIntervalToArrayTransformer;

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Form\Type\FieldDefinition;
 
 use eZ\Publish\API\Repository\FieldTypeService;

--- a/lib/Twig/FieldEditRenderingExtension.php
+++ b/lib/Twig/FieldEditRenderingExtension.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Twig;
 
 use eZ\Publish\Core\MVC\Symfony\Templating\Exception\MissingFieldBlockException;

--- a/lib/Validator/Constraints/FieldDefinitionDefaultValue.php
+++ b/lib/Validator/Constraints/FieldDefinitionDefaultValue.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/lib/Validator/Constraints/FieldDefinitionDefaultValueValidator.php
+++ b/lib/Validator/Constraints/FieldDefinitionDefaultValueValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Validator/Constraints/FieldSettings.php
+++ b/lib/Validator/Constraints/FieldSettings.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/lib/Validator/Constraints/FieldSettingsValidator.php
+++ b/lib/Validator/Constraints/FieldSettingsValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/Validator/Constraints/FieldTypeValidator.php
+++ b/lib/Validator/Constraints/FieldTypeValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use eZ\Publish\API\Repository\FieldTypeService;

--- a/lib/Validator/Constraints/FieldValueValidator.php
+++ b/lib/Validator/Constraints/FieldValueValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use eZ\Publish\API\Repository\ContentTypeService;

--- a/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
+++ b/lib/Validator/Constraints/UniqueFieldDefinitionIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/lib/Validator/Constraints/UniqueFieldDefinitionIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueFieldDefinitionIdentifierValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/lib/Validator/Constraints/ValidatorConfiguration.php
+++ b/lib/Validator/Constraints/ValidatorConfiguration.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/lib/Validator/Constraints/ValidatorConfigurationValidator.php
+++ b/lib/Validator/Constraints/ValidatorConfigurationValidator.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/tests/RepositoryForms/Data/ContentTypeDataTest.php
+++ b/tests/RepositoryForms/Data/ContentTypeDataTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Data;
 
 use EzSystems\RepositoryForms\Data\ContentTypeData;

--- a/tests/RepositoryForms/Data/FieldDefinitionDataTest.php
+++ b/tests/RepositoryForms/Data/FieldDefinitionDataTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\tests\RepositoryForms\Data;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;

--- a/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
+++ b/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Data\Mapper;
 
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/tests/RepositoryForms/Event/FormActionEventTest.php
+++ b/tests/RepositoryForms/Event/FormActionEventTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Event;
 
 use EzSystems\RepositoryForms\Event\FormActionEvent;

--- a/tests/RepositoryForms/FieldType/DataTransformer/CountryValueTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/CountryValueTransformerTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
 
 use eZ\Publish\Core\FieldType\Country\Value;

--- a/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
 
 use DateInterval;

--- a/tests/RepositoryForms/FieldType/DataTransformer/TextLineValueTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/TextLineValueTransformerTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
 
 use eZ\Publish\Core\FieldType\TextLine\Value;

--- a/tests/RepositoryForms/FieldType/FieldTypeFormMapperRegistryTest.php
+++ b/tests/RepositoryForms/FieldType/FieldTypeFormMapperRegistryTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\FieldType;
 
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry;

--- a/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
+++ b/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Form\DataTransformer;
 
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;

--- a/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
+++ b/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Form\Processor;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;

--- a/tests/RepositoryForms/Twig/FieldEditRenderingExtensionTest.php
+++ b/tests/RepositoryForms/Twig/FieldEditRenderingExtensionTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension\FileSystemTwigIntegrationTestCase;

--- a/tests/RepositoryForms/Validator/Constraints/FieldDefinitionDefaultValueTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldDefinitionDefaultValueTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Validator\Constraints\FieldDefinitionDefaultValue;

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Validator\Constraints\FieldSettings;

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use eZ\Publish\Core\FieldType\ValidationError;

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifier;

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;

--- a/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Validator\Constraints\UniqueFieldDefinitionIdentifier;

--- a/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueFieldDefinitionIdentifierValidatorTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Data\ContentTypeData;

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfiguration;

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
 
 use eZ\Publish\Core\FieldType\ValidationError;


### PR DESCRIPTION
…le_quote,return,phpdoc_trim,multiline_array_trailing_comma,pre_increment,concat_with_spaces

Ran this, because of ezrobot complains:
`~/.composer/vendor/fabpot/php-cs-fixer/php-cs-fixer --level=psr2 --fixers=no_empty_lines_after_phpdocs,phpdoc_inline_tag,phpdoc_scalar,phpdoc_short_description,single_quote,return,phpdoc_trim,multiline_array_trailing_comma,pre_increment,concat_with_spaces fix .`

This PR is just to verify that ezrobot is happy now.

Same as https://github.com/ezsystems/PlatformUIBundle/pull/293