### PR TITLE
EZP-25863: Made user register use the main language

### DIFF
--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -26,6 +26,11 @@ class UserRegisterController extends Controller
     private $contentTypeService;
 
     /**
+     * @var UserRegisterMapper
+     */
+    private $userRegisterMapper;
+
+    /**
      * @var RegistrationGroupLoader
      */
     private $registrationGroupLoader;
@@ -47,11 +52,13 @@ class UserRegisterController extends Controller
 
     public function __construct(
         ContentTypeService $contentTypeService,
+        UserRegisterMapper $userRegisterMapper,
         RegistrationGroupLoader $registrationGroupLoader,
         ActionDispatcherInterface $contentActionDispatcher,
         Repository $repository
     ) {
         $this->contentTypeService = $contentTypeService;
+        $this->userRegisterMapper = $userRegisterMapper;
         $this->registrationGroupLoader = $registrationGroupLoader;
         $this->contentActionDispatcher = $contentActionDispatcher;
         $this->repository = $repository;
@@ -83,18 +90,16 @@ class UserRegisterController extends Controller
             throw new \Exception('You are not allowed to register a new account');
         }
 
-        $language = 'eng-GB';
-
         $contentType = $this->repository->sudo(
             function () {
                 return $this->contentTypeService->loadContentTypeByIdentifier('user');
             }
         );
 
-        $data = (new UserRegisterMapper())->mapToFormData($contentType, [
-            'mainLanguageCode' => $language,
-        ]);
+        $data = $this->userRegisterMapper->mapToFormData($contentType);
         $data->addParentGroup($this->registrationGroupLoader->getParentGroup($data));
+
+        $language = $data->mainLanguageCode;
 
         $form = $this->createForm(new UserRegisterType(), $data, ['languageCode' => $language]);
         $form->handleRequest($request);

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -49,6 +49,8 @@ parameters:
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
 
+    ezrepoforms.user_content_type_identifier: "user"
+
 services:
     # deprecated in 1.1, will be removed in 2.0
     ezrepoforms.field_type_form_mapper.registry:
@@ -301,7 +303,6 @@ services:
     ezrepoforms.controller.user_register:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
-            - "@ezpublish.api.service.content_type"
             - "@ezrepoforms.form_data_mapper.user_register"
             - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
@@ -318,9 +319,19 @@ services:
         arguments:
             - "@ezpublish.api.repository"
         calls:
-            - [setGroupId, ["$users.registration_group$"]]
+            - [setParam, ["groupId", "$users.registration_group$"]]
+
+    ezrepoforms.user_register.registration_content_type_loader.configurable:
+        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
+        arguments:
+            - "@ezpublish.api.repository"
+        calls:
+            - [setParam, ["contentTypeIdentifier", "%ezrepoforms.user_content_type_identifier%"]]
 
     ezrepoforms.form_data_mapper.user_register:
         class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
+        arguments:
+            - "@ezrepoforms.user_register.registration_content_type_loader.configurable"
+            - "@ezrepoforms.user_register.registration_group_loader.configurable"
         calls:
-            - [setParam, ['language', "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]
+            - [setParam, ["language", "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -302,6 +302,7 @@ services:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
             - "@ezpublish.api.service.content_type"
+            - "@ezrepoforms.form_data_mapper.user_register"
             - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
             - "@ezpublish.api.repository"
@@ -315,6 +316,11 @@ services:
     ezrepoforms.user_register.registration_group_loader.configurable:
         class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
         arguments:
-            - @ezpublish.api.repository
+            - "@ezpublish.api.repository"
         calls:
             - [setGroupId, ["$users.registration_group$"]]
+
+    ezrepoforms.form_data_mapper.user_register:
+        class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
+        calls:
+            - [setParam, ['language', "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -17,15 +17,38 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * Form data mapper for user registration / creation.
  */
-class UserRegisterMapper implements FormDataMapperInterface
+class UserRegisterMapper
 {
+    /**
+     * @var array
+     */
+    private $params;
+
+    public function __construct(array $params = [])
+    {
+        $this->params = $params;
+    }
+
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
+    }
+
+    /**
+     * @param array $params Parameters override array. See configureOptions().
+     *
+     * @return UserCreateData
+     */
     public function mapToFormData(ValueObject $contentType, array $params = [])
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
-        $params = $resolver->resolve($params);
+        $params = $resolver->resolve($params + $this->params);
 
-        $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
+        $data = new UserCreateData([
+            'contentType' => $contentType,
+            'mainLanguageCode' => $this->params['language'],
+        ]);
         if (isset($params['parentGroup'])) {
             $data->addParentGroup($params['parentGroup']);
         }
@@ -35,7 +58,7 @@ class UserRegisterMapper implements FormDataMapperInterface
                 'fieldDefinition' => $fieldDef,
                 'field' => new Field([
                     'fieldDefIdentifier' => $fieldDef->identifier,
-                    'languageCode' => $params['mainLanguageCode'],
+                    'languageCode' => $params['language'],
                 ]),
                 'value' => $fieldDef->defaultValue,
             ]));
@@ -47,8 +70,8 @@ class UserRegisterMapper implements FormDataMapperInterface
     private function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver
-            ->setRequired(['mainLanguageCode'])
-            ->setDefined(['parentGroup'])
-            ->addAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup');
+            ->setDefined('parentGroup')
+            ->addAllowedTypes('parentGroup', '\eZ\Publish\API\Repository\Values\User\UserGroup')
+            ->setRequired('language');
     }
 }

--- a/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
@@ -12,9 +12,9 @@ use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Loads the registration user group from a configured, injected group ID.
+ * Loads the registration content type from a configured, injected content type identifier.
  */
-class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
+class ConfigurableRegistrationContentTypeLoader implements RegistrationContentTypeLoader
 {
     /**
      * @var Repository
@@ -39,7 +39,7 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
         return $this;
     }
 
-    public function loadGroup()
+    public function loadContentType()
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -47,15 +47,18 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
 
         return $this->repository->sudo(
             function () {
-                return $this->repository->getUserService()->loadUserGroup(
-                    $this->params['groupId']
-                );
+                return
+                    $this->repository
+                        ->getContentTypeService()
+                        ->loadContentTypeByIdentifier(
+                            $this->params['contentTypeIdentifier']
+                        );
             }
         );
     }
 
     private function configureOptions(OptionsResolver $optionsResolver)
     {
-        $optionsResolver->setRequired('groupId');
+        $optionsResolver->setRequired('contentTypeIdentifier');
     }
 }

--- a/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationContentTypeLoader.php
@@ -8,56 +8,30 @@
  */
 namespace EzSystems\RepositoryForms\UserRegister;
 
-use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Loads the registration content type from a configured, injected content type identifier.
  */
-class ConfigurableRegistrationContentTypeLoader implements RegistrationContentTypeLoader
+class ConfigurableRegistrationContentTypeLoader
+    extends ConfigurableSudoRepositoryLoader
+    implements RegistrationContentTypeLoader
 {
-    /**
-     * @var Repository
-     */
-    private $repository;
-
-    /**
-     * @var array
-     */
-    private $params = [];
-
-    public function __construct(Repository $repository, $params = null)
-    {
-        $this->repository = $repository;
-        $this->params = $params;
-    }
-
-    public function setParam($name, $value)
-    {
-        $this->params[$name] = $value;
-
-        return $this;
-    }
-
     public function loadContentType()
     {
-        $resolver = new OptionsResolver();
-        $this->configureOptions($resolver);
-        $this->params = $resolver->resolve($this->params);
-
-        return $this->repository->sudo(
+        return $this->sudo(
             function () {
                 return
-                    $this->repository
+                    $this->getRepository()
                         ->getContentTypeService()
                         ->loadContentTypeByIdentifier(
-                            $this->params['contentTypeIdentifier']
+                            $this->getParam('contentTypeIdentifier')
                         );
             }
         );
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    protected function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver->setRequired('contentTypeIdentifier');
     }

--- a/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
+++ b/lib/UserRegister/ConfigurableRegistrationGroupLoader.php
@@ -8,53 +8,29 @@
  */
 namespace EzSystems\RepositoryForms\UserRegister;
 
-use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Loads the registration user group from a configured, injected group ID.
  */
-class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
+class ConfigurableRegistrationGroupLoader
+    extends ConfigurableSudoRepositoryLoader
+    implements RegistrationGroupLoader
 {
-    /**
-     * @var Repository
-     */
-    private $repository;
-
-    /**
-     * @var array
-     */
-    private $params = [];
-
-    public function __construct(Repository $repository, $params = null)
-    {
-        $this->repository = $repository;
-        $this->params = $params;
-    }
-
-    public function setParam($name, $value)
-    {
-        $this->params[$name] = $value;
-
-        return $this;
-    }
-
     public function loadGroup()
     {
-        $resolver = new OptionsResolver();
-        $this->configureOptions($resolver);
-        $this->params = $resolver->resolve($this->params);
-
-        return $this->repository->sudo(
+        return $this->sudo(
             function () {
-                return $this->repository->getUserService()->loadUserGroup(
-                    $this->params['groupId']
-                );
+                return $this->getRepository()
+                    ->getUserService()
+                    ->loadUserGroup(
+                        $this->getParam('groupId')
+                    );
             }
         );
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    protected function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver->setRequired('groupId');
     }

--- a/lib/UserRegister/ConfigurableSudoRepositoryLoader.php
+++ b/lib/UserRegister/ConfigurableSudoRepositoryLoader.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\UserRegister;
+
+use Closure;
+use eZ\Publish\API\Repository\Repository;
+use OutOfBoundsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A repository data loader that uses the sudo() method.
+ *
+ * It comes with parameter handling, either by passing an array of (supported) options
+ * to the constructor, or using the setParam() method.
+ *
+ * Implementations will call load() with a repository callback as an argument.
+ * The repository can be accessed using getRepository().
+ *
+ * ** Use with care**.
+ */
+abstract class ConfigurableSudoRepositoryLoader
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var array
+     */
+    private $params = [];
+
+    public function __construct(Repository $repository, $params = null)
+    {
+        $this->repository = $repository;
+        $this->params = $params;
+    }
+
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
+
+        return $this;
+    }
+
+    protected function getParam($name)
+    {
+        if (!isset($this->params[$name])) {
+            throw new OutOfBoundsException("No such param '$name'");
+        }
+
+        return $this->params[$name];
+    }
+
+    /**
+     * @return Repository
+     */
+    protected function getRepository()
+    {
+        return $this->repository;
+    }
+
+    protected function sudo(Closure $callback)
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $this->params = $resolver->resolve($this->params);
+
+        return $this->repository->sudo($callback);
+    }
+
+    abstract protected function configureOptions(OptionsResolver $optionsResolver);
+}

--- a/lib/UserRegister/RegistrationContentTypeLoader.php
+++ b/lib/UserRegister/RegistrationContentTypeLoader.php
@@ -8,17 +8,17 @@
  */
 namespace EzSystems\RepositoryForms\UserRegister;
 
-use eZ\Publish\API\Repository\Values\User\UserGroup;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
- * Used to load a user group during registration.
+ * Loads the content type used by user registration.
  */
-interface RegistrationGroupLoader
+interface RegistrationContentTypeLoader
 {
     /**
-     * Loads a parent group.
+     * Gets the Content Type used by user registration.
      *
-     * @return UserGroup
+     * @return ContentType
      */
-    public function loadGroup();
+    public function loadContentType();
 }


### PR DESCRIPTION
> Implements [EZP-25863](https://jira.ez.no/browse/EZP-25863)

Changes the hardcoded `"eng-GB"` to the site's most prioritized language.

The `UserRegisterMapper` is now a service. It is changed to accept parameters using a `setParam` method, that accepts `"language"`. The language is read from the configuration using the expression language (see `services.yml`).

Other changes (refactoring commit):
- ContentType and Parent Group loading is now handled by dedicated loaders ( `RegistrationContentTypeLoader` and `RegistrationGroupLoader`), both used by the `UserRegisterMapper`.

### TODO
- [x] Split the Content Type change to its own commit.
- [ ] Tests