### PR TITLE
Fix EZP-24701: Role versioning

### DIFF
--- a/lib/Data/Mapper/RoleMapper.php
+++ b/lib/Data/Mapper/RoleMapper.php
@@ -19,16 +19,16 @@ class RoleMapper implements FormDataMapperInterface
      * Maps a ValueObject from eZ content repository to a data usable as underlying form data
      * (e.g. create/update struct).
      *
-     * @param ValueObject|\eZ\Publish\API\Repository\Values\User\Role $role
+     * @param ValueObject|\eZ\Publish\API\Repository\Values\User\RoleDraft $role
      * @param array $params
      *
      * @return RoleData
      */
-    public function mapToFormData(ValueObject $role, array $params = [])
+    public function mapToFormData(ValueObject $roleDraft, array $params = [])
     {
-        $roleData = new RoleData(['role' => $role]);
+        $roleData = new RoleData(['roleDraft' => $roleDraft]);
         if (!$roleData->isNew()) {
-            $roleData->identifier = $role->identifier;
+            $roleData->identifier = $roleDraft->identifier;
         }
 
         return $roleData;

--- a/lib/Data/RoleData.php
+++ b/lib/Data/RoleData.php
@@ -26,12 +26,12 @@ class RoleData extends RoleUpdateStruct implements NewsnessCheckable
     use NewnessChecker;
 
     /**
-     * @var \eZ\Publish\API\Repository\Values\User\Role
+     * @var \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    protected $role;
+    protected $roleDraft;
 
     protected function getIdentifierValue()
     {
-        return $this->role->identifier;
+        return $this->roleDraft->identifier;
     }
 }

--- a/lib/Form/Processor/RoleFormProcessor.php
+++ b/lib/Form/Processor/RoleFormProcessor.php
@@ -9,6 +9,7 @@
 namespace EzSystems\RepositoryForms\Form\Processor;
 
 use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -36,24 +37,23 @@ class RoleFormProcessor implements EventSubscriberInterface
 
     public function processDefaultAction(FormActionEvent $event)
     {
-        // TODO: When we have role versioning, save draft here.
-        // For now, processSaveRole takes care of saving. Follow-up: EZP-24701
-        //$this->addNotification('role.notification.draft_saved');
+        /** @var \EzSystems\RepositoryForms\Data\RoleData $roleData */
+        $roleData = $event->getData();
+        $roleDraft = $roleData->roleDraft;
+        $this->roleService->updateRoleDraft($roleDraft, $roleData);
     }
 
     public function processSaveRole(FormActionEvent $event)
     {
-        /** @var \EzSystems\RepositoryForms\Data\RoleData $roleData */
-        $roleData = $event->getData();
-        $this->roleService->updateRole($roleData->role, $roleData);
+        /** @var RoleDraft $roleDraft */
+        $roleDraft = $event->getData()->roleDraft;
+        $this->roleService->publishRoleDraft($roleDraft);
     }
 
     public function processRemoveDraft(FormActionEvent $event)
     {
-        $role = $event->getData()->role;
-        // TODO: This is just a temporary implementation of draft removal. To be done properly in follow-up: EZP-24701
-        if (preg_match('/^__new__[a-z0-9]{32}$/', $role->identifier) === 1) {
-            $this->roleService->deleterole($role);
-        }
+        /** @var RoleDraft $roleDraft */
+        $roleDraft = $event->getData()->roleDraft;
+        $this->roleService->deleteRoleDraft($roleDraft);
     }
 }

--- a/lib/Validator/Constraints/UniqueRoleIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueRoleIdentifierValidator.php
@@ -42,8 +42,8 @@ class UniqueRoleIdentifierValidator extends ConstraintValidator
 
         try {
             $role = $this->roleService->loadRoleByIdentifier($value->identifier);
-            // It's of course OK to edit a draft of an existing Role :-)
-            if ($role->id === $value->role->id) {
+            // It is of course OK to edit a draft of an existing Role :-)
+            if ($role->id === $value->roleDraft->id) {
                 return;
             }
 

--- a/tests/RepositoryForms/Data/Mapper/RoleMapperTest.php
+++ b/tests/RepositoryForms/Data/Mapper/RoleMapperTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Tests\Data\Mapper;
+
+use eZ\Publish\Core\Repository\Values\User\Role;
+use eZ\Publish\Core\Repository\Values\User\RoleDraft;
+use EzSystems\RepositoryForms\Data\Mapper\RoleMapper;
+use EzSystems\RepositoryForms\Data\RoleData;
+use PHPUnit_Framework_TestCase;
+
+class RoleMapperTest extends PHPUnit_Framework_TestCase
+{
+    public function testMapToFormData()
+    {
+        $identifier = 'Snafu';
+        $roleDraft = new RoleDraft([
+            'innerRole' => new Role([
+                'identifier' => $identifier,
+            ]),
+        ]);
+
+        $expectedRoleData = new RoleData([
+            'roleDraft' => $roleDraft,
+            'identifier' => $roleDraft->identifier,
+        ]);
+
+        self::assertEquals($expectedRoleData, (new RoleMapper())->mapToFormData($roleDraft));
+    }
+}


### PR DESCRIPTION
Makes use of role draft features added in main PR in ezpublish-kernel.

I removed the RoleFormProcessor I had here earlier. I moved code from here to the RoleFormProcessor in PlatformUI because I needed access to the notification feature it has, and I thought repository-forms should not depend on PlatformUI. On the other hand it means role editing will only work in PlatformUI. Unsure if this is the right way.

Requirement for https://github.com/ezsystems/ezpublish-kernel/pull/1376

https://jira.ez.no/browse/EZP-24701