### PR TITLE
[travis] removed php 5.4 from the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
 


### PR DESCRIPTION
Not supported by `ezpublish-kernel` anymore.