### PR TITLE
Fix EZP-24752: Cancel buttons should be not trigger validation in PlatformUI

### DIFF
--- a/lib/Form/Type/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentTypeUpdateType.php
@@ -114,7 +114,7 @@ class ContentTypeUpdateType extends AbstractType
             ->add('addFieldDefinition', 'submit', ['label' => 'content_type.add_field_definition'])
             ->add('removeFieldDefinition', 'submit', ['label' => 'content_type.remove_field_definitions'])
             ->add('saveContentType', 'submit', ['label' => 'content_type.save'])
-            ->add('removeDraft', 'submit', ['label' => 'content_type.remove_draft'])
+            ->add('removeDraft', 'submit', ['label' => 'content_type.remove_draft', 'validation_groups' => false])
             ->add('publishContentType', 'submit', ['label' => 'content_type.publish']);
     }
 

--- a/lib/Form/Type/RoleUpdateType.php
+++ b/lib/Form/Type/RoleUpdateType.php
@@ -38,6 +38,6 @@ class RoleUpdateType extends AbstractType
         $builder
             ->add('identifier', 'text', ['label' => 'role.identifier'])
             ->add('saveRole', 'submit', ['label' => 'role.save'])
-            ->add('removeDraft', 'submit', ['label' => 'role.remove_draft']);
+            ->add('removeDraft', 'submit', ['label' => 'role.remove_draft', 'validation_groups' => false]);
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24752

This patch deactivates validation when submitting ContentType / Role editing forms with the cancel button.
For this to completely work, a piece of JS should be implemented in PlatformUI to deactivate HTML5 validation as well.