### PR TITLE
Fix EZP-25159: Implement missing limitation mappers Node and Subtree

### DIFF
--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -28,6 +28,8 @@ parameters:
     ezrepoforms.limitation.form_mapper.group.class: EzSystems\RepositoryForms\Limitation\Mapper\GroupLimitationMapper
     ezrepoforms.limitation.form_mapper.parentdepth.class: EzSystems\RepositoryForms\Limitation\Mapper\ParentDepthLimitationMapper
     ezrepoforms.limitation.form_mapper.parentdepth.maxdepth: 20
+    ezrepoforms.limitation.udw.template: "EzSystemsRepositoryFormsBundle:Limitation:udw_limitation_value.html.twig"
+    ezrepoforms.limitation.form_mapper.subtree.class: EzSystems\RepositoryForms\Limitation\Mapper\SubtreeLimitationMapper
 
 services:
     # Form types
@@ -177,3 +179,20 @@ services:
         arguments: [%ezrepoforms.limitation.form_mapper.parentdepth.maxdepth%]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentDepth }
+
+    ezrepoforms.limitation.form_mapper.udw_based:
+        class: EzSystems\RepositoryForms\Limitation\Mapper\UDWBasedMapper
+        calls:
+            - [setFormTemplate, [%ezrepoforms.limitation.udw.template%]]
+
+    ezrepoforms.limitation.form_mapper.location:
+        parent: ezrepoforms.limitation.form_mapper.udw_based
+        tags:
+            - { name: ez.limitation.formMapper, limitationType: Node }
+
+    ezrepoforms.limitation.form_mapper.subtree:
+        parent: ezrepoforms.limitation.form_mapper.udw_based
+        class: %ezrepoforms.limitation.form_mapper.subtree.class%
+        arguments: [@ezpublish.api.service.location]
+        tags:
+            - { name: ez.limitation.formMapper, limitationType: Subtree }

--- a/bundle/Resources/translations/ezrepoforms_role.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_role.en.xlf
@@ -94,6 +94,14 @@
                 <source>policy.limitation.group.self</source>
                 <target>Self</target>
             </trans-unit>
+            <trans-unit id="58e363b2a3b22ed976fd14fce49f8ae1">
+                <source>role.policy.limitation.location.udw_title</source>
+                <target>Select locations to use as policy limitation</target>
+            </trans-unit>
+            <trans-unit id="112d31a04edd6a98ec253cc6b9336f75">
+                <source>role.policy.limitation.location.udw_button</source>
+                <target>Select locations</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
+++ b/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
@@ -1,0 +1,18 @@
+{{ form_label(form.limitationValues) }}
+{{ form_errors(form.limitationValues) }}
+{{ form_widget(form.limitationValues) }}
+
+<button data-universaldiscovery-title="{{ "role.policy.limitation.location.udw_title"|trans({}, "ezrepoforms_role") }}"
+        class="ez-button-tree pure-button ez-font-icon ez-button ez-pick-location-limitation-button"
+        data-location-input-selector="#{{form.limitationValues.vars.id}}"
+        data-selected-location-list-selector="#{{form.limitationValues.vars.id}}-selected-location"
+>{{ "role.policy.limitation.location.udw_button"|trans({}, "ezrepoforms_role") }}</button>
+<div>
+    <ul id="{{form.limitationValues.vars.id}}-selected-location">
+        {% for limitationValue in form.limitationValues.vars.value %}
+        <li>
+            {{ render( controller( "ez_content:view", {'contentId': limitationValue, 'viewType': '_platformui_content_name'} ) ) }}
+        </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * DataTransformer for UDWBasedMapper.
+ * Needed to display the form field correctly and transform it back to an appropriate value object.
+ */
+class UDWBasedValueTransformer implements DataTransformerInterface
+{
+    public function transform($value)
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        return implode(',', $value);
+    }
+
+    public function reverseTransform($value)
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return explode(',', $value);
+    }
+}

--- a/lib/Limitation/Mapper/SubtreeLimitationMapper.php
+++ b/lib/Limitation/Mapper/SubtreeLimitationMapper.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+class SubtreeLimitationMapper extends UDWBasedMapper
+{
+    /**
+     * @var LocationService
+     */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    public function filterLimitationValues(Limitation $limitation)
+    {
+        if (!is_array($limitation->limitationValues)) {
+            return;
+        }
+
+        // UDW returns an array of location IDs. If we haven't used UDW, the value is as stored: an array of path strings.
+        foreach ($limitation->limitationValues as $key => $limitationValue) {
+            if (preg_match('/\A\d+\z/', $limitationValue) === 1) {
+                $limitation->limitationValues[$key] = $this->locationService->loadLocation($limitationValue)->pathString;
+            }
+        }
+    }
+}

--- a/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueTransformer;
+use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Base class for mappers based on Universal Discovery Widget.
+ */
+class UDWBasedMapper implements LimitationFormMapperInterface
+{
+    /**
+     * Form template to use.
+     *
+     * @var string
+     */
+    private $template;
+
+    public function setFormTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    public function getFormTemplate()
+    {
+        return $this->template;
+    }
+
+    public function mapLimitationForm(FormInterface $form, Limitation $data)
+    {
+        $form->add(
+            // Creating from FormBuilder as we need to add a DataTransformer.
+            $form->getConfig()->getFormFactory()->createBuilder()
+                ->create('limitationValues', 'hidden', [
+                    'required' => false,
+                    'label' => $data->getIdentifier(),
+                ])
+                ->addModelTransformer(new UDWBasedValueTransformer())
+                // Deactivate auto-initialize as we're not on the root form.
+                ->setAutoInitialize(false)->getForm()
+        );
+    }
+
+    public function filterLimitationValues(Limitation $limitation)
+    {
+    }
+}


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25159
> State: Ready for review
> Also requires https://github.com/ezsystems/PlatformUIBundle/pull/433

Adds the missing, UDW-based limitation mappers, used when editing role policies. Extracted from https://github.com/ezsystems/repository-forms/pull/58

- [x] Node
- [x] Subtree
- [x] Multiple selection