### PR TITLE
Fix EZP-25002: Unable to add more options to ezselection field type

### DIFF
--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -279,6 +279,10 @@
                 <source>field_definition.ezselection.options</source>
                 <target>Options</target>
             </trans-unit>
+            <trans-unit id="9346e6056cfea40f0386d670b68b7450">
+                <source>field_definition.ezselection.add_remove_empty_options</source>
+                <target>Add option / remove empty options</target>
+            </trans-unit>
             <trans-unit id="140">
                 <source>field_definition.ezrichtext.num_rows</source>
                 <target>Number of text rows in the editor</target>

--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -193,7 +193,12 @@
             </div>
         {% endfor %}
         {# This field is used for adding new select items #}
-        {{ form_widget(form.options.vars.prototype) }}
+        <div>
+            {{ form_widget(form.options.vars.prototype) }}
+        </div>
+        <div>
+            {{ form_widget(form.addOption) }}
+        </div>
     </div>
 {% endblock %}
 

--- a/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -44,6 +44,7 @@ class SelectionFormMapper implements FieldTypeFormMapperInterface
                 'required' => false,
                 'property_path' => 'fieldSettings[options]',
                 'label' => 'field_definition.ezselection.options',
-            ]);
+            ])
+            ->add('addOption', 'submit', ['label' => 'field_definition.ezselection.add_remove_empty_options']);
     }
 }


### PR DESCRIPTION
This is the simplest solution, with no javascript. It adds a button "Add option / remove empty options" which will remove any empty options, and add a new one if none are empty. Will reload the form for each press of the button.

![Screenshot](http://i.imgur.com/ieCMVs7.png)

Dynamic editing via javascript is a bit more complex, see http://symfony.com/doc/current/cookbook/form/form_collections.html#cookbook-form-collections-new-prototype

https://jira.ez.no/browse/EZP-25002