### PR TITLE
Made user registration group configurable

### DIFF
--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -11,11 +11,11 @@ namespace EzSystems\RepositoryFormsBundle\Controller;
 use eZ\Bundle\EzPublishCoreBundle\Controller;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Repository;
-use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
+use EzSystems\RepositoryForms\UserRegister\RegistrationGroupLoader;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserRegisterController extends Controller
@@ -26,9 +26,9 @@ class UserRegisterController extends Controller
     private $contentTypeService;
 
     /**
-     * @var UserService
+     * @var RegistrationGroupLoader
      */
-    private $userService;
+    private $registrationGroupLoader;
 
     /**
      * @var ActionDispatcherInterface
@@ -47,12 +47,12 @@ class UserRegisterController extends Controller
 
     public function __construct(
         ContentTypeService $contentTypeService,
-        UserService $userService,
+        RegistrationGroupLoader $registrationGroupLoader,
         ActionDispatcherInterface $contentActionDispatcher,
         Repository $repository
     ) {
         $this->contentTypeService = $contentTypeService;
-        $this->userService = $userService;
+        $this->registrationGroupLoader = $registrationGroupLoader;
         $this->contentActionDispatcher = $contentActionDispatcher;
         $this->repository = $repository;
     }
@@ -93,12 +93,9 @@ class UserRegisterController extends Controller
 
         $data = (new UserRegisterMapper())->mapToFormData($contentType, [
             'mainLanguageCode' => $language,
-            'parentGroup' => $this->repository->sudo(
-                function () {
-                    return $this->userService->loadUserGroup(11);
-                }
-            ),
         ]);
+        $data->addParentGroup($this->registrationGroupLoader->getParentGroup($data));
+
         $form = $this->createForm(new UserRegisterType(), $data, ['languageCode' => $language]);
         $form->handleRequest($request);
 

--- a/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class UserRegistration extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('users')
+                ->info('Users configuration')
+                ->children()
+                    ->scalarNode('registration_group_id')
+                        ->info('Content id of the user group where users who register are created.')
+                        ->defaultValue(11)
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (!empty($scopeSettings['users'])) {
+            $contextualizer->setContextualParameter('users.registration_group', $currentScope,
+                $scopeSettings['users']['registration_group_id']);
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -14,6 +14,7 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -28,5 +29,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
 
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
+        $eZExtension->addConfigParser(new UserRegistration());
+        $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -1,0 +1,2 @@
+parameters:
+    ezsettings.default.users.registration_group: 11

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -300,7 +300,7 @@ services:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
             - "@ezpublish.api.service.content_type"
-            - "@ezpublish.api.service.user"
+            - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
             - "@ezpublish.api.repository"
         parent: ezpublish.controller.base
@@ -309,3 +309,10 @@ services:
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit
+
+    ezrepoforms.user_register.registration_group_loader.configurable:
+        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
+        arguments:
+            - @ezpublish.api.repository
+        calls:
+            - [setGroupId, ["$users.registration_group$"]]

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -19,3 +19,16 @@ Scenario: A new user account can be registered from "/register"
      Then I am on the registration confirmation page
       And I see a registration confirmation message
       And the user account has been created
+
+Scenario: The user group where registered users are created can be customized
+    Given a User Group
+      And the following configuration:
+      """
+      ezpublish:
+        system:
+          default:
+            users:
+              registration_group_id: <userGroupContentId>
+      """
+     When I register a user account
+     Then the user is created in this user group

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -26,7 +26,10 @@ class UserRegisterMapper implements FormDataMapperInterface
         $params = $resolver->resolve($params);
 
         $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
-        $data->addParentGroup($params['parentGroup']);
+        if (isset($params['parentGroup'])) {
+            $data->addParentGroup($params['parentGroup']);
+        }
+
         foreach ($contentType->fieldDefinitions as $fieldDef) {
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
@@ -44,7 +47,8 @@ class UserRegisterMapper implements FormDataMapperInterface
     private function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver
-            ->setRequired(['mainLanguageCode', 'parentGroup'])
-            ->setAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
+            ->setRequired(['mainLanguageCode'])
+            ->setDefined(['parentGroup'])
+            ->addAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
     }
 }

--- a/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use eZ\Publish\API\Repository\Repository;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use InvalidArgumentException;
+
+/**
+ * Loads the registration user group from a configured, injected group ID.
+ */
+class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $groupId;
+
+    public function __construct(Repository $repository, $groupId = null)
+    {
+        $this->repository = $repository;
+        $this->groupId = $groupId;
+    }
+
+    public function setGroupId($groupId)
+    {
+        $this->groupId = $groupId;
+
+        return $this;
+    }
+
+    public function getParentGroup(UserCreateData $userCreateData)
+    {
+        if ($this->groupId === null) {
+            throw new InvalidArgumentException('groupId needs to be set');
+        }
+
+        return $this->repository->sudo(
+            function () {
+                return $this->repository->getUserService()->loadUserGroup($this->groupId);
+            }
+        );
+    }
+}

--- a/lib/UserRegister/RegistrationGroupLoader.php
+++ b/lib/UserRegister/RegistrationGroupLoader.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+
+/**
+ * Used to set the parent group during user registration.
+ */
+interface RegistrationGroupLoader
+{
+    /**
+     * Gets the parent group of $userCreateData.
+     *
+     * @param UserCreateData $userCreateData
+     *
+     * @return UserGroup
+     */
+    public function getParentGroup(UserCreateData $userCreateData);
+}


### PR DESCRIPTION
> Implements [EZP-25840](https://jira.ez.no/browse/EZP-25840)

Adds a `RegistrationGroupLoader`, with a `ConfigurableRegistrationGroupLoader` that receives a newly added `user.registration_group_id` siteaccess aware configuration variable. This variable is configured as follows:

```yaml
ezpublish:
  system:
    <scope>:
      users:
        registration_group_id: 11
```