### PR TITLE
Fix EZP-25432 In Textline fieldtype, is being permitted the "Minimum length" and "Maximum length" to have negative values

### DIFF
--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -24,11 +24,13 @@ class TextLineFormMapper implements FieldTypeFormMapperInterface
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][minStringLength]',
                 'label' => 'field_definition.ezstring.min_length',
+                'attr' => ['min' => 0],
             ])
             ->add('maxLength', 'integer', [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][maxStringLength]',
                 'label' => 'field_definition.ezstring.max_length',
+                'attr' => ['min' => 0],
             ])
             ->add(
                 // Creating from FormBuilder as we need to add a DataTransformer.


### PR DESCRIPTION
> Part of https://jira.ez.no/browse/EZP-25342
> Related PR https://github.com/ezsystems/ezpublish-kernel/pull/1553

Added a min attribute to the ```input type="number"``` so capable browsers can warn the user if negative value (or ```0```) is entered. 
