### PR TITLE
Primitive user generated content framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,53 @@
 language: php
+sudo: required
 
-php:
-    - 5.5
-    - 5.6
+matrix:
+  # mark as finished before allow_failures are run
+  fast_finish: true
+  include:
+    # 5.5
+    - php: 5.5
+      env: TEST_CONFIG="phpunit.xml.dist"
+    - php: 5.5
+      env: BEHAT_OPTS="--profile=repository-forms"
+     # 5.6
+    - php: 5.6
+      env: TEST_CONFIG="phpunit.xml.dist"
+    - php: 5.6
+      env: BEHAT_OPTS="--profile=repository-forms"
+    # 7.0
+    - php: 7.0
+      env: TEST_CONFIG="phpunit.xml.dist"
+    - php: 7.0
+      env: BEHAT_OPTS="--profile=repository-forms"
 
 # test only master (+ Pull requests)
 branches:
-    only:
-        - master
+  only:
+    - master
 
 before_install:
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
+# setup requirements for running unit/behat tests
 before_script:
-    - composer selfupdate
-    - composer install --prefer-dist
+  # Prepare system
+  - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
+  # Detecting timezone issues by testing on random timezone
+  - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
+  - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
-script: phpunit --coverage-text
+# execute phpunit or behat as the script command
+script:
+  - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform" && php bin/behat -vv $BEHAT_OPTS ; fi
+  - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional ; fi
 
+# disable mail notifications
 notifications:
-    email: false
+  email: false
+
+# reduce depth (history) of git checkout
+git:
+  depth: 30

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -1,0 +1,11 @@
+# This file is meant to be imported from ezplatform's behat.yml.dist.
+# All path are relative to the root ezplatform directory.
+repository-forms:
+    suites:
+        content_edit:
+            paths:
+                - vendor/ezsystems/repository-forms/features/ContentEdit
+            contexts:
+                - EzSystems\RepositoryForms\Features\Context\ContentType:
+                    contentTypeService: @ezpublish.api.service.content_type
+                - EzSystems\RepositoryForms\Features\Context\ContentEdit

--- a/bin/.travis/composer-auth.json
+++ b/bin/.travis/composer-auth.json
@@ -1,0 +1,8 @@
+{
+    "github-oauth": {
+        "github.com": "PLEASE DO NOT USE THIS TOKEN IN YOUR OWN PROJECTS/FORKS",
+        "github.com": "This token is reserved for testing with ezsystems repositories",
+        "github.com": "NB: You create your own token without(!) any scope to use same approach",
+        "github.com": "d0285ed5c8644f30547572ead2ed897431c1fc09"
+    }
+}

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# File for setting up system for behat testing, just like done in DemoBundle's .travis.yml
+
+# Change local git repo to be a full one as we will reuse it for composer install below
+git fetch --unshallow && git checkout -b tmp_travis_branch
+export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR
+export TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
+cd "$HOME/build"
+
+# Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
+git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
+cd ezplatform
+
+# Install everything needed for behat testing, using our local branch of this repo
+./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/repository-forms:dev-tmp_travis_branch as 1.0"

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# File for setting up system for unit/integration testing
+
+# Disable xdebug to speed things up as we don't currently generate coverge on travis
+if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] ; then phpenv config-rm xdebug.ini ; fi
+
+# Update composer to newest version
+# disabled, issues with packagist/github, something..
+composer self-update -v --no-interaction
+
+# Setup github key to avoid api rate limit
+cp bin/.travis/composer-auth.json ~/.composer/auth.json
+
+# Switch to another Symfony version if asked for
+if [ "$SYMFONY_VERSION" != "" ] ; then composer require --no-update symfony/symfony="$SYMFONY_VERSION" ; fi;
+
+# Install packages using composer
+composer install -v --no-progress --no-interaction

--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use EzSystems\RepositoryForms\Data\Mapper\ContentCreateMapper;
+use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
+use EzSystems\RepositoryForms\Form\Type\Content\ContentEditType;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentEditController extends Controller
+{
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var LocationService
+     */
+    private $locationService;
+
+    /**
+     * @var ActionDispatcherInterface
+     */
+    private $contentActionDispatcher;
+
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        ContentService $contentService,
+        LocationService $locationService,
+        ActionDispatcherInterface $contentActionDispatcher
+    ) {
+        $this->contentTypeService = $contentTypeService;
+        $this->locationService = $locationService;
+        $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Displays and processes a content creation form. Showing the form does not create a draft in the repository.
+     *
+     * @param int $contentTypeIdentifier ContentType id to create
+     * @param string $language Language code to create the content in (eng-GB, ger-DE, ...))
+     * @param int $parentLocationId Location the content should be a child of
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function createWithoutDraftAction($contentTypeIdentifier, $language, $parentLocationId, Request $request)
+    {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        $data = (new ContentCreateMapper())->mapToFormData($contentType, [
+            'mainLanguageCode' => $language,
+            'parentLocation' => $this->locationService->newLocationCreateStruct($parentLocationId),
+        ]);
+        $form = $this->createForm(new ContentEditType(), $data, ['languageCode' => $language]);
+        $form->handleRequest($request);
+
+        if ($form->isValid()) {
+            $this->contentActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
+            if ($response = $this->contentActionDispatcher->getResponse()) {
+                return $response;
+            }
+        }
+
+        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
+            'form' => $form->createView(),
+            'languageCode' => $language,
+        ]);
+    }
+}

--- a/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to register FieldType form mappers in the mapper dispatcher.
+ */
+class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezrepoforms.field_type_form_mapper.dispatcher')) {
+            return;
+        }
+
+        $dispatcherDefinition = $container->findDefinition('ezrepoforms.field_type_form_mapper.dispatcher');
+
+        foreach ($container->findTaggedServiceIds('ez.fieldType.formMapper') as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['fieldType'])) {
+                    throw new LogicException(
+                        'ez.fieldType.formMapper service tag needs a "fieldType" attribute to identify which field type the mapper is for. None given.'
+                    );
+                }
+
+                $dispatcherDefinition->addMethodCall('addMapper', [new Reference($id), $attribute['fieldType']]);
+            }
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -10,6 +10,7 @@
  */
 namespace EzSystems\RepositoryFormsBundle;
 
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,6 +22,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new FieldTypeFormMapperPass());
+        $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
     }
 }

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+ez_content_create_no_draft:
+    path: /content/create/nodraft/{contentTypeIdentifier}/{language}/{parentLocationId}
+    defaults:
+        _controller: ez_content_edit:createWithoutDraftAction

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -43,6 +43,8 @@ parameters:
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
     ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
 
+    ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
+
 services:
     # deprecated in 1.1, will be removed in 2.0
     ezrepoforms.field_type_form_mapper.registry:
@@ -232,3 +234,16 @@ services:
         arguments: [@ezpublish.api.service.content_type]
         tags:
             - { name: kernel.event_subscriber }
+
+    # Controllers
+    ezrepoforms.controller.content_edit:
+        class: %ezrepoforms.controller.content_edit.class%
+        arguments:
+            - @ezpublish.api.service.content_type
+            - @ezpublish.api.service.content
+            - @ezpublish.api.service.location
+            - @ezrepoforms.action_dispatcher.content
+        parent: ezpublish.controller.base
+
+    ez_content_edit:
+        alias: ezrepoforms.controller.content_edit

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -41,6 +41,7 @@ parameters:
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
 
 services:
+    # deprecated in 1.1, will be removed in 2.0
     ezrepoforms.field_type_form_mapper.registry:
         class: %ezrepoforms.field_type_form_mapper.registry.class%
 
@@ -134,11 +135,15 @@ services:
         class: %ezrepoforms.field_type.form_mapper.ezstring.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezstring }
+        arguments:
+            - @ezpublish.api.service.field_type
 
     ezrepoforms.field_type.form_mapper.eztext:
         class: %ezrepoforms.field_type.form_mapper.eztext.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: eztext }
+        arguments:
+            - @ezpublish.api.service.field_type
 
     ezrepoforms.field_type.form_mapper.eztime:
         class: %ezrepoforms.field_type.form_mapper.eztime.class%

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -5,6 +5,7 @@ imports:
 
 parameters:
     ezrepoforms.field_type_form_mapper.registry.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry
+    ezrepoforms.field_type_form_mapper.dispatcher.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcher
     ezrepoforms.content_type.update.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeUpdateType
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
     ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
@@ -50,6 +51,9 @@ services:
     ezrepoforms.field_type_form_mapper.registry:
         class: %ezrepoforms.field_type_form_mapper.registry.class%
 
+    ezrepoforms.field_type_form_mapper.dispatcher:
+        class: %ezrepoforms.field_type_form_mapper.dispatcher.class%
+
     ezrepoforms.content_type.update.form_type:
         class: %ezrepoforms.content_type.update.form_type.class%
         arguments: [@ezpublish.field_type_collection.factory, @translator]
@@ -64,7 +68,7 @@ services:
 
     ezrepoforms.field.form_type:
         class: %ezrepoforms.field.form_type.class%
-        arguments: [@ezrepoforms.field_type_form_mapper.registry]
+        arguments: [@ezrepoforms.field_type_form_mapper.dispatcher]
         tags:
             - { name: form.type, alias: ezrepoforms_content_field }
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -41,6 +41,7 @@ parameters:
     ezrepoforms.form_processor.content_type.options:
         redirectRouteAfterPublish: %ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
+    ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
 
 services:
     # deprecated in 1.1, will be removed in 2.0
@@ -217,6 +218,12 @@ services:
     ezrepoforms.form_processor.content_type:
         class: %ezrepoforms.form_processor.content_type.class%
         arguments: [@ezpublish.api.service.content_type, @router, %ezrepoforms.form_processor.content_type.options%]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.form_processor.content:
+        class: %ezrepoforms.form_processor.content.class%
+        arguments: [@ezpublish.api.service.content, @router]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
     ezrepoforms.field_type_form_mapper.registry.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry
     ezrepoforms.content_type.update.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeUpdateType
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
+    ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
 
     ezrepoforms.field_type.form_mapper.ezbinaryfile.class: EzSystems\RepositoryForms\FieldType\Mapper\BinaryFileFormMapper
     ezrepoforms.field_type.form_mapper.ezcountry.class: EzSystems\RepositoryForms\FieldType\Mapper\CountryFormMapper
@@ -56,6 +57,12 @@ services:
         arguments: [@ezrepoforms.field_type_form_mapper.registry, @ezpublish.api.service.field_type]
         tags:
             - { name: form.type, alias: ezrepoforms_fielddefinition_update }
+
+    ezrepoforms.field.form_type:
+        class: %ezrepoforms.field.form_type.class%
+        arguments: [@ezrepoforms.field_type_form_mapper.registry]
+        tags:
+            - { name: form.type, alias: ezrepoforms_content_field }
 
     # FieldType form mappers
     ezrepoforms.field_type.form_mapper.ezbinaryfile:

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -35,6 +35,7 @@ parameters:
     ezrepoforms.twig.field_edit_rendering_extension.class: EzSystems\RepositoryForms\Twig\FieldEditRenderingExtension
     ezrepoforms.action_dispatcher.content_type.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeDispatcher
     ezrepoforms.action_dispatcher.content_type.group.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeGroupDispatcher
+    ezrepoforms.action_dispatcher.content.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentDispatcher
     ezrepoforms.form_processor.content_type.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeFormProcessor
     ezrepoforms.form_processor.content_type.options.redirect_route_after_publish: ~
     ezrepoforms.form_processor.content_type.options:
@@ -199,6 +200,10 @@ services:
         abstract: true
         calls:
             - [setEventDispatcher, [@event_dispatcher]]
+
+    ezrepoforms.action_dispatcher.content:
+        class: %ezrepoforms.action_dispatcher.content.class%
+        parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.action_dispatcher.content_type:
         class: %ezrepoforms.action_dispatcher.content_type.class%

--- a/bundle/Resources/translations/ezrepoforms_content.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content.en.xlf
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="eb732abfbae397aca2742d95e9d0be74">
+                <source>content.create_button</source>
+                <target>Create</target>
+            </trans-unit>
+            <trans-unit id="feebb073e498ff5b9166f640554eeb60">
+                <source>content.edit_button</source>
+                <target>Edit</target>
+            </trans-unit>
+            <trans-unit id="f51270da268bd8eda1a5d49f51cf93f6">
+                <source>content.publish_button</source>
+                <target>Publish</target>
+            </trans-unit>
+            <trans-unit id="39a661284481408be917e7c121e7ab1d">
+                <source>content.save_button</source>
+                <target>Save draft</target>
+            </trans-unit>
+            <trans-unit id="6a0d486e8aa479d2af5f67112f464e20">
+                <source>content.cancel_button</source>
+                <target>Cancel</target>
+            </trans-unit>
+            <trans-unit id="e93fea1c0536d108e24b150ac03c2677">
+                <source>content.field.non_editable</source>
+                <target>This field is not editable.</target>
+            </trans-unit>
+            
+            <!-- FieldTypes -->
+            <trans-unit id="7b0583136e2275a809b31ae90a455e59">
+                <source>content.field_type.ezuser.username</source>
+                <target>Username:</target>
+            </trans-unit>
+            <trans-unit id="8acd3d9a24e181ea0e82ad298422fdc7">
+                <source>content.field_type.ezuser.password</source>
+                <target>Password:</target>
+            </trans-unit>
+            <trans-unit id="fd2c89db5fdb5a32b85b4813a80f0c35">
+                <source>content.field_type.ezuser.password_confirm</source>
+                <target>Confirm password:</target>
+            </trans-unit>
+            <trans-unit id="94f3c48fbdb6323962103bebf6575c30">
+                <source>content.field_type.ezuser.email</source>
+                <target>E-mail:</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/bundle/Resources/views/Content/content_edit.html.twig
+++ b/bundle/Resources/views/Content/content_edit.html.twig
@@ -1,0 +1,5 @@
+{% import "EzSystemsRepositoryFormsBundle:Content:content_form.html.twig" as contentForms %}
+
+<section class="ez-content-edit">
+    {{ contentForms.display_form(form) }}
+</section>

--- a/bundle/Resources/views/Content/content_form.html.twig
+++ b/bundle/Resources/views/Content/content_form.html.twig
@@ -1,0 +1,23 @@
+{% macro display_form(form) %}
+    {{ form_start(form) }}
+
+    {% for fieldForm in form.fieldsData %}
+        <div class="{{ fieldForm.vars.data.fieldDefinition.fieldTypeIdentifier }}-field field-edit">
+            <fieldset>
+                <legend>{{- form_label(fieldForm) -}}</legend>
+                {{- form_errors(fieldForm) -}}
+                {%- if fieldForm.value is defined -%}
+                    {{ form_errors(fieldForm.value) }}
+                    {{ form_widget(fieldForm.value, {"contentData": form.vars.data}) }}
+                {%- else -%}
+                    <p class="non-editable">
+                        {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
+                    </p>
+                    {%- do fieldForm.setRendered() -%}
+                {% endif %}
+            </fieldset>
+        </div>
+    {% endfor %}
+
+    {{ form_end(form) }}
+{% endmacro %}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/validator": "~2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "~4.7",
+        "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,16 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*"
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7",
+        "behat/behat": "^3.0"
     },
     "autoload": {
         "psr-4": {
             "EzSystems\\RepositoryFormsBundle\\": "bundle",
             "EzSystems\\RepositoryForms\\": "lib",
             "EzSystems\\RepositoryForms\\Tests\\": "tests/RepositoryForms",
-            "EzSystems\\RepositoryFormsBundle\\Tests\\": "tests/RepositoryFormsBundle"
+            "EzSystems\\RepositoryFormsBundle\\Tests\\": "tests/RepositoryFormsBundle",
+            "EzSystems\\RepositoryForms\\Features\\": "features"
         }
     },
     "extra": {

--- a/doc/changes-1.1.md
+++ b/doc/changes-1.1.md
@@ -1,0 +1,4 @@
+# Changes in version 1.1
+
+## Deprecations
+- `FieldTypeFormMapperInterface` is deprecated, and replaced by `FieldDefinitionFormMapperInterface`

--- a/doc/changes-1.1.md
+++ b/doc/changes-1.1.md
@@ -2,3 +2,10 @@
 
 ## Deprecations
 - `FieldTypeFormMapperInterface` is deprecated, and replaced by `FieldDefinitionFormMapperInterface`
+- The FieldType form mapper registry, associated services, classes and interfaces are deprecated, and will be removed
+  in 2.0:
+    - `ezrepoforms.field_type_form_mapper.registry` service
+    - `EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry` class
+    - `EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface` interface
+    - `EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass` compiler pass
+  The new `ezrepoforms.field_type_form_mapper.registry` should be used instead.

--- a/features/ContentEdit/create_without_draft.feature
+++ b/features/ContentEdit/create_without_draft.feature
@@ -1,0 +1,14 @@
+Feature: Edit content
+    In order to allow users to create content
+    As a project owner
+    I need to expose a form that creates a content item without using a draft.
+
+Scenario: Create a folder without a draft
+    Given that I have permission to create folders
+      And there is a Content Type "folder" with the id "1"
+      #And there is a Location with the id "2"
+     When I go to "content/create/nodraft/folder/eng-GB/2"
+     Then I should see a folder content edit form
+     When I fill in the folder edit form
+      And I press "Publish"
+     Then I am on the View of the Content that was published

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\MinkContext;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ContentEdit extends MinkContext implements Context, SnippetAcceptingContext
+{
+    /**
+     * Name of the content that was created using the edit form. Used to validate that the content was created.
+     * @var string
+     */
+    private $createdContentName;
+
+    /**
+     * @Then /^I should see a folder content edit form$/
+     * @Then /^I should see a content edit form$/
+     */
+    public function iShouldSeeAContentEditForm()
+    {
+        $this->assertSession()->elementExists('css', 'form[name=ezrepoforms_content_edit]');
+    }
+
+    /**
+     * @Then /^I am on the View of the Content that was published$/
+     */
+    public function iAmOnTheViewOfTheContentThatWasPublished()
+    {
+        if (!isset($this->createdContentName)) {
+            throw new \Exception('No created content name set');
+        }
+
+        $page = $this->getSession()->getPage();
+        Assertion::assertTrue($page->has('css', 'span.ezstring-field'));
+        Assertion::assertEquals($this->createdContentName, $page->find('css', 'span.ezstring-field')->getText());
+    }
+
+    /**
+     * @When /^I fill in the folder edit form$/
+     */
+    public function iFillInTheFolderEditForm()
+    {
+        // will only work for single value fields
+        $this->createdContentName = 'Behat content edit @' . microtime(true);
+        $this->fillField('ezrepoforms_content_edit_fieldsData_name_value', $this->createdContentName);
+    }
+
+    /**
+     * @Given /^that I have permission to create folders$/
+     */
+    public function thatIHavePermissionToCreateFolders()
+    {
+        $this->visit('/login');
+        $this->fillField('Username', 'admin');
+        $this->fillField('Password', 'publish');
+        $this->pressButton('Login');
+    }
+}

--- a/features/Context/ContentType.php
+++ b/features/Context/ContentType.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ContentType extends RawMinkContext implements Context, SnippetAcceptingContext
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @Given /^there is a Content Type "([^"]*)" with the id "([^"]*)"$/
+     */
+    public function thereIsAContentTypeWithId($contentTypeIdentifier, $id)
+    {
+        try {
+            $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+            Assertion::assertEquals($id, $contentType->id);
+        } catch (NotFoundException $e) {
+            Assertion::fail("No ContentType with the identifier '$contentTypeIdentifier' could be found.");
+        }
+    }
+}

--- a/lib/Data/Content/ContentCreateData.php
+++ b/lib/Data/Content/ContentCreateData.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Content;
+
+use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+use EzSystems\RepositoryForms\Data\NewnessCheckable;
+
+/**
+ * @property-read \EzSystems\RepositoryForms\Data\Content\FieldData[] $fieldsData
+ */
+class ContentCreateData extends ContentCreateStruct implements NewnessCheckable
+{
+    use ContentData;
+
+    /**
+     * @var LocationCreateStruct[]
+     */
+    private $locationStructs;
+
+    public function isNew()
+    {
+        return true;
+    }
+
+    /**
+     * @return LocationCreateStruct[]
+     */
+    public function getLocationStructs()
+    {
+        return $this->locationStructs;
+    }
+
+    /**
+     * Adds a location struct.
+     * A location will be created out of it, bound to the created content.
+     *
+     * @param LocationCreateStruct $locationStruct
+     */
+    public function addLocationStruct(LocationCreateStruct $locationStruct)
+    {
+        $this->locationStructs[] = $locationStruct;
+    }
+}

--- a/lib/Data/Content/ContentData.php
+++ b/lib/Data/Content/ContentData.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Content;
+
+trait ContentData
+{
+    /**
+     * @var \EzSystems\RepositoryForms\Data\Content\FieldData[]
+     */
+    protected $fieldsData;
+
+    public function addFieldData(FieldData $fieldData)
+    {
+        $this->fieldsData[$fieldData->fieldDefinition->identifier] = $fieldData;
+    }
+}

--- a/lib/Data/Content/FieldData.php
+++ b/lib/Data/Content/FieldData.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the eZ Repository Forms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * @property-read \eZ\Publish\API\Repository\Values\Content\Field $field
+ * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+ */
+class FieldData extends ValueObject
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Field
+     */
+    protected $field;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
+     */
+    protected $fieldDefinition;
+
+    /**
+     * @var mixed
+     */
+    public $value;
+}

--- a/lib/Data/Content/FieldData.php
+++ b/lib/Data/Content/FieldData.php
@@ -30,4 +30,9 @@ class FieldData extends ValueObject
      * @var mixed
      */
     public $value;
+
+    public function getFieldTypeIdentifier()
+    {
+        return $this->fieldDefinition->fieldTypeIdentifier;
+    }
 }

--- a/lib/Data/Mapper/ContentCreateMapper.php
+++ b/lib/Data/Mapper/ContentCreateMapper.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use EzSystems\RepositoryForms\Data\Content\ContentCreateData;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form data mapper for content create without a draft.
+ */
+class ContentCreateMapper implements FormDataMapperInterface
+{
+    /**
+     * Maps a ValueObject from eZ content repository to a data usable as underlying form data (e.g. create/update struct).
+     *
+     * @param ValueObject|\eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     * @param array $params
+     *
+     * @return ContentCreateData
+     */
+    public function mapToFormData(ValueObject $contentType, array $params = [])
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $params = $resolver->resolve($params);
+
+        $data = new ContentCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
+        $data->addLocationStruct($params['parentLocation']);
+        foreach ($contentType->fieldDefinitions as $fieldDef) {
+            $data->addFieldData(new FieldData([
+                'fieldDefinition' => $fieldDef,
+                'field' => new Field([
+                    'fieldDefIdentifier' => $fieldDef->identifier,
+                    'languageCode' => $params['mainLanguageCode'],
+                ]),
+                'value' => $fieldDef->defaultValue,
+            ]));
+        }
+
+        return $data;
+    }
+
+    private function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver
+            ->setRequired(['mainLanguageCode', 'parentLocation'])
+            ->setAllowedTypes('parentLocation', '\eZ\Publish\API\Repository\Values\Content\LocationCreateStruct');
+    }
+}

--- a/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/lib/Data/Mapper/ContentUpdateMapper.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use EzSystems\RepositoryForms\Data\Content\ContentUpdateData;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentUpdateMapper implements FormDataMapperInterface
+{
+    /**
+     * Maps a ValueObject from eZ content repository to a data usable as underlying form data (e.g. create/update struct).
+     *
+     * @param ValueObject|\eZ\Publish\API\Repository\Values\Content\Content $contentDraft
+     * @param array $params
+     *
+     * @return ContentUpdateData
+     */
+    public function mapToFormData(ValueObject $contentDraft, array $params = [])
+    {
+        $optionsResolver = new OptionsResolver();
+        $this->configureOptions($optionsResolver);
+        $params = $optionsResolver->resolve($params);
+
+        $data = new ContentUpdateData(['contentDraft' => $contentDraft, 'contentType' => $params['contentType']]);
+        $fields = $contentDraft->getFieldsByLanguage($params['languageCode']);
+        foreach ($params['contentType']->fieldDefinitions as $fieldDef) {
+            $field = $fields[$fieldDef->identifier];
+            $data->addFieldData(new FieldData([
+                'fieldDefinition' => $fieldDef,
+                'field' => $field,
+                'value' => $field->value,
+            ]));
+        }
+
+        return $data;
+    }
+
+    private function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver
+            ->setRequired(['languageCode', 'contentType'])
+            ->setAllowedTypes('contentType', '\eZ\Publish\API\Repository\Values\ContentType\ContentType');
+    }
+}

--- a/lib/Event/RepositoryFormEvents.php
+++ b/lib/Event/RepositoryFormEvents.php
@@ -43,6 +43,26 @@ final class RepositoryFormEvents
     const CONTENT_TYPE_GROUP_UPDATE = 'contentType.group.update';
 
     /**
+     * Base name for Content edit processing events.
+     */
+    const CONTENT_EDIT = 'content.edit';
+
+    /**
+     * Triggered when saving a content draft.
+     */
+    const CONTENT_SAVE_DRAFT = 'content.edit.saveDraft';
+
+    /**
+     * Triggered when publishing a content.
+     */
+    const CONTENT_PUBLISH = 'content.edit.publish';
+
+    /**
+     * Triggered when canceling a content edition.
+     */
+    const CONTENT_CANCEL = 'content.edit.cancel';
+
+    /**
      * Base name for Role update processing events.
      */
     const ROLE_UPDATE = 'role.update';

--- a/lib/FieldType/DataTransformer/FieldValueTransformer.php
+++ b/lib/FieldType/DataTransformer/FieldValueTransformer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
+
+use eZ\Publish\API\Repository\FieldType;
+use eZ\Publish\SPI\FieldType\Value;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * Generic data transformer for FieldTypes values.
+ * Uses FieldType::toHash() / FieldType::fromHash().
+ */
+class FieldValueTransformer implements DataTransformerInterface
+{
+    /**
+     * @var FieldType
+     */
+    private $fieldType;
+
+    public function __construct(FieldType $fieldType)
+    {
+        $this->fieldType = $fieldType;
+    }
+
+    /**
+     * Transforms a FieldType Value into a hash using `FieldTpe::toHash()`.
+     * This hash is compatible with `reverseTransform()`.
+     *
+     * @param \eZ\Publish\SPI\FieldType\Value $value
+     *
+     * @return array|null the value's hash, or null if $value was not a FieldType Value
+     */
+    public function transform($value)
+    {
+        if (!$value instanceof Value) {
+            return null;
+        }
+
+        return $this->fieldType->toHash($value);
+    }
+
+    /**
+     * Transforms a hash into a FieldType Value using `FieldType::fromHash()`.
+     * The FieldValue is compatible with `transform()`.
+     *
+     * @param array $value
+     *
+     * @return \eZ\Publish\SPI\FieldType\Value
+     */
+    public function reverseTransform($value)
+    {
+        if (!$value) {
+            return $this->fieldType->getEmptyValue();
+        }
+
+        return $this->fieldType->fromHash($value);
+    }
+}

--- a/lib/FieldType/FieldDefinitionFormMapperInterface.php
+++ b/lib/FieldType/FieldDefinitionFormMapperInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * A field definition mapper maps FieldDefinition to a FieldDefinitionForm.
+ *
+ * Each FieldType will implement its own, depending on the form elements it takes to configure a FieldDefinition.
+ */
+interface FieldDefinitionFormMapperInterface extends FieldFormMapperInterface
+{
+    /**
+     * "Maps" FieldDefinition form to current FieldType.
+     * Gives the opportunity to enrich $fieldDefinitionForm with custom fields for:
+     * - validator configuration,
+     * - field settings
+     * - default value.
+     *
+     * @param FormInterface $fieldDefinitionForm Form for current FieldDefinition.
+     * @param FieldDefinitionData $data Underlying data for current FieldDefinition form.
+     */
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data);
+}

--- a/lib/FieldType/FieldFormMapperInterface.php
+++ b/lib/FieldType/FieldFormMapperInterface.php
@@ -11,12 +11,8 @@
 namespace EzSystems\RepositoryForms\FieldType;
 
 /**
- * Interface for FieldType form mappers.
- *
- * It maps a FieldType's specifics to editing Forms (e.g. FieldDefinition forms).
- *
- * @deprecated since 1.1, will be removed in 2.0. Use FieldDefinitionFormMapperInterface instead.
+ * Common interface for field mappers (definition, value...).
  */
-interface FieldTypeFormMapperInterface extends FieldDefinitionFormMapperInterface
+interface FieldFormMapperInterface
 {
 }

--- a/lib/FieldType/FieldTypeFormMapperDispatcher.php
+++ b/lib/FieldType/FieldTypeFormMapperDispatcher.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType;
+
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Form\FormInterface;
+use InvalidArgumentException;
+
+/**
+ * FieldType mappers dispatcher.
+ *
+ * Adds the form elements matching the given Field Data (Value or Definition) to a given Form.
+ */
+class FieldTypeFormMapperDispatcher implements FieldTypeFormMapperDispatcherInterface
+{
+    /**
+     * FieldType form mappers, indexed by FieldType identifier.
+     *
+     * @var FieldTypeFormMapperInterface[]
+     */
+    private $mappers = [];
+
+    public function addMapper(FieldFormMapperInterface $mapper, $fieldTypeIdentifier)
+    {
+        if ($mapper instanceof FieldTypeFormMapperInterface) {
+            @trigger_error(
+                'The FieldTypeFormMapperInterface interface is deprecated in ezsystems/repository-forms 1.1, ' .
+                "and will be removed in version 2.0\n" .
+                'Use FieldValueFormMapperInterface and FieldDefinitionFormMapperInterface instead',
+                E_USER_DEPRECATED
+            );
+        } elseif (!$mapper instanceof FieldValueFormMapperInterface && !$mapper instanceof FieldDefinitionFormMapperInterface) {
+            throw new \InvalidArgumentException('Expecting a FieldValueFormMapperInterface or FieldDefinitionFormMapperInterface');
+        }
+
+        $this->mappers[$fieldTypeIdentifier] = $mapper;
+    }
+
+    public function map(FormInterface $fieldForm, $data)
+    {
+        if (!$data instanceof FieldDefinitionData && !$data instanceof FieldData) {
+            throw new InvalidArgumentException('Invalid data object, valid types are FieldData and FieldDefinitionData');
+        }
+
+        $fieldTypeIdentifier = $data->getFieldTypeIdentifier();
+        if (!isset($this->mappers[$fieldTypeIdentifier])) {
+            return;
+        }
+
+        if ($data instanceof FieldDefinitionData) {
+            if ($this->mappers[$fieldTypeIdentifier] instanceof FieldDefinitionFormMapperInterface) {
+                $this->mappers[$fieldTypeIdentifier]->mapFieldDefinitionForm($fieldForm, $data);
+            }
+
+            return;
+        }
+
+        if ($data instanceof FieldData) {
+            if ($this->mappers[$fieldTypeIdentifier] instanceof FieldValueFormMapperInterface) {
+                $this->mappers[$fieldTypeIdentifier]->mapFieldValueForm($fieldForm, $data);
+            }
+
+            return;
+        }
+    }
+}

--- a/lib/FieldType/FieldTypeFormMapperDispatcherInterface.php
+++ b/lib/FieldType/FieldTypeFormMapperDispatcherInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\FieldType;
+
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * FieldType mappers dispatcher. Maps Field (definition, value) data to a Form using the appropriate mapper.
+ */
+interface FieldTypeFormMapperDispatcherInterface
+{
+    /**
+     * Adds a new Field mapper for a fieldtype identifier.
+     *
+     * @param \EzSystems\RepositoryForms\FieldType\FieldFormMapperInterface
+     * @param string $fieldTypeIdentifier FieldType identifier this mapper is for.
+     *
+     * @return mixed
+     */
+    public function addMapper(FieldFormMapperInterface $mapper, $fieldTypeIdentifier);
+
+    /**
+     * Maps, if a mapper is available for the fieldtype, $data to $form.
+     *
+     * @param \Symfony\Component\Form\FormInterface $form
+     * @param FieldDefinitionData|FieldData $data
+     *
+     * @return self
+     *
+     * @throws \InvalidArgumentException If $data is not a FieldData or FieldDefinitionData
+     */
+    public function map(FormInterface $form, $data);
+}

--- a/lib/FieldType/FieldTypeFormMapperRegistry.php
+++ b/lib/FieldType/FieldTypeFormMapperRegistry.php
@@ -16,6 +16,8 @@ use InvalidArgumentException;
 
 /**
  * Registry for FieldType form mappers.
+ *
+ * @deprecated Deprecated since version 1.1, will be removed in version 2.0. Use the FieldTypeFormMapperDispatcher.
  */
 class FieldTypeFormMapperRegistry implements FieldTypeFormMapperRegistryInterface
 {

--- a/lib/FieldType/FieldTypeFormMapperRegistryInterface.php
+++ b/lib/FieldType/FieldTypeFormMapperRegistryInterface.php
@@ -12,6 +12,8 @@ namespace EzSystems\RepositoryForms\FieldType;
 
 /**
  * Interface for FieldType form mappers registry.
+ *
+ * @deprecated Deprecated since version 1.1, will be removed in version 2.0. Use the FieldTypeFormMapperDispatcher.
  */
 interface FieldTypeFormMapperRegistryInterface
 {

--- a/lib/FieldType/FieldValueFormMapperInterface.php
+++ b/lib/FieldType/FieldValueFormMapperInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\FieldType;
+
+use Symfony\Component\Form\FormInterface;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+
+interface FieldValueFormMapperInterface extends FieldFormMapperInterface
+{
+    /**
+     * "Maps" Field form to current FieldType.
+     * Allows to add form fields for content edition.
+     *
+     * @param FormInterface $fieldForm Form for the current Field.
+     * @param FieldData $data Underlying data for current Field form.
+     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data);
+}

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -10,12 +10,26 @@
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
+use eZ\Publish\API\Repository\FieldTypeService;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class TextBlockFormMapper implements FieldTypeFormMapperInterface
+class TextBlockFormMapper implements FieldTypeFormMapperInterface, FieldValueFormMapperInterface
 {
+    /**
+     * @var \eZ\Publish\API\Repository\FieldTypeService
+     */
+    private $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
@@ -25,6 +39,31 @@ class TextBlockFormMapper implements FieldTypeFormMapperInterface
                     'property_path' => 'fieldSettings[textRows]',
                     'label' => 'field_definition.eztext.text_rows',
                 ]
+            );
+    }
+
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($fieldDefinition->getNames());
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        'text',
+                        [
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $label,
+                            'attr' => ['rows' => $data->fieldDefinition->fieldSettings['textRows']],
+                        ]
+                    )
+                    ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition)))
+                    // Deactivate auto-initialize as we're not on the root form.
+                    ->setAutoInitialize(false)
+                    ->getForm()
             );
     }
 }

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -10,13 +10,27 @@
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
+use eZ\Publish\API\Repository\FieldTypeService;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\TextLineValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class TextLineFormMapper implements FieldTypeFormMapperInterface
+class TextLineFormMapper implements FieldTypeFormMapperInterface, FieldValueFormMapperInterface
 {
+    /**
+     * @var \eZ\Publish\API\Repository\FieldTypeService
+     */
+    private $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
@@ -42,6 +56,34 @@ class TextLineFormMapper implements FieldTypeFormMapperInterface
                     ->addModelTransformer(new TextLineValueTransformer())
                     // Deactivate auto-initialize as we're not on the root form.
                     ->setAutoInitialize(false)->getForm()
+            );
+    }
+
+    /**
+     * "Maps" Field form to current FieldType.
+     * Allows to add form fields for content edition.
+     *
+     * @param FormInterface $fieldForm Form for the current Field.
+     * @param FieldData $data Underlying data for current Field form.
+     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($fieldDefinition->getNames());
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        'text',
+                        ['required' => $fieldDefinition->isRequired, 'label' => $label]
+                    )
+                    ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))
+                    // Deactivate auto-initialize as we're not on the root form.
+                    ->setAutoInitialize(false)
+                    ->getForm()
             );
     }
 }

--- a/lib/Form/ActionDispatcher/ContentDispatcher.php
+++ b/lib/Form/ActionDispatcher/ContentDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
+
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentDispatcher extends AbstractActionDispatcher
+{
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+    }
+
+    protected function getActionEventBaseName()
+    {
+        return RepositoryFormEvents::CONTENT_EDIT;
+    }
+}

--- a/lib/Form/Processor/ContentFormProcessor.php
+++ b/lib/Form/Processor/ContentFormProcessor.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Processor;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentStruct;
+use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Listens for and processes RepositoryForm events: publish, remove draft, save draft...
+ */
+class ContentFormProcessor implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    public function __construct(ContentService $contentService, RouterInterface $router)
+    {
+        $this->contentService = $contentService;
+        $this->router = $router;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::CONTENT_PUBLISH => ['processPublish', 10],
+            RepositoryFormEvents::CONTENT_CANCEL => ['processRemoveDraft', 10],
+            RepositoryFormEvents::CONTENT_SAVE_DRAFT => ['processSaveDraft', 10],
+        ];
+    }
+
+    public function processSaveDraft(FormActionEvent $event)
+    {
+        /** @var \EzSystems\RepositoryForms\Data\Content\ContentCreateData|\EzSystems\RepositoryForms\Data\Content\ContentUpdateData $data */
+        $data = $event->getData();
+        $form = $event->getForm();
+
+        $formConfig = $form->getConfig();
+        $languageCode = $formConfig->getOption('languageCode');
+        $draft = $this->saveDraft($data, $languageCode);
+
+        $defaultUrl = $this->router->generate('ez_content_edit', [
+            'contentId' => $draft->id,
+            'version' => $draft->getVersionInfo()->versionNo,
+            'language' => $languageCode,
+        ]);
+        $event->setResponse(new RedirectResponse($formConfig->getAction() ?: $defaultUrl));
+    }
+
+    public function processPublish(FormActionEvent $event)
+    {
+        /** @var \EzSystems\RepositoryForms\Data\Content\ContentCreateData|\EzSystems\RepositoryForms\Data\Content\ContentUpdateData $data */
+        $data = $event->getData();
+        $form = $event->getForm();
+
+        $draft = $this->saveDraft($data, $form->getConfig()->getOption('languageCode'));
+        $content = $this->contentService->publishVersion($draft->versionInfo);
+
+        // Redirect to the provided URL. Defaults to URLAlias of the published content.
+        $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->router->generate(
+            UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            ['contentId' => $content->id],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+        $event->setResponse(new RedirectResponse($redirectUrl));
+    }
+
+    public function processRemoveDraft(FormActionEvent $event)
+    {
+        /** @var \EzSystems\RepositoryForms\Data\Content\ContentCreateData|\EzSystems\RepositoryForms\Data\Content\ContentUpdateData $data */
+        $data = $event->getData();
+        $form = $event->getForm();
+
+        if ($data->isNew()) {
+            return;
+        }
+
+        $this->contentService->deleteVersion($data->contentDraft->getVersionInfo());
+        $url = $this->router->generate(
+            UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            ['contentId' => $data->contentDraft->id],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+        $event->setResponse(new RedirectResponse($url));
+    }
+
+    /**
+     * Saves content draft corresponding to $data.
+     * Depending on the nature of $data (create or update data), the draft will either be created or simply updated.
+     *
+     * @param ContentStruct|\EzSystems\RepositoryForms\Data\Content\ContentCreateData|\EzSystems\RepositoryForms\Data\Content\ContentUpdateData $data
+     * @param $languageCode
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    private function saveDraft(ContentStruct $data, $languageCode)
+    {
+        foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+            $data->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
+        }
+
+        if ($data->isNew()) {
+            $contentDraft = $this->contentService->createContent($data, $data->getLocationStructs());
+        } else {
+            $contentDraft = $this->contentService->updateContent($data->contentDraft->getVersionInfo(), $data);
+        }
+
+        return $contentDraft;
+    }
+}

--- a/lib/Form/Type/Content/ContentEditType.php
+++ b/lib/Form/Type/Content/ContentEditType.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Type\Content;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form type for content edition (create/update).
+ * Underlying data will be either \EzSystems\RepositoryForms\Data\Content\ContentCreateData or \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
+ * depending on the context (create or update).
+ */
+class ContentEditType extends AbstractType
+{
+    public function getName()
+    {
+        return 'ezrepoforms_content_edit';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('fieldsData', 'collection', [
+                'type' => 'ezrepoforms_content_field',
+                'label' => 'ezrepoforms.content.fields',
+                'options' => ['languageCode' => $options['languageCode']],
+            ])
+            ->add('redirectUrlAfterPublish', 'hidden', ['required' => false, 'mapped' => false])
+            ->add('publish', 'submit', ['label' => 'content.publish_button']);
+
+        if ($options['drafts_enabled']) {
+            $builder
+                ->add('saveDraft', 'submit', ['label' => 'content.save_button'])
+                ->add('cancel', 'submit', [
+                    'label' => 'content.cancel_button',
+                    'attr' => ['formnovalidate' => 'formnovalidate'],
+                ]);
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'drafts_enabled' => false,
+                'data_class' => '\eZ\Publish\API\Repository\Values\Content\ContentStruct',
+                'translation_domain' => 'ezrepoforms_content',
+            ])
+            ->setRequired(['languageCode']);
+    }
+}

--- a/lib/Form/Type/Content/ContentFieldType.php
+++ b/lib/Form/Type/Content/ContentFieldType.php
@@ -8,7 +8,7 @@
  */
 namespace EzSystems\RepositoryForms\Form\Type\Content;
 
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcherInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -18,13 +18,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ContentFieldType extends AbstractType
 {
     /**
-     * @var FieldTypeFormMapperRegistryInterface
+     * @var FieldTypeFormMapperDispatcherInterface
      */
-    private $fieldTypeFormMapperRegistry;
+    private $fieldTypeFormMapper;
 
-    public function __construct(FieldTypeFormMapperRegistryInterface $fieldTypeFormMapperRegistry)
+    public function __construct(FieldTypeFormMapperDispatcherInterface $fieldTypeFormMapper)
     {
-        $this->fieldTypeFormMapperRegistry = $fieldTypeFormMapperRegistry;
+        $this->fieldTypeFormMapper = $fieldTypeFormMapper;
     }
 
     public function getName()
@@ -45,14 +45,7 @@ class ContentFieldType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
-            /** @var \EzSystems\RepositoryForms\Data\Content\FieldData $data */
-            $data = $event->getData();
-            $form = $event->getForm();
-
-            $fieldTypeIdentifier = $data->fieldDefinition->fieldTypeIdentifier;
-            if ($this->fieldTypeFormMapperRegistry->hasValueMapper($fieldTypeIdentifier)) {
-                $this->fieldTypeFormMapperRegistry->getValueMapper($fieldTypeIdentifier)->mapFieldValueForm($form, $data);
-            }
+            $this->fieldTypeFormMapper->map($event->getForm(), $event->getData());
         });
     }
 }

--- a/lib/Form/Type/Content/ContentFieldType.php
+++ b/lib/Form/Type/Content/ContentFieldType.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Type\Content;
+
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentFieldType extends AbstractType
+{
+    /**
+     * @var FieldTypeFormMapperRegistryInterface
+     */
+    private $fieldTypeFormMapperRegistry;
+
+    public function __construct(FieldTypeFormMapperRegistryInterface $fieldTypeFormMapperRegistry)
+    {
+        $this->fieldTypeFormMapperRegistry = $fieldTypeFormMapperRegistry;
+    }
+
+    public function getName()
+    {
+        return 'ezrepoforms_content_field';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'data_class' => '\EzSystems\RepositoryForms\Data\Content\FieldData',
+                'translation_domain' => 'ezrepoforms_content',
+            ])
+            ->setRequired(['languageCode']);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            /** @var \EzSystems\RepositoryForms\Data\Content\FieldData $data */
+            $data = $event->getData();
+            $form = $event->getForm();
+
+            $fieldTypeIdentifier = $data->fieldDefinition->fieldTypeIdentifier;
+            if ($this->fieldTypeFormMapperRegistry->hasValueMapper($fieldTypeIdentifier)) {
+                $this->fieldTypeFormMapperRegistry->getValueMapper($fieldTypeIdentifier)->mapFieldValueForm($form, $data);
+            }
+        });
+    }
+}

--- a/tests/RepositoryForms/FieldType/DataTransformer/CountryValueTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/CountryValueTransformerTest.php
@@ -86,7 +86,7 @@ class CountryValueTransformerTest extends PHPUnit_Framework_TestCase
             [42],
             ['snafu'],
             [null],
-            [[1,2,3]],
+            [[1, 2, 3]],
         ];
     }
 

--- a/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/DateIntervalToArrayTransformerTest.php
@@ -61,8 +61,8 @@ class DateIntervalToArrayTransformerTest extends PHPUnit_Framework_TestCase
         return [
             [null],
             [['']],
-            [['','','']],
-            [['',null,'']],
+            [['', '', '']],
+            [['', null, '']],
         ];
     }
 

--- a/tests/RepositoryForms/FieldType/FieldTypeFormMapperDispatcherTest.php
+++ b/tests/RepositoryForms/FieldType/FieldTypeFormMapperDispatcherTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\FieldType;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\ContentTypeData;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcher;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcherInterface;
+use PHPUnit_Framework_TestCase;
+
+class FieldTypeFormMapperDispatcherTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FieldTypeFormMapperDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var \EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldDefinitionMapperMock;
+
+    /**
+     * @var \EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldValueMapperMock;
+
+    public function setUp()
+    {
+        $this->dispatcher = new FieldTypeFormMapperDispatcher();
+
+        // Should be improved to test with a value + definition mapper (this is what repo-forms uses)
+        $this->fieldDefinitionMapperMock = $this->getMock('EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface');
+        $this->fieldValueMapperMock = $this->getMock('EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface');
+        $this->dispatcher->addMapper($this->fieldDefinitionMapperMock, 'first_type');
+        $this->dispatcher->addMapper($this->fieldValueMapperMock, 'second_type');
+    }
+
+    public function testMapFieldDefinition()
+    {
+        $data = new FieldDefinitionData([
+            'fieldDefinition' => new FieldDefinition(['fieldTypeIdentifier' => 'first_type']),
+            'contentTypeData' => new ContentTypeData(),
+        ]);
+
+        $formMock = $this->getMock('Symfony\Component\Form\FormInterface');
+
+        $this->fieldValueMapperMock
+            ->expects($this->never())
+            ->method('mapFieldValueForm');
+
+        $this->fieldDefinitionMapperMock
+            ->expects($this->once())
+            ->method('mapFieldDefinitionForm')
+            ->with($formMock, $data);
+
+        $this->dispatcher->map($formMock, $data);
+    }
+
+    public function testMapFieldValue()
+    {
+        $data = new FieldData([
+            'field' => new Field(['fieldDefIdentifier' => 'second_type']),
+            'fieldDefinition' => new FieldDefinition(['fieldTypeIdentifier' => 'second_type']),
+        ]);
+
+        $formMock = $this->getMock('Symfony\Component\Form\FormInterface');
+
+        $this->fieldValueMapperMock
+            ->expects($this->once())
+            ->method('mapFieldValueForm')
+            ->with($formMock, $data);
+
+        $this->fieldDefinitionMapperMock
+            ->expects($this->never())
+            ->method('mapFieldDefinitionForm');
+
+        $this->dispatcher->map($formMock, $data);
+    }
+}

--- a/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperPassTest.php
+++ b/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperPassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\Tests\DependencyInjection\Compiler;
+
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FieldTypeFormMapperPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->setDefinition('ezrepoforms.field_type_form_mapper.registry', new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new FieldTypeFormMapperPass());
+    }
+
+    public function testRegisterMappers()
+    {
+        $fieldTypeMapperServiceId = 'fieldtype_mapper';
+        $def = new Definition();
+        $def->addTag('ez.fieldType.formMapper', ['fieldType' => 'fieldtype1']);
+        $def->setClass(get_class($this->getMock('EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface')));
+        $this->setDefinition($fieldTypeMapperServiceId, $def);
+
+        $fieldValueMapperServiceId = 'fieldvalue_mapper';
+        $def = new Definition();
+        $def->addTag('ez.fieldType.formMapper', ['fieldType' => 'fieldtype2']);
+        $def->setClass(get_class($this->getMock('EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface')));
+        $this->setDefinition($fieldValueMapperServiceId, $def);
+
+        $this->compile();
+
+        // But there should not be a mapper call with $fieldValueMapperServiceId
+        $definition = $this->container->getDefinition('ezrepoforms.field_type_form_mapper.registry');
+        foreach ($definition->getMethodCalls() as $methodCall) {
+            list($method, $arguments) = $methodCall;
+            $this->assertFalse($method === 'addMapper' && ($arguments[0] === new Reference($fieldTypeMapperServiceId)));
+        }
+
+        // There should be a mapper call with $fieldTypeMapperServiceId
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezrepoforms.field_type_form_mapper.registry',
+            'addMapper',
+            [new Reference($fieldTypeMapperServiceId), 'fieldtype1']
+        );
+    }
+}


### PR DESCRIPTION
> Implements [EZP-25100](https://jira.ez.no/browse/EZP-25100)
> Re-created from https://github.com/ezsystems/repository-forms/pull/59 & https://github.com/ezsystems/repository-forms/pull/62
> Status: ready for review
> Requires https://github.com/ezsystems/ezplatform/pull/85
> TL;DR: Implements a controller action that creates content, without using an intermediary draft, using Symfony forms. Does not include validation.


Provides a `ContentEditController` with a `createWithoutDraft` action.

http://ezplatform.loc/content/create/nodraft/1/eng-GB/2  will generate a content create form for a Folder (`1`). Submitting the form will create a Folder in `eng-GB`, below location `2`.

### Scope
- Only the minimal/most simplistic set of FieldTypes are supported: TextLine, and TextBlock.
- No validation is implemented.
- The only action for now is "create and publish", without using a draft (`createWithoutDraftAction`). We believe this use-case is both the simplest to implement and the most common, as it doesn't require that a draft is created into the repository to display a content form.

### Components

#### `ez_content_edit` controller + routes
New routes are added within the `/content` namespace, like `/content/create/nodraft/{contentTypeId}/{language}/{parentLocationId}`, that defaults to simple controller actions.

The controller uses an `ActionDispatcher` to process the actual submitted data.

#### The `FieldValueMapperInterface`
The `FieldTypeFormMapperInterface`, responsible for mapping FieldDefinitions, is deprecated, and replaced by `FieldDefinitionFormMapperInterface`. This interface has an evil twin, `FieldValueFormMapperInterface`, that maps Field Values. All interfaces, including the default one, inherit from `FieldFormMapperInterface`.

The `FieldTypeFormMapperRegistry` is also deprecated. A `FieldTypeFormMapperDispatcher` replaces it. It handles both FieldDefinition and FieldValue through a unique `map()` method:

```php
$this->fieldMapper->map($contentItemForm, $fieldData);
$this->fieldMapper->map($contentTypeForm, $fieldDefinitionData);
```

This mapper will do the mapping if there is a mapper, and skip silently if there isn't.

### TODO
- [x] Change `contentTypeId` to `contentTypeIdentifier`
- [x] Rebase/merge master (deps)
- [x] Remove commit "[tmp] Set ezsystems/ezplatform branch" before merging
- [x] Re-consider the changes to FieldMapper interfaces, and see if a cleaner approach, especially regarding the registry, and how it is used.
- [x] Travis behat integration
- [x] Re-credit form related commits
- [x] Behat coverage
- [x] Consider separating the view api integration from the forms part. Use a basic controller with all the pieces in place ?