### PR TITLE
EZP-25376: implemented FieldsGroups in ContentType edition

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -63,6 +63,8 @@ services:
     ezrepoforms.field_definition.form_type:
         class: %ezrepoforms.field_definition.form_type.class%
         arguments: [@ezrepoforms.field_type_form_mapper.registry, @ezpublish.api.service.field_type]
+        calls:
+            - [setGroupsList, [@ezpublish.fields_groups.list]]
         tags:
             - { name: form.type, alias: ezrepoforms_fielddefinition_update }
 
@@ -224,6 +226,8 @@ services:
     ezrepoforms.form_processor.content_type:
         class: %ezrepoforms.form_processor.content_type.class%
         arguments: [@ezpublish.api.service.content_type, @router, %ezrepoforms.form_processor.content_type.options%]
+        calls:
+            - [setGroupsList, [@ezpublish.fields_groups.list]]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/bundle/Resources/translations/ezplatform_fields_groups.en.xlf
+++ b/bundle/Resources/translations/ezplatform_fields_groups.en.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>content</source>
+                <target>Content</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.1@dev",
+        "ezsystems/ezpublish-kernel": "~6.3@dev",
         "symfony/form": "~2.7",
         "symfony/validator": "~2.7"
     },
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -12,6 +12,7 @@ namespace EzSystems\RepositoryForms\Form\Processor;
 
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -35,11 +36,21 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
      */
     private $options;
 
+    /**
+     * @var \eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList
+     */
+    private $groupsList;
+
     public function __construct(ContentTypeService $contentTypeService, RouterInterface $router, array $options = [])
     {
         $this->contentTypeService = $contentTypeService;
         $this->router = $router;
         $this->setOptions($options);
+    }
+
+    public function setGroupsList(FieldsGroupsList $groupsList)
+    {
+        $this->groupsList = $groupsList;
     }
 
     public function setOptions(array $options = [])
@@ -95,6 +106,11 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
             'names' => [$event->getOption('languageCode') => 'New FieldDefinition'],
             'position' => $maxFieldPos + 1,
         ]);
+
+        if (isset($this->groupsList)) {
+            $fieldDefCreateStruct->fieldGroup = $this->groupsList->getDefaultGroup();
+        }
+
         $this->contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreateStruct);
     }
 

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -11,6 +11,7 @@
 namespace EzSystems\RepositoryForms\Form\Type\FieldDefinition;
 
 use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface;
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;
 use Symfony\Component\Form\AbstractType;
@@ -34,10 +35,20 @@ class FieldDefinitionType extends AbstractType
      */
     private $fieldTypeService;
 
+    /**
+     * @var FieldsGroupsList
+     */
+    private $groupsList;
+
     public function __construct(FieldTypeFormMapperRegistryInterface $fieldTypeMapperRegistry, FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeMapperRegistry = $fieldTypeMapperRegistry;
         $this->fieldTypeService = $fieldTypeService;
+    }
+
+    public function setGroupsList(FieldsGroupsList $groupsList)
+    {
+        $this->groupsList = $groupsList;
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -52,6 +63,11 @@ class FieldDefinitionType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $fieldsGroups = [];
+        if (isset($this->groupsList)) {
+            $fieldsGroups = array_flip($this->groupsList->getGroups());
+        }
+
         $translatablePropertyTransformer = new TranslatablePropertyTransformer($options['languageCode']);
         $builder
             ->add(
@@ -69,7 +85,15 @@ class FieldDefinitionType extends AbstractType
             )
             ->add('isRequired', 'checkbox', ['required' => false, 'label' => 'field_definition.is_required'])
             ->add('isTranslatable', 'checkbox', ['required' => false, 'label' => 'field_definition.is_translatable'])
-            ->add('fieldGroup', 'choice', ['choices' => []], ['required' => false, 'label' => 'field_definition.field_group'])
+            ->add(
+                'fieldGroup',
+                'choice', [
+                    'choices' => $fieldsGroups,
+                    'choices_as_values' => true,
+                    'required' => false,
+                    'label' => 'field_definition.field_group',
+                ]
+            )
             ->add('position', 'integer', ['label' => 'field_definition.position'])
             ->add('selected', 'checkbox', ['required' => false, 'mapped' => false]);
 

--- a/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
+++ b/tests/RepositoryForms/Form/Processor/ContentTypeFormProcessorTest.php
@@ -25,12 +25,12 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject
      */
     private $contentTypeService;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $router;
 
@@ -39,12 +39,20 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
      */
     private $formProcessor;
 
+    /**
+     * @var \eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $groupsList;
+
     protected function setUp()
     {
         parent::setUp();
         $this->contentTypeService = $this->getMock('\eZ\Publish\API\Repository\ContentTypeService');
         $this->router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $this->groupsList = $this->getMock('eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList');
+
         $this->formProcessor = new ContentTypeFormProcessor($this->contentTypeService, $this->router);
+        $this->formProcessor->setGroupsList($this->groupsList);
     }
 
     public function testSubscribedEvents()
@@ -122,6 +130,7 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
             'identifier' => $expectedNewFieldDefIdentifier,
             'names' => [$languageCode => 'New FieldDefinition'],
             'position' => 1,
+            'fieldGroup' => 'content',
         ]);
         $this->contentTypeService
             ->expects($this->once())
@@ -132,6 +141,10 @@ class ContentTypeFormProcessorTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('addFieldDefinition')
             ->with($contentTypeDraft, $this->equalTo($expectedFieldDefCreateStruct));
+        $this->groupsList
+            ->expects($this->once())
+            ->method('getDefaultGroup')
+            ->will($this->returnValue('content'));
 
         $event = new FormActionEvent(
             $mainForm,


### PR DESCRIPTION
> Implements http://jira.ez.no/browse/EZP-25376
> Integrates fields groups added in https://github.com/ezsystems/ezpublish-kernel/pull/1575
> Requires ezpublish-kernel:6.3@dev (FieldsGroups API)

Integrates fields groups in ContentType edit forms. Backward compatibility is covered by injecting `fields_groups.list` service using a setter (avoids adding another optional argument to the ctor), and making it optional in the code.

### Tasks
- [x] Merge https://github.com/ezsystems/ezpublish-kernel/pull/1575 first, and remove the deps commit