### PR TITLE
Fixed form errors due to symfony 2.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.7",
         "behat/behat": "^3.0"
     },
+    "conflict": {
+        "symfony/symfony": "2.7.11"
+    },
     "autoload": {
         "psr-4": {
             "EzSystems\\RepositoryFormsBundle\\": "bundle",

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
         "branch-alias": {
             "dev-master": "1.1.x-dev"
         }
+    },
+    "config": {
+        "bin-dir": "bin"
     }
 }


### PR DESCRIPTION
> Re-opening of #76 against 1.1
> Fixes [EZP-25685](https://jira.ez.no/browse/EZP-25685), [EZP-25689](https://jira.ez.no/browse/EZP-25689), [EZP-25691](https://jira.ez.no/browse/EZP-25691), [EZP-25677](https://jira.ez.no/browse/EZP-25677)

Changes to PropertyAccess (https://github.com/symfony/property-access/commit/d3b7d77fb3c815e2d2d70bc6b8df7f2b6ea821f5) create a regression in multiple content type forms.

The regression is fixed in https://github.com/symfony/symfony/commit/2b30d48 on the 2.7 branch, not tagged yet.