### PR TITLE
Fix EZP-25159: Implement missing limitation mappers Node and Subtree

### DIFF
--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -28,6 +28,9 @@ parameters:
     ezrepoforms.limitation.form_mapper.group.class: EzSystems\RepositoryForms\Limitation\Mapper\GroupLimitationMapper
     ezrepoforms.limitation.form_mapper.parentdepth.class: EzSystems\RepositoryForms\Limitation\Mapper\ParentDepthLimitationMapper
     ezrepoforms.limitation.form_mapper.parentdepth.maxdepth: 20
+    ezrepoforms.limitation.udw.template: "EzSystemsRepositoryFormsBundle:Limitation:udw_limitation_value.html.twig"
+    ezrepoforms.limitation.form_mapper.location.class: EzSystems\RepositoryForms\Limitation\Mapper\LocationLimitationMapper
+    ezrepoforms.limitation.form_mapper.subtree.class: EzSystems\RepositoryForms\Limitation\Mapper\SubtreeLimitationMapper
 
 services:
     # Form types
@@ -177,3 +180,18 @@ services:
         arguments: [%ezrepoforms.limitation.form_mapper.parentdepth.maxdepth%]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentDepth }
+
+    ezrepoforms.limitation.form_mapper.location:
+        class: %ezrepoforms.limitation.form_mapper.location.class%
+        tags:
+            - { name: ez.limitation.formMapper, limitationType: Node }
+        calls:
+            - [setFormTemplate, [%ezrepoforms.limitation.udw.template%]]
+
+    ezrepoforms.limitation.form_mapper.subtree:
+        class: %ezrepoforms.limitation.form_mapper.subtree.class%
+        arguments: [@ezpublish.api.service.location]
+        tags:
+            - { name: ez.limitation.formMapper, limitationType: Subtree }
+        calls:
+            - [setFormTemplate, [%ezrepoforms.limitation.udw.template%]]

--- a/bundle/Resources/translations/ezrepoforms_role.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_role.en.xlf
@@ -94,6 +94,14 @@
                 <source>policy.limitation.group.self</source>
                 <target>Self</target>
             </trans-unit>
+            <trans-unit id="58e363b2a3b22ed976fd14fce49f8ae1">
+                <source>role.policy.limitation.location.udw_title</source>
+                <target>Select a location to use as policy limitation</target>
+            </trans-unit>
+            <trans-unit id="112d31a04edd6a98ec253cc6b9336f75">
+                <source>role.policy.limitation.location.udw_button</source>
+                <target>Select a location</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
+++ b/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
@@ -1,0 +1,14 @@
+{{ form_label(form.limitationValues) }}
+{{ form_errors(form.limitationValues) }}
+{{ form_widget(form.limitationValues) }}
+
+<button data-universaldiscovery-title="{{ "role.policy.limitation.location.udw_title"|trans({}, "ezrepoforms_role") }}"
+        class="ez-button-tree pure-button ez-font-icon ez-button ez-pick-location-limitation-button"
+        data-location-input-selector="#{{form.limitationValues.vars.id}}"
+        data-selected-location-selector="#{{form.limitationValues.vars.id}}-selected-location"
+>{{ "role.policy.limitation.location.udw_button"|trans({}, "ezrepoforms_role") }}</button>
+<div id="{{form.limitationValues.vars.id}}-selected-location">
+    {% if form.limitationValues.vars.value is not empty %}
+        {{ render( controller( "ez_content:view", {'contentId': form.limitationValues.vars.value, 'viewType': '_platformui_content_name'} ) ) }}
+    {% endif %}
+</div>

--- a/lib/Limitation/Mapper/LocationLimitationMapper.php
+++ b/lib/Limitation/Mapper/LocationLimitationMapper.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+class LocationLimitationMapper extends UDWBasedMapper
+{
+    public function filterLimitationValues(Limitation $limitation)
+    {
+        $limitation->limitationValues = [$limitation->limitationValues];
+    }
+}

--- a/lib/Limitation/Mapper/SubtreeLimitationMapper.php
+++ b/lib/Limitation/Mapper/SubtreeLimitationMapper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+class SubtreeLimitationMapper extends UDWBasedMapper
+{
+    /**
+     * @var LocationService
+     */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    public function filterLimitationValues(Limitation $limitation)
+    {
+        // UDW returns a location ID. If we haven't used UDW, the value is as stored: a path string.
+        if (preg_match('/\A\d+\z/', $limitation->limitationValues) === 1) {
+            $limitation->limitationValues = [$this->locationService->loadLocation($limitation->limitationValues)->pathString];
+        } else {
+            $limitation->limitationValues = [$limitation->limitationValues];
+        }
+    }
+}

--- a/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Base class for mappers based on Universal Discovery Widget.
+ */
+abstract class UDWBasedMapper implements LimitationFormMapperInterface
+{
+    /**
+     * Form template to use.
+     *
+     * @var string
+     */
+    private $template;
+
+    public function setFormTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    public function getFormTemplate()
+    {
+        return $this->template;
+    }
+
+    public function mapLimitationForm(FormInterface $form, Limitation $data)
+    {
+        $form->add('limitationValues', 'hidden', [
+            'data' => $data->limitationValues[0],
+            'required' => false,
+            'label' => $data->getIdentifier(),
+        ]);
+    }
+}


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25159
> State: Ready for review
> Also requires https://github.com/ezsystems/PlatformUIBundle/pull/433

Adds the missing, UDW-based limitation mappers, used when editing role policies. Extracted from https://github.com/ezsystems/repository-forms/pull/58

- [x] Node
- [x] Subtree