### PR TITLE
Fix EZP-24569: Automatically compute FieldDefinition position

### DIFF
--- a/lib/Data/ContentTypeData.php
+++ b/lib/Data/ContentTypeData.php
@@ -44,4 +44,22 @@ class ContentTypeData extends ContentTypeUpdateStruct implements NewsnessCheckab
     {
         $this->fieldDefinitionsData[] = $fieldDefinitionData;
     }
+
+    /**
+     * Sort $this->fieldDefinitionsData first by position, then by identifier.
+     */
+    public function sortFieldDefinitions()
+    {
+        usort(
+            $this->fieldDefinitionsData,
+            function ($a, $b) {
+                if ($a->fieldDefinition->position === $b->fieldDefinition->position) {
+                    // The identifiers can never be the same
+                    return $a->fieldDefinition->identifier < $b->fieldDefinition->identifier ? -1 : 1;
+                }
+
+                return $a->fieldDefinition->position < $b->fieldDefinition->position ? -1 : 1;
+            }
+        );
+    }
 }

--- a/lib/Data/Mapper/ContentTypeDraftMapper.php
+++ b/lib/Data/Mapper/ContentTypeDraftMapper.php
@@ -60,6 +60,7 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
                 'isSearchable' => $fieldDef->isSearchable,
             ]));
         }
+        $contentTypeData->sortFieldDefinitions();
 
         return $contentTypeData;
     }

--- a/tests/RepositoryForms/Data/ContentTypeDataTest.php
+++ b/tests/RepositoryForms/Data/ContentTypeDataTest.php
@@ -38,4 +38,39 @@ class ContentTypeDataTest extends PHPUnit_Framework_TestCase
         $data->addFieldDefinitionData($fieldDef4);
         self::assertSame([$fieldDef1, $fieldDef2, $fieldDef3, $fieldDef4], $data->fieldDefinitionsData);
     }
+
+    public function testSortFieldDefinitions()
+    {
+        $fieldDef1 = new FieldDefinitionData(
+            ['fieldDefinition' => $this->getMockForAbstractClass(
+                '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition',
+                [['id' => 1, 'identifier' => 'snarf', 'position' => 3]]
+            )]
+        );
+        $fieldDef2 = new FieldDefinitionData(
+            ['fieldDefinition' => $this->getMockForAbstractClass(
+                '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition',
+                [['id' => 2, 'identifier' => 'gnubel', 'position' => 2]]
+            )]
+        );
+        $fieldDef3 = new FieldDefinitionData(
+            ['fieldDefinition' => $this->getMockForAbstractClass(
+                '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition',
+                [['id' => 3, 'identifier' => 'heffa', 'position' => 2]]
+            )]
+        );
+        $fieldDef4 = new FieldDefinitionData(
+            ['fieldDefinition' => $this->getMockForAbstractClass(
+                '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition',
+                [['id' => 4, 'identifier' => 'lump', 'position' => 1]]
+            )]
+        );
+
+        $fieldDefs = [$fieldDef1, $fieldDef2, $fieldDef3, $fieldDef4];
+        $data = new ContentTypeData(['fieldDefinitionsData' => $fieldDefs]);
+        self::assertSame($fieldDefs, $data->fieldDefinitionsData);
+
+        $data->sortFieldDefinitions();
+        self::assertSame([$fieldDef4, $fieldDef2, $fieldDef3, $fieldDef1], $data->fieldDefinitionsData);
+    }
 }

--- a/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
+++ b/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
@@ -53,7 +53,22 @@ class ContentTypeDraftMapperTest extends PHPUnit_Framework_TestCase
             'defaultValue' => null,
             'isSearchable' => false,
         ]);
-        $fieldDefs = [$fieldDef1, $fieldDef2];
+        $fieldDef3 = new FieldDefinition([
+            'identifier' => 'identifiea3',
+            'fieldTypeIdentifier' => 'eztext',
+            'names' => ['fre-FR' => 'foo3'],
+            'descriptions' => ['fre-FR' => 'some description 3'],
+            'fieldGroup' => 'foo3',
+            'position' => 15,
+            'isTranslatable' => false,
+            'isRequired' => false,
+            'isInfoCollector' => true,
+            'validatorConfiguration' => ['validator3' => 'config'],
+            'fieldSettings' => ['field3' => 'settings'],
+            'defaultValue' => null,
+            'isSearchable' => false,
+        ]);
+        $fieldDefs = [$fieldDef1, $fieldDef2, $fieldDef3];
 
         $identifier = 'identifier';
         $remoteId = 'remoteId';
@@ -114,6 +129,22 @@ class ContentTypeDraftMapperTest extends PHPUnit_Framework_TestCase
             'isSearchable' => $fieldDef1->isSearchable,
         ]);
         $expectedContentTypeData->addFieldDefinitionData($expectedFieldDefData1);
+        $expectedFieldDefData3 = new FieldDefinitionData([
+            'fieldDefinition' => $fieldDef3,
+            'contentTypeData' => $expectedContentTypeData, 'identifier' => $fieldDef3->identifier,
+            'names' => $fieldDef3->names,
+            'descriptions' => $fieldDef3->descriptions,
+            'fieldGroup' => $fieldDef3->fieldGroup,
+            'position' => $fieldDef3->position,
+            'isTranslatable' => $fieldDef3->isTranslatable,
+            'isRequired' => $fieldDef3->isRequired,
+            'isInfoCollector' => $fieldDef3->isInfoCollector,
+            'validatorConfiguration' => $fieldDef3->validatorConfiguration,
+            'fieldSettings' => $fieldDef3->fieldSettings,
+            'defaultValue' => $fieldDef3->defaultValue,
+            'isSearchable' => $fieldDef3->isSearchable,
+        ]);
+        $expectedContentTypeData->addFieldDefinitionData($expectedFieldDefData3);
         $expectedFieldDefData2 = new FieldDefinitionData([
             'fieldDefinition' => $fieldDef2,
             'contentTypeData' => $expectedContentTypeData, 'identifier' => $fieldDef2->identifier,

--- a/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
+++ b/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
@@ -121,7 +121,13 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
             'fieldTypeIdentifier' => $fieldTypeIdentifier,
             'identifier' => $expectedNewFieldDefIdentifier,
             'names' => [$languageCode => 'New FieldDefinition'],
+            'position' => 1,
         ]);
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeDraft')
+            ->with($contentTypeDraft->id)
+            ->willReturn($contentTypeDraft);
         $this->contentTypeService
             ->expects($this->once())
             ->method('addFieldDefinition')


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-24569
> Status: Ready for review
> BDD for this: https://github.com/ezsystems/PlatformUIBundle/pull/423

Changes:
- Fielddefs are sorted when the content type is updated
- New fielddefs are created with position = max existing position + 1, so they show up last
- When the position is the same, sort by ~~create order~~ identifier (alphabetically ascending)

Tasks
- [x] "max existing position + 1" doesn't work when a position has been edited at the same time (same submit) as a new fielddef is added - the edited position is not taken into account
- [x] Tests