### PR TITLE
Feature: user registration

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -16,4 +16,9 @@ repository-forms:
                 - EzSystems\RepositoryForms\Features\Context\ContentType
                 - EzSystems\RepositoryForms\Features\Context\FieldTypeFormContext
                 - EzSystems\RepositoryForms\Features\Context\SelectionFieldTypeFormContext
+        user_registration:
+            paths:
+                - vendor/ezsystems/repository-forms/features/User/Registration
+            contexts:
+                - EzSystems\RepositoryForms\Features\Context\UserRegistrationContext
                 - Behat\MinkExtension\Context\MinkContext

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -9,7 +9,6 @@
 namespace EzSystems\RepositoryFormsBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
-use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Repository;
 use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
@@ -21,14 +20,9 @@ use Symfony\Component\HttpFoundation\Request;
 class UserRegisterController extends Controller
 {
     /**
-     * @var ContentTypeService
+     * @var UserRegisterMapper
      */
-    private $contentTypeService;
-
-    /**
-     * @var RegistrationGroupLoader
-     */
-    private $registrationGroupLoader;
+    private $userRegisterMapper;
 
     /**
      * @var ActionDispatcherInterface
@@ -36,22 +30,17 @@ class UserRegisterController extends Controller
     private $contentActionDispatcher;
 
     /**
-     * @var Repository
-     */
-    private $repository;
-
-    /**
      * @var string
      */
     private $pagelayout;
 
     public function __construct(
-        ContentTypeService $contentTypeService,
+        UserRegisterMapper $userRegisterMapper,
         RegistrationGroupLoader $registrationGroupLoader,
         ActionDispatcherInterface $contentActionDispatcher,
         Repository $repository
     ) {
-        $this->contentTypeService = $contentTypeService;
+        $this->userRegisterMapper = $userRegisterMapper;
         $this->registrationGroupLoader = $registrationGroupLoader;
         $this->contentActionDispatcher = $contentActionDispatcher;
         $this->repository = $repository;
@@ -83,20 +72,14 @@ class UserRegisterController extends Controller
             throw new \Exception('You are not allowed to register a new account');
         }
 
-        $language = 'eng-GB';
-
-        $contentType = $this->repository->sudo(
-            function () {
-                return $this->contentTypeService->loadContentTypeByIdentifier('user');
-            }
+        $data = $this->userRegisterMapper->mapToFormData();
+        $language = $data->mainLanguageCode;
+        $form = $this->createForm(
+            new UserRegisterType(),
+            $data,
+            ['languageCode' => $language]
         );
 
-        $data = (new UserRegisterMapper())->mapToFormData($contentType, [
-            'mainLanguageCode' => $language,
-        ]);
-        $data->addParentGroup($this->registrationGroupLoader->getParentGroup($data));
-
-        $form = $this->createForm(new UserRegisterType(), $data, ['languageCode' => $language]);
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
+use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
+use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
+use Symfony\Component\HttpFoundation\Request;
+
+class UserRegisterController extends Controller
+{
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var UserService
+     */
+    private $userService;
+
+    /**
+     * @var ActionDispatcherInterface
+     */
+    private $contentActionDispatcher;
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $pagelayout;
+
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        UserService $userService,
+        ActionDispatcherInterface $contentActionDispatcher,
+        Repository $repository
+    ) {
+        $this->contentTypeService = $contentTypeService;
+        $this->userService = $userService;
+        $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param string $pagelayout
+     * @return ContentEditController
+     */
+    public function setPagelayout($pagelayout)
+    {
+        $this->pagelayout = $pagelayout;
+
+        return $this;
+    }
+
+    /**
+     * Displays and processes a user registration form.
+     *
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function registerAction(Request $request)
+    {
+        $language = 'eng-GB';
+
+        $contentType = $this->repository->sudo(
+            function () {
+                return $this->contentTypeService->loadContentTypeByIdentifier('user');
+            }
+        );
+
+        $data = (new UserRegisterMapper())->mapToFormData($contentType, [
+            'mainLanguageCode' => $language,
+            'parentGroup' => $this->repository->sudo(
+                function () {
+                    return $this->userService->loadUserGroup(11);
+                }
+            ),
+        ]);
+        $form = $this->createForm(new UserRegisterType(), $data, ['languageCode' => $language]);
+        $form->handleRequest($request);
+
+        if ($form->isValid()) {
+            $this->contentActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
+            if ($response = $this->contentActionDispatcher->getResponse()) {
+                return $response;
+            }
+        }
+
+        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
+            'form' => $form->createView(),
+            'languageCode' => $language,
+            'pagelayout' => $this->pagelayout,
+        ]);
+    }
+
+    public function registerConfirmAction()
+    {
+        return $this->render(
+            '@EzSystemsRepositoryForms/User/register_confirmation.html.twig',
+            ['pagelayout' => $this->pagelayout]
+        );
+    }
+}

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\UserService;
 use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
 use Symfony\Component\HttpFoundation\Request;
@@ -73,9 +74,15 @@ class UserRegisterController extends Controller
      * @param Request $request
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Exception if the current user isn't allowed to register an account
      */
     public function registerAction(Request $request)
     {
+        if (!$this->isGranted(new Attribute('user', 'register'))) {
+            throw new \Exception('You are not allowed to register a new account');
+        }
+
         $language = 'eng-GB';
 
         $contentType = $this->repository->sudo(

--- a/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class UserRegistration extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('users')
+                ->info('Users configuration')
+                ->children()
+                    ->scalarNode('registration_group_id')
+                        ->info('Content id of the user group where users who register are created.')
+                        ->defaultValue(11)
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (!empty($scopeSettings['users'])) {
+            $contextualizer->setContextualParameter('users.registration_group', $currentScope,
+                $scopeSettings['users']['registration_group_id']);
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -14,6 +14,7 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -28,5 +29,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
 
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
+        $eZExtension->addConfigParser(new UserRegistration());
+        $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }
 }

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -10,6 +10,7 @@
  */
 namespace EzSystems\RepositoryFormsBundle;
 
+use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
@@ -24,5 +25,8 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $container->addCompilerPass(new FieldTypeFormMapperPass());
         $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
+
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -1,0 +1,2 @@
+parameters:
+    ezsettings.default.users.registration_group: 11

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -2,3 +2,13 @@ ez_content_create_no_draft:
     path: /content/create/nodraft/{contentTypeIdentifier}/{language}/{parentLocationId}
     defaults:
         _controller: ez_content_edit:createWithoutDraftAction
+
+ez_user_register:
+  path: /register
+  defaults:
+      _controller: "ezrepoforms.controller.user_register:registerAction"
+
+ez_user_register_confirmation:
+  path: /register-confirm
+  defaults:
+      _controller: "ezrepoforms.controller.user_register:registerConfirmAction"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -302,7 +302,7 @@ services:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
             - "@ezpublish.api.service.content_type"
-            - "@ezpublish.api.service.user"
+            - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
             - "@ezpublish.api.repository"
         parent: ezpublish.controller.base
@@ -311,3 +311,10 @@ services:
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit
+
+    ezrepoforms.user_register.registration_group_loader.configurable:
+        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
+        arguments:
+            - @ezpublish.api.repository
+        calls:
+            - [setGroupId, ["$users.registration_group$"]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -78,7 +78,7 @@ services:
             - { name: form.type, alias: ezrepoforms_content_field }
 
     ezrepoforms.field_value.user_type:
-        class: EzSystems\RepositoryForms\Form\Type\UserType
+        class: EzSystems\RepositoryForms\Form\Type\User\UserAccountType
         tags:
             - { name: form.type, alias: ezuser }
 
@@ -189,12 +189,11 @@ services:
             - @ezpublish.api.service.field_type
 
     ezrepoforms.field_type.form_mapper.ezuser:
-        class: "%ezrepoforms.field_type.form_mapper.form_type_based.class%"
-        parent: ezrepoforms.field_type.form_mapper.form_type_based
+        class: 'EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper'
         tags:
             - { name: ez.fieldFormMapper.value, fieldType: ezuser }
-        calls:
-           - [setFormType, ["ezuser"]]
+        arguments:
+            - '@ezpublish.api.service.field_type'
 
     # Validators
     ezrepoforms.validator.unique_content_type_identifier:
@@ -272,6 +271,15 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezrepoforms.form_processor.user_register:
+        class: 'EzSystems\RepositoryForms\Form\Processor\UserRegisterFormProcessor'
+        arguments:
+            - '@ezpublish.api.repository'
+            - '@ezpublish.api.service.user'
+            - '@router'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezrepoforms.form_processor.content_type_group:
         class: %ezrepoforms.form_processor.content_type_group.class%
         arguments: [@ezpublish.api.service.content_type]
@@ -289,6 +297,17 @@ services:
         parent: ezpublish.controller.base
         calls:
             - [setPageLayout, [$pagelayout$]]
+
+    ezrepoforms.controller.user_register:
+        class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
+        arguments:
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.user"
+            - "@ezrepoforms.action_dispatcher.content"
+            - "@ezpublish.api.repository"
+        parent: ezpublish.controller.base
+        calls:
+            - [setPagelayout, ["$pagelayout$"]]
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -49,6 +49,8 @@ parameters:
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
 
+    ezrepoforms.user_content_type_identifier: "user"
+
 services:
     # deprecated in 1.1, will be removed in 2.0
     ezrepoforms.field_type_form_mapper.registry:
@@ -301,7 +303,7 @@ services:
     ezrepoforms.controller.user_register:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
-            - "@ezpublish.api.service.content_type"
+            - "@ezrepoforms.form_data_mapper.user_register"
             - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
             - "@ezpublish.api.repository"
@@ -315,6 +317,21 @@ services:
     ezrepoforms.user_register.registration_group_loader.configurable:
         class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
         arguments:
-            - @ezpublish.api.repository
+            - "@ezpublish.api.repository"
         calls:
-            - [setGroupId, ["$users.registration_group$"]]
+            - [setParam, ["groupId", "$users.registration_group$"]]
+
+    ezrepoforms.user_register.registration_content_type_loader.configurable:
+        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
+        arguments:
+            - "@ezpublish.api.repository"
+        calls:
+            - [setParam, ["contentTypeIdentifier", "%ezrepoforms.user_content_type_identifier%"]]
+
+    ezrepoforms.form_data_mapper.user_register:
+        class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
+        arguments:
+            - "@ezrepoforms.user_register.registration_content_type_loader.configurable"
+            - "@ezrepoforms.user_register.registration_group_loader.configurable"
+        calls:
+            - [setParam, ["language", "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]

--- a/bundle/Resources/translations/ezrepoforms_user_registration.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_user_registration.en.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>user.register_button</source>
+                <target>Register</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/bundle/Resources/views/User/register_confirmation.html.twig
+++ b/bundle/Resources/views/User/register_confirmation.html.twig
@@ -1,0 +1,8 @@
+{% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
+
+{% block content %}
+    <h1>Your account has been created</h1>
+    <p class="user-register-confirmation-message">
+        Thank you for registering an account. You can now <a href="{{ path('login') }}">login</a>.
+    </p>
+{% endblock %}

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This file is part of the ezplatform package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+
+class UserRegistrationContext extends RawMinkContext implements Context, SnippetAcceptingContext
+{
+    use RepositoryContext;
+
+    private static $password = 'publish';
+    private static $language = 'eng-GB';
+    private static $groupId = 4;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->setRepository($repository);
+    }
+
+    /**
+     * @Given /^I do not have the user\/register policy$/
+     */
+    public function iDoNotHaveTheUserRegisterPolicy()
+    {
+        $role = $this->createRegistrationRole(false);
+        $user = $this->createUserWithRole($role);
+        $this->loginAs($user);
+    }
+
+    /**
+     * @Given /^I do have the user\/register policy$/
+     */
+    public function iDoHaveTheUserRegisterPolicy()
+    {
+        $role = $this->createRegistrationRole(true);
+        $user = $this->createUserWithRole($role);
+        $this->loginAs($user);
+    }
+
+    /**
+     * Creates a user for registration testing, and assigns it the role $role.
+     *
+     * @param Role $role
+     *
+     * @return User
+     */
+    private function createUserWithRole(Role $role)
+    {
+        $userService = $this->getRepository()->getUserService();
+        $username = uniqid($role->identifier);
+        $createStruct = $userService->newUserCreateStruct(
+            $username,
+            $username . '@example.com',
+            self::$password,
+            'eng-GB'
+        );
+        $createStruct->setField('first_name', $username);
+        $createStruct->setField('last_name', 'The first');
+        $user = $userService->createUser($createStruct, [$userService->loadUserGroup(self::$groupId)]);
+
+        $this->getRepository()->getRoleService()->assignRoleToUser($role, $user);
+
+        return $user;
+    }
+
+    /**
+     * Creates a role for user registration test.
+     *
+     * It always has the minimal set of policies to operate (user/login and content/read).
+     *
+     * @param bool $withUserRegisterPolicy Determines if the role gets the user/register policy
+     *
+     * @return Role
+     */
+    private function createRegistrationRole($withUserRegisterPolicy = true)
+    {
+        $roleIdentifier = uniqid(
+            'anonymous_role_' . ($withUserRegisterPolicy ? 'with' : 'without') . '_register'
+        );
+
+        $roleService = $this->getRepository()->getRoleService();
+        $roleCreateStruct = new RoleCreateStruct(['identifier' => $roleIdentifier]);
+        $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('user', 'login'));
+        $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('content', 'read'));
+
+        if ($withUserRegisterPolicy === true) {
+            $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('user', 'register'));
+        }
+
+        $roleService->publishRoleDraft($roleService->createRole($roleCreateStruct));
+
+        return $roleService->loadRoleByIdentifier($roleIdentifier);
+    }
+
+    /**
+     * @Then /^I see an error message saying that I can not register$/
+     */
+    public function iSeeAnErrorMessageSayingThatICanNotRegister()
+    {
+        $this->assertSession()->pageTextContains('You are not allowed to register a new account');
+    }
+
+    /**
+     * @param User $user
+     * @throws \Behat\Mink\Exception\ElementNotFoundException
+     */
+    public function loginAs(User $user)
+    {
+        $this->visitPath('/login');
+        $page = $this->getSession()->getPage();
+        $page->fillField('username', $user->login);
+        $page->fillField('password', self::$password);
+        $page->findButton('Login')->press();
+        $this->assertSession()->statusCodeEquals(200);
+    }
+
+    /**
+     * @Then /^I can see the registration form$/
+     */
+    public function iCanSeeTheRegistrationForm()
+    {
+        $this->assertSession()->pageTextNotContains('You are not allowed to register a new account');
+        $this->assertSession()->elementExists('css', 'form[name=ezrepoforms_user_register]');
+    }
+}

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -9,13 +9,13 @@ Scenario: Registration is disabled for users who do not have the "user/register"
      Then I see an error message saying that I can not register
 
 Scenario: A new user account can be registered from "/register"
-    Given that I am not logged in
-      And that the Anonymous user has the "user/register" policy
-     When I go to "/register"
-     Then a form is displayed
+    Given I do have the user/register policy
+      And I go to "/register"
+     Then I can see the registration form
       And it matches the structure of the configured registration user Content Type
       And it has a register button
      When I fill in the form with valid values
       And I click on the register button
-     Then I get redirected to "/register-confirmation"
+     Then I am on the registration confirmation page
       And I see a registration confirmation message
+      And the user account has been created

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -1,0 +1,21 @@
+Feature: User registration form
+    In order to allow users to create an account on a site
+    As a site owner
+    I want to expose a user registration form
+
+Scenario: Registration is disabled for users who do not have the "user/register" policy
+    Given I do not have the user/register policy
+     When I go to "/register"
+     Then I see an error message saying that I can not register
+
+Scenario: A new user account can be registered from "/register"
+    Given that I am not logged in
+      And that the Anonymous user has the "user/register" policy
+     When I go to "/register"
+     Then a form is displayed
+      And it matches the structure of the configured registration user Content Type
+      And it has a register button
+     When I fill in the form with valid values
+      And I click on the register button
+     Then I get redirected to "/register-confirmation"
+      And I see a registration confirmation message

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -19,3 +19,16 @@ Scenario: A new user account can be registered from "/register"
      Then I am on the registration confirmation page
       And I see a registration confirmation message
       And the user account has been created
+
+Scenario: The user group where registered users are created can be customized
+    Given a User Group
+      And the following configuration:
+      """
+      ezpublish:
+        system:
+          default:
+            users:
+              registration_group_id: <userGroupContentId>
+      """
+     When I register a user account
+     Then the user is created in this user group

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form data mapper for user registration / creation.
+ */
+class UserRegisterMapper implements FormDataMapperInterface
+{
+    public function mapToFormData(ValueObject $contentType, array $params = [])
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $params = $resolver->resolve($params);
+
+        $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
+        $data->addParentGroup($params['parentGroup']);
+        foreach ($contentType->fieldDefinitions as $fieldDef) {
+            $data->addFieldData(new FieldData([
+                'fieldDefinition' => $fieldDef,
+                'field' => new Field([
+                    'fieldDefIdentifier' => $fieldDef->identifier,
+                    'languageCode' => $params['mainLanguageCode'],
+                ]),
+                'value' => $fieldDef->defaultValue,
+            ]));
+        }
+
+        return $data;
+    }
+
+    private function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver
+            ->setRequired(['mainLanguageCode', 'parentGroup'])
+            ->setAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
+    }
+}

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -26,7 +26,10 @@ class UserRegisterMapper implements FormDataMapperInterface
         $params = $resolver->resolve($params);
 
         $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
-        $data->addParentGroup($params['parentGroup']);
+        if (isset($params['parentGroup'])) {
+            $data->addParentGroup($params['parentGroup']);
+        }
+
         foreach ($contentType->fieldDefinitions as $fieldDef) {
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
@@ -44,7 +47,8 @@ class UserRegisterMapper implements FormDataMapperInterface
     private function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver
-            ->setRequired(['mainLanguageCode', 'parentGroup'])
-            ->setAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
+            ->setRequired(['mainLanguageCode'])
+            ->setDefined(['parentGroup'])
+            ->addAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
     }
 }

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -9,33 +9,66 @@
 namespace EzSystems\RepositoryForms\Data\Mapper;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
-use eZ\Publish\API\Repository\Values\ValueObject;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use EzSystems\RepositoryForms\UserRegister\RegistrationContentTypeLoader;
+use EzSystems\RepositoryForms\UserRegister\RegistrationGroupLoader;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Form data mapper for user registration / creation.
  */
-class UserRegisterMapper implements FormDataMapperInterface
+class UserRegisterMapper
 {
-    public function mapToFormData(ValueObject $contentType, array $params = [])
+    /**
+     * @var RegistrationContentTypeLoader
+     */
+    private $contentTypeLoader;
+
+    /**
+     * @var RegistrationGroupLoader
+     */
+    private $parentGroupLoader;
+
+    /**
+     * @var array
+     */
+    private $params;
+
+    public function __construct(RegistrationContentTypeLoader $contentTypeLoader, RegistrationGroupLoader $registrationGroupLoader)
+    {
+        $this->contentTypeLoader = $contentTypeLoader;
+        $this->parentGroupLoader = $registrationGroupLoader;
+    }
+
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
+    }
+
+    /**
+     * @return UserCreateData
+     */
+    public function mapToFormData()
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
-        $params = $resolver->resolve($params);
+        $this->params = $resolver->resolve($this->params);
 
-        $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
-        if (isset($params['parentGroup'])) {
-            $data->addParentGroup($params['parentGroup']);
-        }
+        $contentType = $this->contentTypeLoader->loadContentType();
+
+        $data = new UserCreateData([
+            'contentType' => $contentType,
+            'mainLanguageCode' => $this->params['language'],
+        ]);
+        $data->addParentGroup($this->parentGroupLoader->loadGroup());
 
         foreach ($contentType->fieldDefinitions as $fieldDef) {
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
                 'field' => new Field([
                     'fieldDefIdentifier' => $fieldDef->identifier,
-                    'languageCode' => $params['mainLanguageCode'],
+                    'languageCode' => $this->params['language'],
                 ]),
                 'value' => $fieldDef->defaultValue,
             ]));
@@ -46,9 +79,6 @@ class UserRegisterMapper implements FormDataMapperInterface
 
     private function configureOptions(OptionsResolver $optionsResolver)
     {
-        $optionsResolver
-            ->setRequired(['mainLanguageCode'])
-            ->setDefined(['parentGroup'])
-            ->addAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
+        $optionsResolver->setRequired('language');
     }
 }

--- a/lib/Data/User/UserAccountFieldData.php
+++ b/lib/Data/User/UserAccountFieldData.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Data\User;
+
+/**
+ * User account field data value object.
+ *
+ * Used to store submitted user account values, since the clear password is not meant to be part of the
+ * User\Value object.
+ */
+class UserAccountFieldData
+{
+    /**
+     * @var string
+     */
+    public $username;
+
+    /**
+     * @var string
+     */
+    public $password;
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    public function __construct($username, $password, $email)
+    {
+        $this->username = $username;
+        $this->password = $password;
+        $this->email = $email;
+    }
+}

--- a/lib/Data/User/UserCreateData.php
+++ b/lib/Data/User/UserCreateData.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\User;
+
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+use eZ\Publish\Core\Repository\Values\User\UserCreateStruct;
+use EzSystems\RepositoryForms\Data\Content\ContentData;
+use EzSystems\RepositoryForms\Data\NewnessCheckable;
+
+/**
+ * @property-read \EzSystems\RepositoryForms\Data\Content\FieldData[] $fieldsData
+ */
+class UserCreateData extends UserCreateStruct implements NewnessCheckable
+{
+    use ContentData;
+
+    /**
+     * @var UserGroup[]
+     */
+    private $parentGroups;
+
+    public function isNew()
+    {
+        return true;
+    }
+
+    /**
+     * @return UserGroup[]
+     */
+    public function getParentGroups()
+    {
+        return $this->parentGroups;
+    }
+
+    /**
+     * Adds a parent group.
+     *
+     * @param UserGroup $parentGroup
+     */
+    public function addParentGroup(UserGroup $parentGroup)
+    {
+        $this->parentGroups[] = $parentGroup;
+    }
+}

--- a/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
+++ b/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType\Mapper;
+
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\Core\FieldType\User\Value as ApiUserValue;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\User\UserAccountFieldData;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Maps a user FieldType.
+ */
+final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\FieldTypeService
+     */
+    private $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    /**
+     * Maps Field form to current FieldType based on the configured form type (self::$formType).
+     *
+     * @param FormInterface $fieldForm Form for the current Field.
+     * @param FieldData $data Underlying data for current Field form.
+     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($fieldDefinition->getNames());
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create('value', 'ezuser', ['required' => $fieldDefinition->isRequired, 'label' => $label])
+                    ->addModelTransformer(
+                        new CallbackTransformer(
+                            function (ApiUserValue $data) {
+                                return new UserAccountFieldData($data->login, null, $data->email);
+                            },
+                            function ($submittedData) {
+                                return new UserAccountFieldData(
+                                    $submittedData->username,
+                                    $submittedData->password,
+                                    $submittedData->email
+                                );
+
+                            }
+                        )
+                    )
+                    ->setAutoInitialize(false)
+                    ->getForm()
+            );
+    }
+}

--- a/lib/Form/Processor/UserRegisterFormProcessor.php
+++ b/lib/Form/Processor/UserRegisterFormProcessor.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Processor;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\ContentStruct;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Listens for and processes RepositoryForm events: publish, remove draft, save draft...
+ */
+class UserRegisterFormProcessor implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function __construct(Repository $repository, UserService $userService, RouterInterface $router)
+    {
+        $this->userService = $userService;
+        $this->router = $router;
+        $this->repository = $repository;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::CONTENT_PUBLISH => ['processPublish', 20],
+        ];
+    }
+
+    public function processPublish(FormActionEvent $event)
+    {
+        /** @var \EzSystems\RepositoryForms\Data\User\UserCreateData $data */
+        if (!($data = $event->getData()) instanceof UserCreateData) {
+            return;
+        }
+        $form = $event->getForm();
+
+        $this->saveDraft($data, $form->getConfig()->getOption('languageCode'));
+
+        $redirectUrl = $this->router->generate('ez_user_register_confirmation');
+        $event->setResponse(new RedirectResponse($redirectUrl));
+        $event->stopPropagation();
+    }
+
+    /**
+     * Saves content draft corresponding to $data.
+     * Depending on the nature of $data (create or update data), the draft will either be created or simply updated.
+     *
+     * @param ContentStruct|\EzSystems\RepositoryForms\Data\User\UserCreateData $data
+     * @param $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    private function saveDraft(UserCreateData $data, $languageCode)
+    {
+        foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+            if ($fieldData->getFieldTypeIdentifier() !== 'ezuser') {
+                $data->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
+            }
+        }
+
+        return $this->repository->sudo(
+            function () use ($data) {
+                return $this->userService->createUser($data, $data->getParentGroups());
+            }
+        );
+    }
+}

--- a/lib/Form/Type/User/UserAccountType.php
+++ b/lib/Form/Type/User/UserAccountType.php
@@ -6,13 +6,13 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\Form\Type;
+namespace EzSystems\RepositoryForms\Form\Type\User;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserType extends AbstractType
+class UserAccountType extends AbstractType
 {
     public function getName()
     {
@@ -23,14 +23,14 @@ class UserType extends AbstractType
     {
         $builder
             ->add('username', 'text', [
-                'property_path' => 'login',
+                'property_path' => 'username',
                 'label' => 'content.field_type.ezuser.username',
                 'required' => $options['required'],
             ])
             ->add('password', 'repeated', [
                 'type' => 'password',
                 'required' => true,
-                'property_path' => 'passwordHash',
+                'property_path' => 'password',
                 'first_options' => ['label' => 'content.field_type.ezuser.password'],
                 'second_options' => ['label' => 'content.field_type.ezuser.password_confirm'],
             ])
@@ -43,7 +43,7 @@ class UserType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'data_class' => '\eZ\Publish\Core\FieldType\User\Value',
+                'data_class' => '\EzSystems\RepositoryForms\Data\User\UserAccountFieldData',
                 'translation_domain' => 'ezrepoforms_content',
             ]);
     }

--- a/lib/Form/Type/User/UserRegisterType.php
+++ b/lib/Form/Type/User/UserRegisterType.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\User;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form type for content edition (create/update).
+ * Underlying data will be either \EzSystems\RepositoryForms\Data\Content\ContentCreateData or \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
+ * depending on the context (create or update).
+ */
+class UserRegisterType extends AbstractType
+{
+    public function getName()
+    {
+        return 'ezrepoforms_user_register';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('fieldsData', 'collection', [
+                'type' => 'ezrepoforms_content_field',
+                'label' => 'ezrepoforms.content.fields',
+                'options' => ['languageCode' => $options['languageCode']],
+            ])
+            ->add('redirectUrlAfterPublish', 'hidden', ['required' => false, 'mapped' => false])
+            // @todo add the string to its own domain
+            ->add('publish', 'submit', ['label' => 'user.register_button'])
+            ->addEventListener(
+                FormEvents::POST_SUBMIT,
+                array($this, 'mapUserFieldToUserCreate')
+            );
+    }
+
+    public function mapUserFieldToUserCreate(FormEvent $event)
+    {
+        $userCreateData = $event->getData();
+
+        if (isset($userCreateData->fieldsData['user_account'])) {
+            $userAccountFieldData = $userCreateData->fieldsData['user_account']->value;
+            $userCreateData->login = $userAccountFieldData->username;
+            $userCreateData->email = $userAccountFieldData->email;
+            $userCreateData->password = $userAccountFieldData->password;
+
+            //$userCreateData->setField('user_account', null);
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'data_class' => '\eZ\Publish\API\Repository\Values\User\UserCreateStruct',
+                'translation_domain' => 'ezrepoforms_content',
+            ])
+            ->setRequired(['languageCode']);
+    }
+}

--- a/lib/Form/Type/User/UserRegisterType.php
+++ b/lib/Form/Type/User/UserRegisterType.php
@@ -61,7 +61,7 @@ class UserRegisterType extends AbstractType
         $resolver
             ->setDefaults([
                 'data_class' => '\eZ\Publish\API\Repository\Values\User\UserCreateStruct',
-                'translation_domain' => 'ezrepoforms_content',
+                'translation_domain' => 'ezrepoforms_user_registration',
             ])
             ->setRequired(['languageCode']);
     }

--- a/lib/Security/UserRegisterPolicyProvider.php
+++ b/lib/Security/UserRegisterPolicyProvider.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Security;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
+
+/**
+ * Adds the user/register policy.
+ */
+class UserRegisterPolicyProvider implements PolicyProviderInterface
+{
+    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    {
+        $configBuilder->addConfig(['user' => ['register' => null]]);
+    }
+}

--- a/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
@@ -11,27 +11,28 @@ namespace EzSystems\RepositoryForms\UserRegister;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Loads the registration user group from a configured, injected group ID.
+ * Loads the registration content type from a configured, injected content type identifier.
  */
-class ConfigurableRegistrationGroupLoader
+class ConfigurableRegistrationContentTypeLoader
     extends ConfigurableSudoRepositoryLoader
-    implements RegistrationGroupLoader
+    implements RegistrationContentTypeLoader
 {
-    public function loadGroup()
+    public function loadContentType()
     {
         return $this->sudo(
             function () {
-                return $this->getRepository()
-                    ->getUserService()
-                    ->loadUserGroup(
-                        $this->getParam('groupId')
-                    );
+                return
+                    $this->getRepository()
+                        ->getContentTypeService()
+                        ->loadContentTypeByIdentifier(
+                            $this->getParam('contentTypeIdentifier')
+                        );
             }
         );
     }
 
     protected function configureOptions(OptionsResolver $optionsResolver)
     {
-        $optionsResolver->setRequired('groupId');
+        $optionsResolver->setRequired('contentTypeIdentifier');
     }
 }

--- a/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use eZ\Publish\API\Repository\Repository;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use InvalidArgumentException;
+
+/**
+ * Loads the registration user group from a configured, injected group ID.
+ */
+class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $groupId;
+
+    public function __construct(Repository $repository, $groupId = null)
+    {
+        $this->repository = $repository;
+        $this->groupId = $groupId;
+    }
+
+    public function setGroupId($groupId)
+    {
+        $this->groupId = $groupId;
+
+        return $this;
+    }
+
+    public function getParentGroup(UserCreateData $userCreateData)
+    {
+        if ($this->groupId === null) {
+            throw new InvalidArgumentException('groupId needs to be set');
+        }
+
+        return $this->repository->sudo(
+            function () {
+                return $this->repository->getUserService()->loadUserGroup($this->groupId);
+            }
+        );
+    }
+}

--- a/lib/UserRegister/ConfigurableSudoRepositoryLoader.php
+++ b/lib/UserRegister/ConfigurableSudoRepositoryLoader.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use Closure;
+use eZ\Publish\API\Repository\Repository;
+use OutOfBoundsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A repository data loader that uses the sudo() method.
+ *
+ * It comes with parameter handling, either by passing an array of (supported) options
+ * to the constructor, or using the setParam() method.
+ *
+ * Implementations will call load() with a repository callback as an argument.
+ * The repository can be accessed using getRepository().
+ *
+ * ** Use with care**.
+ */
+abstract class ConfigurableSudoRepositoryLoader
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var array
+     */
+    private $params = [];
+
+    public function __construct(Repository $repository, $params = null)
+    {
+        $this->repository = $repository;
+        $this->params = $params;
+    }
+
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
+
+        return $this;
+    }
+
+    protected function getParam($name)
+    {
+        if (!isset($this->params[$name])) {
+            throw new OutOfBoundsException("No such param '$name'");
+        }
+
+        return $this->params[$name];
+    }
+
+    /**
+     * @return Repository
+     */
+    protected function getRepository()
+    {
+        return $this->repository;
+    }
+
+    protected function sudo(Closure $callback)
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $this->params = $resolver->resolve($this->params);
+
+        return $this->repository->sudo($callback);
+    }
+
+    abstract protected function configureOptions(OptionsResolver $optionsResolver);
+}

--- a/lib/UserRegister/RegistrationContentTypeLoader.php
+++ b/lib/UserRegister/RegistrationContentTypeLoader.php
@@ -8,17 +8,17 @@
  */
 namespace EzSystems\RepositoryForms\UserRegister;
 
-use eZ\Publish\API\Repository\Values\User\UserGroup;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
- * Used to load a user group during registration.
+ * Loads the content type used by user registration.
  */
-interface RegistrationGroupLoader
+interface RegistrationContentTypeLoader
 {
     /**
-     * Loads a parent group.
+     * Gets the Content Type used by user registration.
      *
-     * @return UserGroup
+     * @return ContentType
      */
-    public function loadGroup();
+    public function loadContentType();
 }

--- a/lib/UserRegister/RegistrationGroupLoader.php
+++ b/lib/UserRegister/RegistrationGroupLoader.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+
+/**
+ * Used to set the parent group during user registration.
+ */
+interface RegistrationGroupLoader
+{
+    /**
+     * Gets the parent group of $userCreateData.
+     *
+     * @param UserCreateData $userCreateData
+     *
+     * @return UserGroup
+     */
+    public function getParentGroup(UserCreateData $userCreateData);
+}


### PR DESCRIPTION
> Epic: [EZP-24258](https://jira.ez.no/browse/EZP-24258)

Adds real user registration support through the `/register` route. Add the `user/register` policy to the anonymous user to enable it (or use the admin account). After registering, the user is redirected to a page that confirms registration.

<img width="340" alt="user_register_screenshot" src="https://cloud.githubusercontent.com/assets/235928/15786461/156f3090-29bd-11e6-9055-8a56de634a52.png">

### Tasks
- [x] Implement the registration form ([EZP-25730](http://jira.ez.no/browse/EZP-25730))
- [x] Add a custom `user/register` policy, and deny the `/register` route if the user does not have this policy ([EZP-25864](https://jira.ez.no/browse/EZP-25864))
- [x] Make target user group configurable ([EZP-25840](https://jira.ez.no/browse/EZP-25840), #88)
- [ ] ~~Make the identifier of the Content Type used for user registration configurable~~
- [x] Read user creation language from prioritized languages ([EZP-25863](https://jira.ez.no/browse/EZP-25863))
- [x] Fix the register button's label
- [ ] Improve the user account's form formatting ?