### PR TITLE
Fix EZP-24942: Press <Enter> in repository form raises a notification error

### DIFF
--- a/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
+++ b/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
@@ -36,7 +36,7 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName, array $options = [])
+    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName = null, array $options = [])
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -46,7 +46,11 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
         $event = new FormActionEvent($form, $data, $actionName, $options);
         $defaultActionEventName = $this->getActionEventBaseName();
         $this->dispatchDefaultAction($defaultActionEventName, $event);
-        $this->dispatchAction($defaultActionEventName . ($actionName ? ".$actionName" : ''), $event);
+        // Action name is not set e.g. when pressing return in a text field.
+        // We have already run the default action, no need to run it again in that case.
+        if ($actionName) {
+            $this->dispatchAction("$defaultActionEventName.$actionName", $event);
+        }
         $this->response = $event->getResponse();
     }
 

--- a/lib/Form/ActionDispatcher/ActionDispatcherInterface.php
+++ b/lib/Form/ActionDispatcher/ActionDispatcherInterface.php
@@ -27,10 +27,11 @@ interface ActionDispatcherInterface
      *
      * @param FormInterface $form The form that has been submitted.
      * @param ValueObject $data Underlying data for the form. Most likely a create or update struct.
-     * @param string $actionName The form action itself. Typically the form clicked button name.
+     * @param string|null $actionName The form action itself. Typically the form clicked button name,
+     *                                or null if the default action is used (e.g. when pressing enter).
      * @param array $options Arbitrary hash of options.
      */
-    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName, array $options = []);
+    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName = null, array $options = []);
 
     /**
      * Returns the generated response, if any. Typically a RedirectResponse.


### PR DESCRIPTION
The default form action is always dispatched first. When no action is specified (as when pressing enter in a repoform) the default action is dispatched a second time. There's no need for this, and in some forms it leads to an error (identifier already exists).

Note: The forms behave a bit differently because actions are set up differently. When pressing enter, the role and content type edit forms save and reload. The section and content type group forms save and close.

https://jira.ez.no/browse/EZP-24942

Also required: https://github.com/ezsystems/PlatformUIBundle/pull/403