### PR TITLE
Small fixes in NewnessChecker & ContentTypeDraftMapper

### DIFF
--- a/lib/Data/ContentTypeData.php
+++ b/lib/Data/ContentTypeData.php
@@ -35,9 +35,9 @@ class ContentTypeData extends ContentTypeUpdateStruct
      */
     protected $fieldDefinitionsData = [];
 
-    public function getIdentifier()
+    protected function getIdentifierValue()
     {
-        return $this->identifier;
+        return $this->contentTypeDraft->identifier;
     }
 
     public function addFieldDefinitionData(FieldDefinitionData $fieldDefinitionData)

--- a/lib/Data/Mapper/ContentTypeDraftMapper.php
+++ b/lib/Data/Mapper/ContentTypeDraftMapper.php
@@ -29,17 +29,18 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
         $contentTypeData = new ContentTypeData(['contentTypeDraft' => $contentTypeDraft]);
         if (!$contentTypeData->isNew()) {
             $contentTypeData->identifier = $contentTypeDraft->identifier;
-            $contentTypeData->remoteId = $contentTypeDraft->remoteId;
-            $contentTypeData->urlAliasSchema = $contentTypeDraft->urlAliasSchema;
-            $contentTypeData->nameSchema = $contentTypeDraft->nameSchema;
-            $contentTypeData->isContainer = $contentTypeDraft->isContainer;
-            $contentTypeData->mainLanguageCode = $contentTypeDraft->mainLanguageCode;
-            $contentTypeData->defaultSortField = $contentTypeDraft->defaultSortField;
-            $contentTypeData->defaultSortOrder = $contentTypeDraft->defaultSortOrder;
-            $contentTypeData->defaultAlwaysAvailable = $contentTypeDraft->defaultAlwaysAvailable;
-            $contentTypeData->names = $contentTypeDraft->getNames();
-            $contentTypeData->descriptions = $contentTypeDraft->getDescriptions();
         }
+
+        $contentTypeData->remoteId = $contentTypeDraft->remoteId;
+        $contentTypeData->urlAliasSchema = $contentTypeDraft->urlAliasSchema;
+        $contentTypeData->nameSchema = $contentTypeDraft->nameSchema;
+        $contentTypeData->isContainer = $contentTypeDraft->isContainer;
+        $contentTypeData->mainLanguageCode = $contentTypeDraft->mainLanguageCode;
+        $contentTypeData->defaultSortField = $contentTypeDraft->defaultSortField;
+        $contentTypeData->defaultSortOrder = $contentTypeDraft->defaultSortOrder;
+        $contentTypeData->defaultAlwaysAvailable = $contentTypeDraft->defaultAlwaysAvailable;
+        $contentTypeData->names = $contentTypeDraft->getNames();
+        $contentTypeData->descriptions = $contentTypeDraft->getDescriptions();
 
         foreach ($contentTypeDraft->fieldDefinitions as $fieldDef) {
             $contentTypeData->addFieldDefinitionData(new FieldDefinitionData([

--- a/lib/Data/NewnessChecker.php
+++ b/lib/Data/NewnessChecker.php
@@ -18,14 +18,18 @@ trait NewnessChecker
     /**
      * Whether the Data object is considered new, based on the identifier
      * If it isn't new, one can e.g. use the identifier from the underlying value object.
+     *
+     * @return bool
      */
     public function isNew()
     {
-        return strpos($this->getIdentifier(), '__new__') === 0;
+        return strpos($this->getIdentifierValue(), '__new__') === 0;
     }
 
     /**
-     * The value of the property which is the identifier of the value object.
+     * Returns the value of the property which can be considered as the value object identifier.
+     *
+     * @return string
      */
-    abstract public function getIdentifier();
+    abstract protected function getIdentifierValue();
 }

--- a/lib/Data/RoleData.php
+++ b/lib/Data/RoleData.php
@@ -30,8 +30,8 @@ class RoleData extends RoleUpdateStruct
      */
     protected $role;
 
-    public function getIdentifier()
+    protected function getIdentifierValue()
     {
-        return $this->identifier;
+        return $this->role->identifier;
     }
 }


### PR DESCRIPTION
* Changed getIdentifier() method name + visibility in NewnessChecker trait, to ensure no collision with regular public getters from value objects
* Fixed ContentTypeDraftMapper. All properties except identifier must be copied from ContentTypeDraft
when a new one is created