### PR TITLE
EZP-25100: Added content edit view

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,11 @@
+# This file is meant to be imported from ezplatform's behat.yml.dist.
+# All path are relative to the root ezplatform directory.
+repository-forms:
+    suites:
+        content_edit:
+            paths:
+                - vendor/ezsystems/repository-forms/features/ContentEdit
+            contexts:
+                - EzSystems\RepositoryForms\Features\Context\ContentType:
+                    contentTypeService: @ezpublish.api.service.content_type
+                - EzSystems\RepositoryForms\Features\Context\ContentEdit

--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -12,11 +12,9 @@ use eZ\Bundle\EzPublishCoreBundle\Controller;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\Core\MVC\Symfony\View\View;
-use EzSystems\RepositoryForms\Data\Mapper\ContentCreateMapper;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\Content\ContentCreateType;
-use EzSystems\RepositoryForms\Form\Type\Content\ContentEditType;
+use EzSystems\RepositoryForms\View\ContentEdit\ContentEditSuccessView;
 use EzSystems\RepositoryForms\View\ContentEdit\ContentEditView;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -54,27 +52,11 @@ class ContentEditController extends Controller
         $this->contentService = $contentService;
     }
 
-    public function createWithoutDraftAction($contentTypeId, $language, $parentLocationId, Request $request)
+    public function createWithoutDraftAction(ContentEditView $view)
     {
-        $contentType = $this->contentTypeService->loadContentType($contentTypeId);
-        $data = (new ContentCreateMapper())->mapToFormData($contentType, [
-            'mainLanguageCode' => $language,
-            'parentLocation' => $this->locationService->newLocationCreateStruct($parentLocationId),
-        ]);
-        $form = $this->createForm(new ContentEditType(), $data, ['languageCode' => $language]);
-        $form->handleRequest($request);
+        $view->setTemplateIdentifier('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig');
 
-        if ($form->isValid()) {
-            $this->contentActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
-            if ($response = $this->contentActionDispatcher->getResponse()) {
-                return $response;
-            }
-        }
-
-        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
-            'form' => $form->createView(),
-            'languageCode' => $language,
-        ]);
+        return $view;
     }
 
     public function createAction($contentTypeId, $language, $parentLocationId)
@@ -120,6 +102,8 @@ class ContentEditController extends Controller
 
     public function editAction(ContentEditView $view)
     {
+        $view->setTemplateIdentifier('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig');
+
         return $view;
     }
 

--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -54,7 +54,9 @@ class ContentEditController extends Controller
 
     public function createWithoutDraftAction(ContentEditView $view)
     {
-        $view->setTemplateIdentifier('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig');
+        if ($view->getTemplateIdentifier() === null) {
+            $view->setTemplateIdentifier('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig');
+        }
 
         return $view;
     }

--- a/bundle/DependencyInjection/Compiler/ViewBuildersPass.php
+++ b/bundle/DependencyInjection/Compiler/ViewBuildersPass.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ViewBuildersPass implements CompilerPassInterface
+{
+    /**
+     * Registers the view builders into the view builder registry.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('ezpublish.view_builder.registry')) {
+            return;
+        }
+
+        $viewBuilderRegistry = $container->findDefinition('ezpublish.view_builder.registry');
+        $viewBuilders = [
+            $container->findDefinition('ezrepoforms.view.content_edit.builder'),
+        ];
+
+        $viewBuilderRegistry->addMethodCall('addToRegistry', [$viewBuilders]);
+    }
+}

--- a/bundle/DependencyInjection/Configuration/Parser/ContentEditView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentEditView.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Declares and parses the content_edit_view semantic config.
+ */
+class ContentEditView extends AbstractParser
+{
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+    }
+
+    public function preMap(array $config, ContextualizerInterface $contextualizer)
+    {
+        $contextualizer->mapConfigArray('content_edit_view', $config, ContextualizerInterface::MERGE_FROM_SECOND_LEVEL);
+    }
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('content_edit_view')
+                ->info('View selection settings when displaying a content edit view')
+                ->children()
+                ->arrayNode('full')
+                    ->useAttributeAsKey('view_name')
+                    ->normalizeKeys(false)
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('template')
+                                ->isRequired()
+                                ->info('Custom template path to use for rendering')
+                                ->example('subdir/my_template.html.twig')
+                            ->end()
+                            ->scalarNode('controller')
+                                ->info(
+                                    <<<EOT
+Use custom controller instead of the default one to display a content edit matching your rules.
+You can use the controller reference notation supported by Symfony.
+EOT
+                                )
+                                ->example('MyBundle:MyControllerClass:editArticleAction')
+                            ->end()
+                            ->arrayNode('match')
+                                ->info('Condition matchers configuration')
+                                ->useAttributeAsKey('view_name')
+                                ->prototype('variable')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->beforeNormalization()
+            ->always()
+            // Add one 'block' level in order to match the other view internal config structure.
+            ->then(function ($v) { return array('full' => $v); })->end()
+            ->end();
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -12,6 +12,7 @@ namespace EzSystems\RepositoryFormsBundle;
 
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\ViewBuildersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,5 +23,6 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         parent::build($container);
         $container->addCompilerPass(new FieldTypeFormMapperPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
+        $container->addCompilerPass(new ViewBuildersPass());
     }
 }

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -13,6 +13,7 @@ namespace EzSystems\RepositoryFormsBundle;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\ViewBuildersPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEditView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -24,5 +25,11 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $container->addCompilerPass(new FieldTypeFormMapperPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
         $container->addCompilerPass(new ViewBuildersPass());
+
+        /**
+         * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension
+         */
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addConfigParser(new ContentEditView());
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -47,6 +47,8 @@ parameters:
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
 
+    ezrepoforms.view.content_edit.form_filter.class: EzSystems\RepositoryForms\View\ContentEdit\ParameterFilter\ContentEditFormFilter
+
 services:
     ezrepoforms.field_type_form_mapper.registry:
         class: %ezrepoforms.field_type_form_mapper.registry.class%
@@ -264,3 +266,10 @@ services:
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit
+
+    ezrepoforms.view.content_edit.form_filter:
+        class: %ezrepoforms.view.content_edit.form_filter.class%
+        arguments:
+            - @ezpublish.api.service.content
+            - @ezpublish.api.service.content_type
+            - @form.factory

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ imports:
     - {resource: language.yml}
     - {resource: section.yml}
     - {resource: role.yml}
+    - {resource: view.yml}
 
 parameters:
     ezrepoforms.field_type_form_mapper.registry.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry
@@ -46,8 +47,6 @@ parameters:
     ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
-
-    ezrepoforms.view.content_edit.form_filter.class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditFormFilter
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -266,37 +265,3 @@ services:
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit
-
-    ezrepoforms.view.content_edit.form_filter:
-        class: %ezrepoforms.view.content_edit.form_filter.class%
-        arguments:
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.content_type
-            - @ezpublish.api.service.location
-            - @form.factory
-        tags:
-            - { name: kernel.event_subscriber }
-
-    ezrepoforms.view.form_parameter_injector:
-        class: EzSystems\RepositoryForms\View\ContentEdit\FormViewParameterInjector
-        tags:
-            - { name: kernel.event_subscriber }
-
-    ezrepoforms.view.content_edit.builder:
-        class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditViewBuilder
-        arguments:
-            - @ezpublish.view.configurator
-            - @ezpublish.view.view_parameters.injector.dispatcher
-
-    ezrepoforms.view.provider:
-        class: %ezpublish.view_provider.configured.class%
-        arguments: [@ezrepoforms.view.matcher_factory]
-        tags:
-            - {name: ezpublish.view_provider, type: 'EzSystems\RepositoryForms\View\ContentEdit\ContentEditView', priority: 10}
-
-    ezrepoforms.view.matcher_factory:
-        class: %ezpublish.view.matcher_factory.class%
-        arguments: [@ezpublish.api.repository, 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
-        calls:
-            - [setContainer, [@service_container]]
-            - [setMatchConfig, [$content_edit_view$]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -273,3 +273,8 @@ services:
             - @ezpublish.api.service.content
             - @ezpublish.api.service.content_type
             - @form.factory
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.view.content_edit.builder:
+        class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditViewBuilder

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -47,7 +47,7 @@ parameters:
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
 
-    ezrepoforms.view.content_edit.form_filter.class: EzSystems\RepositoryForms\View\ContentEdit\ParameterFilter\ContentEditFormFilter
+    ezrepoforms.view.content_edit.form_filter.class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditFormFilter
 
 services:
     ezrepoforms.field_type_form_mapper.registry:
@@ -272,9 +272,31 @@ services:
         arguments:
             - @ezpublish.api.service.content
             - @ezpublish.api.service.content_type
+            - @ezpublish.api.service.location
             - @form.factory
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.view.form_parameter_injector:
+        class: EzSystems\RepositoryForms\View\ContentEdit\FormViewParameterInjector
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.view.content_edit.builder:
         class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditViewBuilder
+        arguments:
+            - @ezpublish.view.configurator
+            - @ezpublish.view.view_parameters.injector.dispatcher
+
+    ezrepoforms.view.provider:
+        class: %ezpublish.view_provider.configured.class%
+        arguments: [@ezrepoforms.view.matcher_factory]
+        tags:
+            - {name: ezpublish.view_provider, type: 'EzSystems\RepositoryForms\View\ContentEdit\ContentEditView', priority: 10}
+
+    ezrepoforms.view.matcher_factory:
+        class: %ezpublish.view.matcher_factory.class%
+        arguments: [@ezpublish.api.repository, 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, [@service_container]]
+            - [setMatchConfig, [$content_edit_view$]]

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -45,7 +45,7 @@ services:
 
     ezrepofoerms.view.default_provider:
         class: %ezpublish.view_provider.configured.class%
-        arguments: [@ezpublish.content_view.default_matcher_factory]
+        arguments: [@ezrepoforms.view.default_matcher_factory]
         tags:
             - {name: ezpublish.view_provider, type: 'EzSystems\RepositoryForms\View\ContentEdit\ContentEditView', priority: -1}
 

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -1,0 +1,57 @@
+parameters:
+    ezrepoforms.default_view_templates.content_edit: 'EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig'
+    ezrepoforms.view.content_edit.form_filter.class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditFormFilter
+    ezsettings.default.content_edit_view: {}
+    ezsettings.default.content_edit_view_defaults:
+        full:
+            default:
+                template: %ezrepoforms.default_view_templates.content_edit%
+                match: []
+
+services:
+    ezrepoforms.view.content_edit.form_filter:
+        class: %ezrepoforms.view.content_edit.form_filter.class%
+        arguments:
+            - @ezpublish.api.service.content
+            - @ezpublish.api.service.content_type
+            - @ezpublish.api.service.location
+            - @form.factory
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.view.form_parameter_injector:
+        class: EzSystems\RepositoryForms\View\ContentEdit\FormViewParameterInjector
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.view.content_edit.builder:
+        class: EzSystems\RepositoryForms\View\ContentEdit\ContentEditViewBuilder
+        arguments:
+            - @ezpublish.view.configurator
+            - @ezpublish.view.view_parameters.injector.dispatcher
+
+    ezrepoforms.view.provider:
+        class: %ezpublish.view_provider.configured.class%
+        arguments: [@ezrepoforms.view.matcher_factory]
+        tags:
+            - {name: ezpublish.view_provider, type: 'EzSystems\RepositoryForms\View\ContentEdit\ContentEditView', priority: 10}
+
+    ezrepoforms.view.matcher_factory:
+        class: %ezpublish.view.matcher_factory.class%
+        arguments: [@ezpublish.api.repository, 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, [@service_container]]
+            - [setMatchConfig, [$content_edit_view$]]
+
+    ezrepofoerms.view.default_provider:
+        class: %ezpublish.view_provider.configured.class%
+        arguments: [@ezpublish.content_view.default_matcher_factory]
+        tags:
+            - {name: ezpublish.view_provider, type: 'EzSystems\RepositoryForms\View\ContentEdit\ContentEditView', priority: -1}
+
+    ezrepoforms.view.default_matcher_factory:
+        class: %ezpublish.view.matcher_factory.class%
+        arguments: [@ezpublish.api.repository, 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
+        calls:
+            - [setContainer, [@service_container]]
+            - [setMatchConfig, [$content_edit_view_defaults$]]

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,16 @@
         "symfony/validator": "~2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "~4.7",
+        "behat/behat": "^3.0"
     },
     "autoload": {
         "psr-4": {
             "EzSystems\\RepositoryFormsBundle\\": "bundle",
             "EzSystems\\RepositoryForms\\": "lib",
             "EzSystems\\RepositoryForms\\Tests\\": "tests/RepositoryForms",
-            "EzSystems\\RepositoryFormsBundle\\Tests\\": "tests/RepositoryFormsBundle"
+            "EzSystems\\RepositoryFormsBundle\\Tests\\": "tests/RepositoryFormsBundle",
+            "EzSystems\\RepositoryForms\\Features\\": "features"
         }
     },
     "extra": {

--- a/features/ContentEdit/create_without_draft.feature
+++ b/features/ContentEdit/create_without_draft.feature
@@ -1,0 +1,11 @@
+Feature: Edit content
+    In order to allow users to create content
+    As a project owner
+    I need to expose a form that creates a content item without using a draft.
+
+Scenario: Create a folder without a draft
+    Given there is a Content Type "folder" with the id "1"
+      #And there is a Location with the id "2"
+     When I go to "content/create/nodraft/1/eng-GB/2"
+     Then I should see a content edit form
+

--- a/features/ContentEdit/create_without_draft.feature
+++ b/features/ContentEdit/create_without_draft.feature
@@ -4,8 +4,11 @@ Feature: Edit content
     I need to expose a form that creates a content item without using a draft.
 
 Scenario: Create a folder without a draft
-    Given there is a Content Type "folder" with the id "1"
+    Given that I have permission to create folders
+      And there is a Content Type "folder" with the id "1"
       #And there is a Location with the id "2"
      When I go to "content/create/nodraft/1/eng-GB/2"
-     Then I should see a content edit form
-
+     Then I should see a folder content edit form
+     When I fill in the folder edit form
+      And I press "Publish"
+     Then I am on the View of the Content that was published

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -12,7 +12,8 @@ use PHPUnit_Framework_Assert as Assertion;
 class ContentEdit extends MinkContext implements Context, SnippetAcceptingContext
 {
     /**
-     * The
+     * Name of the content that was created using the edit form. Used to validate that the content was created.
+     * @var string
      */
     private $createdContentName;
 
@@ -31,7 +32,7 @@ class ContentEdit extends MinkContext implements Context, SnippetAcceptingContex
     public function iAmOnTheViewOfTheContentThatWasPublished()
     {
         if (!isset($this->createdContentName)) {
-            throw new \Exception("No created content name set");
+            throw new \Exception('No created content name set');
         }
 
         $page = $this->getSession()->getPage();
@@ -45,8 +46,8 @@ class ContentEdit extends MinkContext implements Context, SnippetAcceptingContex
     public function iFillInTheFolderEditForm()
     {
         // will only work for single value fields
-        $this->createdContentName = "Behat content edit @" . microtime(true);
-        $this->fillField("ezrepoforms_content_edit_fieldsData_name_value", $this->createdContentName);
+        $this->createdContentName = 'Behat content edit @' . microtime(true);
+        $this->fillField('ezrepoforms_content_edit_fieldsData_name_value', $this->createdContentName);
     }
 
     /**

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -6,16 +6,57 @@ namespace EzSystems\RepositoryForms\Features\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\MinkExtension\Context\MinkContext;
+use PHPUnit_Framework_Assert as Assertion;
 
 class ContentEdit extends MinkContext implements Context, SnippetAcceptingContext
 {
     /**
+     * The
+     */
+    private $createdContentName;
+
+    /**
+     * @Then /^I should see a folder content edit form$/
      * @Then /^I should see a content edit form$/
      */
     public function iShouldSeeAContentEditForm()
     {
         $this->assertSession()->elementExists('css', 'form[name=ezrepoforms_content_edit]');
+    }
+
+    /**
+     * @Then /^I am on the View of the Content that was published$/
+     */
+    public function iAmOnTheViewOfTheContentThatWasPublished()
+    {
+        if (!isset($this->createdContentName)) {
+            throw new \Exception("No created content name set");
+        }
+
+        $page = $this->getSession()->getPage();
+        Assertion::assertTrue($page->has('css', 'span.ezstring-field'));
+        Assertion::assertEquals($this->createdContentName, $page->find('css', 'span.ezstring-field')->getText());
+    }
+
+    /**
+     * @When /^I fill in the folder edit form$/
+     */
+    public function iFillInTheFolderEditForm()
+    {
+        // will only work for single value fields
+        $this->createdContentName = "Behat content edit @" . microtime(true);
+        $this->fillField("ezrepoforms_content_edit_fieldsData_name_value", $this->createdContentName);
+    }
+
+    /**
+     * @Given /^that I have permission to create folders$/
+     */
+    public function thatIHavePermissionToCreateFolders()
+    {
+        $this->visit('/login');
+        $this->fillField('Username', 'admin');
+        $this->fillField('Password', 'publish');
+        $this->pressButton('Login');
     }
 }

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\MinkExtension\Context\MinkContext;
+
+class ContentEdit extends MinkContext implements Context, SnippetAcceptingContext
+{
+    /**
+     * @Then /^I should see a content edit form$/
+     */
+    public function iShouldSeeAContentEditForm()
+    {
+        $this->assertSession()->elementExists('css', 'form[name=ezrepoforms_content_edit]');
+    }
+}

--- a/features/Context/ContentType.php
+++ b/features/Context/ContentType.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ContentType extends RawMinkContext implements Context, SnippetAcceptingContext
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @Given /^there is a Content Type "([^"]*)" with the id "([^"]*)"$/
+     */
+    public function thereIsAContentTypeWithId($contentTypeIdentifier, $id)
+    {
+        try {
+            $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+            Assertion::assertEquals($id, $contentType->id);
+        } catch (NotFoundException $e) {
+            Assertion::fail("No ContentType with the identifier '$contentTypeIdentifier'' could be found.");
+        }
+    }
+}

--- a/lib/View/ContentEdit/ContentEditFormFilter.php
+++ b/lib/View/ContentEdit/ContentEditFormFilter.php
@@ -2,16 +2,19 @@
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\View\ContentEdit\ParameterFilter;
+namespace EzSystems\RepositoryForms\View\ContentEdit;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use EzSystems\RepositoryForms\Data\Mapper\ContentCreateMapper;
 use EzSystems\RepositoryForms\Data\Mapper\ContentUpdateMapper;
 use EzSystems\RepositoryForms\Form\Type\Content\ContentEditType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Adds, if applicable, the ContentEditForm view to the request.
@@ -27,31 +30,43 @@ class ContentEditFormFilter implements EventSubscriberInterface
     /** @var FormFactoryInterface */
     private $formFactory;
 
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
     /**
      * ContentEditFormFilter constructor.
      *
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
      */
     public function __construct(
         ContentService $contentService,
         ContentTypeService $contentTypeService,
+        LocationService $locationService,
         FormFactoryInterface $formFactory
     ) {
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->formFactory = $formFactory;
+        $this->locationService = $locationService;
     }
 
     public static function getSubscribedEvents()
     {
-        return [ViewEvents::FILTER_BUILDER_PARAMETERS => 'addContentEditForm'];
+        return [
+            ViewEvents::FILTER_BUILDER_PARAMETERS => [
+                ['addContentEditForm'],
+                ['addContentEditWithoutDraftForm'],
+            ],
+        ];
     }
 
     public function addContentEditForm(FilterViewBuilderParametersEvent $e)
     {
         $request = $e->getRequest();
+
         if ($request->attributes->get('_controller') !== 'ez_content_edit:editAction') {
             return;
         }
@@ -62,6 +77,7 @@ class ContentEditFormFilter implements EventSubscriberInterface
             $request->attributes->get('version')
         );
         $contentType = $this->contentTypeService->loadContentType($contentDraft->contentInfo->contentTypeId);
+
         $data = (new ContentUpdateMapper())->mapToFormData($contentDraft, [
             'languageCode' => $request->attributes->get('language'),
             'contentType' => $contentType,
@@ -72,5 +88,24 @@ class ContentEditFormFilter implements EventSubscriberInterface
         ]);
 
         $e->getParameters()->add(['form', $form->handleRequest($request)]);
+    }
+
+    public function addContentEditWithoutDraftForm(FilterViewBuilderParametersEvent $e)
+    {
+        $request = $e->getRequest();
+
+        if ($request->attributes->get('_controller') !== 'ez_content_edit:createWithoutDraftAction') {
+            return;
+        }
+
+        $contentType = $this->contentTypeService->loadContentType($request->attributes->get('contentTypeId'));
+        $data = (new ContentCreateMapper())->mapToFormData($contentType, [
+            'mainLanguageCode' => $request->attributes->get('language'),
+            'parentLocation' => $this->locationService->newLocationCreateStruct($request->attributes->get('parentLocationId')),
+        ]);
+        $form = $this->formFactory->create(new ContentEditType(), $data, ['languageCode' => $request->attributes->get('language')]);
+        $form->handleRequest($request);
+
+        $e->getParameters()->add(['form' => $form]);
     }
 }

--- a/lib/View/ContentEdit/ContentEditFormFilter.php
+++ b/lib/View/ContentEdit/ContentEditFormFilter.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View\ContentEdit\ParameterFilter;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
+use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use EzSystems\RepositoryForms\Data\Mapper\ContentUpdateMapper;
+use EzSystems\RepositoryForms\Form\Type\Content\ContentEditType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Adds, if applicable, the ContentEditForm view to the request.
+ */
+class ContentEditFormFilter implements EventSubscriberInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var FormFactoryInterface */
+    private $formFactory;
+
+    /**
+     * ContentEditFormFilter constructor.
+     *
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     */
+    public function __construct(
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        FormFactoryInterface $formFactory
+    ) {
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->formFactory = $formFactory;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [ViewEvents::FILTER_BUILDER_PARAMETERS => 'addContentEditForm'];
+    }
+
+    public function addContentEditForm(FilterViewBuilderParametersEvent $e)
+    {
+        $request = $e->getRequest();
+        if ($request->attributes->get('_controller') !== 'ez_content_edit:editAction') {
+            return;
+        }
+
+        $contentDraft = $this->contentService->loadContent(
+            $request->attributes->get('contentId'),
+            [$request->attributes->get('language')],
+            $request->attributes->get('version')
+        );
+        $contentType = $this->contentTypeService->loadContentType($contentDraft->contentInfo->contentTypeId);
+        $data = (new ContentUpdateMapper())->mapToFormData($contentDraft, [
+            'languageCode' => $request->attributes->get('language'),
+            'contentType' => $contentType,
+        ]);
+        $form = $this->formFactory->create(new ContentEditType(), $data, [
+            'languageCode' => $request->attributes->get('language'),
+            'drafts_enabled' => true,
+        ]);
+
+        $e->getParameters()->add(['form', $form->handleRequest($request)]);
+    }
+}

--- a/lib/View/ContentEdit/ContentEditSuccessView.php
+++ b/lib/View/ContentEdit/ContentEditSuccessView.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View\ContentEdit;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+class ContentEditView extends BaseView implements View/*, FormView */
+{
+    /**
+     * @var \Symfony\Component\Form\FormInterface
+     */
+    private $form;
+
+    /**
+     * @var string
+     */
+    private $language;
+
+    /**
+     * @param mixed $language
+     *
+     * @return ContentEditView
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * @param FormInterface $form
+     *
+     * @return ContentEditView
+     */
+    public function setForm($form)
+    {
+        $this->form = $form;
+
+        return $this;
+    }
+
+    /**
+     * @return FormInterface
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+}

--- a/lib/View/ContentEdit/ContentEditSuccessView.php
+++ b/lib/View/ContentEdit/ContentEditSuccessView.php
@@ -6,10 +6,10 @@ namespace EzSystems\RepositoryForms\View\ContentEdit;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
 
-class ContentEditView extends BaseView implements View/*, FormView */
+class ContentEditSuccessView extends BaseView implements View/*, FormView */
 {
     /**
      * @var \Symfony\Component\Form\FormInterface
@@ -17,36 +17,14 @@ class ContentEditView extends BaseView implements View/*, FormView */
     private $form;
 
     /**
-     * @var string
-     */
-    private $language;
-
-    /**
-     * @param mixed $language
+     * The Form object that was successfully processed.
+     * Could have been a FormInterface, but we use getClickedButton() on the view, and it is not part of the interface.
+     *
+     * @param Form $form A form object.
      *
      * @return ContentEditView
      */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
-
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
-
-    /**
-     * @param FormInterface $form
-     *
-     * @return ContentEditView
-     */
-    public function setForm($form)
+    public function setForm(FormInterface $form)
     {
         $this->form = $form;
 
@@ -54,7 +32,7 @@ class ContentEditView extends BaseView implements View/*, FormView */
     }
 
     /**
-     * @return FormInterface
+     * @return Form
      */
     public function getForm()
     {

--- a/lib/View/ContentEdit/ContentEditView.php
+++ b/lib/View/ContentEdit/ContentEditView.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View\ContentEdit;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\Form\FormView;
+
+class ContentEditView extends BaseView implements View/*, FormView */
+{
+    /**
+     * @var \Symfony\Component\Form\FormView
+     */
+    private $formView;
+
+    /**
+     * @var string
+     */
+    private $language;
+
+    /**
+     * @param FormView $formView
+     *
+     * @return ContentEditView
+     */
+    public function setFormView(FormView $formView)
+    {
+        $this->formView = $formView;
+
+        return $this;
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormView|null
+     */
+    public function getFormView()
+    {
+        return $this->formView;
+    }
+
+    /**
+     * @param mixed $language
+     *
+     * @return ContentEditView
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+}

--- a/lib/View/ContentEdit/ContentEditView.php
+++ b/lib/View/ContentEdit/ContentEditView.php
@@ -5,11 +5,14 @@
 namespace EzSystems\RepositoryForms\View\ContentEdit;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentTypeView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\RepositoryForms\Data\Content\ContentCreateData;
+use EzSystems\RepositoryForms\Data\Content\ContentUpdateData;
 use Symfony\Component\Form\FormView as SymfonyFormView;
 use EzSystems\RepositoryForms\View\FormView as EzFormView;
 
-class ContentEditView extends BaseView implements View, EzFormView
+class ContentEditView extends BaseView implements View, EzFormView, ContentTypeView
 {
     /**
      * @var \Symfony\Component\Form\FormView
@@ -59,5 +62,25 @@ class ContentEditView extends BaseView implements View, EzFormView
     public function getLanguage()
     {
         return $this->language;
+    }
+
+    /**
+     * Returns the contained ContentType id.
+     * @return mixed
+     */
+    public function getContentTypeId()
+    {
+        if (!isset($this->formView->vars['data'])) {
+            // should we throw something ?
+            return null;
+        }
+
+        $data = $this->formView->vars['data'];
+
+        if (!$data instanceof ContentCreateData && !$data instanceof ContentUpdateData) {
+            return null;
+        }
+
+        return $data->contentType->id;
     }
 }

--- a/lib/View/ContentEdit/ContentEditView.php
+++ b/lib/View/ContentEdit/ContentEditView.php
@@ -6,9 +6,10 @@ namespace EzSystems\RepositoryForms\View\ContentEdit;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormView as SymfonyFormView;
+use EzSystems\RepositoryForms\View\FormView as EzFormView;
 
-class ContentEditView extends BaseView implements View/*, FormView */
+class ContentEditView extends BaseView implements View, EzFormView
 {
     /**
      * @var \Symfony\Component\Form\FormView
@@ -21,11 +22,11 @@ class ContentEditView extends BaseView implements View/*, FormView */
     private $language;
 
     /**
-     * @param FormView $formView
+     * @param \Symfony\Component\Form\FormView $formView
      *
-     * @return ContentEditView
+     * @return \EzSystems\RepositoryForms\View\ContentEdit\ContentEditView
      */
-    public function setFormView(FormView $formView)
+    public function setFormView(SymfonyFormView $formView)
     {
         $this->formView = $formView;
 

--- a/lib/View/ContentEdit/ContentEditViewBuilder.php
+++ b/lib/View/ContentEdit/ContentEditViewBuilder.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View\ContentEdit;
+
+use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\Form\FormInterface;
+
+class ContentEditViewBuilder implements ViewBuilder
+{
+    /**
+     * Tests if the builder matches the given argument.
+     *
+     * @param mixed $argument Anything the builder can decide against. Example: a controller's request string.
+     *
+     * @return bool true if the ViewBuilder matches the argument, false otherwise.
+     */
+    public function matches($argument)
+    {
+        return $argument === 'ez_content_edit:editAction';
+    }
+
+    /**
+     * Builds the View based on $parameters.
+     *
+     * @param array $parameters
+     *
+     * @return View An implementation of the View interface
+     */
+    public function buildView(array $parameters)
+    {
+        if (!isset($parameters['form']) || !$parameters['form'] instanceof FormInterface) {
+            throw new \InvalidArgumentException("Missing or invalid 'form' view parameter");
+        }
+
+        /** @var FormInterface $form */
+        $form = $parameters['form'];
+
+        if ($form->isValid()) {
+            // @lolautruche: is there an else ?
+        }
+
+        $view = new ContentEditView();
+        $view->setFormView($form->createView());
+        $view->setLanguage($parameters['language']);
+
+        return $view;
+//        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_create_no_draft.html.twig', [
+//            'form' => $form->createView(),
+//            'languageCode' => $language,
+//        ]);
+    }
+}

--- a/lib/View/ContentEdit/ContentEditViewBuilder.php
+++ b/lib/View/ContentEdit/ContentEditViewBuilder.php
@@ -71,9 +71,5 @@ class ContentEditViewBuilder implements ViewBuilder
         $this->viewParametersInjector->injectViewParameters($view, $parameters);
 
         return $view;
-//        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_create_no_draft.html.twig', [
-//            'form' => $form->createView(),
-//            'languageCode' => $language,
-//        ]);
     }
 }

--- a/lib/View/ContentEdit/FormViewParameterInjector.php
+++ b/lib/View/ContentEdit/FormViewParameterInjector.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View\ContentEdit;
+
+use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent;
+use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use EzSystems\RepositoryForms\View\FormView;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Injects the form property from FormView objects into the view parameters.
+ */
+class FormViewParameterInjector implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [ViewEvents::FILTER_VIEW_PARAMETERS => 'injectForm'];
+    }
+
+    public function injectForm(FilterViewParametersEvent $event)
+    {
+        if (!($view = $event->getView()) instanceof FormView) {
+            return;
+        }
+
+        $event->getParameterBag()->add(['form' => $view->getFormView()]);
+    }
+}

--- a/lib/View/FormView.php
+++ b/lib/View/FormView.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\View;
+
+use Symfony\Component\Form\FormView as SymfonyFormView;
+
+/**
+ * A View of a Sf Form Component FormView object.
+ */
+interface FormView
+{
+    /**
+     * @return \Symfony\Component\Form\FormView|null
+     */
+    public function getFormView();
+
+    /**
+     * @param \Symfony\Component\Form\FormView $formView
+     *
+     * @return FormView
+     */
+    public function setFormView(SymfonyFormView $formView);
+}


### PR DESCRIPTION
> PR against https://github.com/ezsystems/repository-forms/pull/59
> Adds View support for content edit
> Requires https://github.com/ezsystems/ezpublish-kernel/pull/1517

Form data, and the form in general, is processed by the ContentEditForm Filter.

The ViewBuilder will:
- if the forms needs to be (re)displayed, build a ContentEditView object.
  The request then enters the classic view workflow, where the default controller action is empty, and the template is used in the view listener. The controller action/template will be customizable with the matching ViewProvider and MatcherFactory.
- If the form was valid, build a ContentEditSuccessView.
  This view is processed by an actual controller action, that isn't meant to
  be customized. It uses the actionDispatcher, and if the dispatcher returns a response (redirection), use it as the controller's response.

### TODO
- [x] Add the matcher stuff (to customize the view / set custom templates)
- [x] Add semantic config for `content_edit_view`
- [x] See how matchers can work with this (a ContentEditView is not really a ContentView, since it doesn't really contain a Content. How can we make this work ?)
- [ ] Test the workflow with draft