### PR TITLE
Fix EZP-25079: When saving a new policy draft module/function choice is lost

### DIFF
--- a/lib/Data/Role/PolicyDataTrait.php
+++ b/lib/Data/Role/PolicyDataTrait.php
@@ -44,9 +44,9 @@ trait PolicyDataTrait
      */
     public $moduleFunction;
 
-    public function setPolicy(PolicyDraft $policyDraft)
+    public function setPolicyDraft(PolicyDraft $policyDraft)
     {
-        $this->policy = $policyDraft;
+        $this->policyDraft = $policyDraft;
     }
 
     public function getId()


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25079

When saving a policy without publishing, we now retrieve the updated role and inject
the new policy into the data object.