### PR TITLE
Make user registration templates customizable

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -22,3 +22,4 @@ repository-forms:
             contexts:
                 - EzSystems\RepositoryForms\Features\Context\UserRegistrationContext
                 - Behat\MinkExtension\Context\MinkContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -9,12 +9,10 @@
 namespace EzSystems\RepositoryFormsBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
-use eZ\Publish\API\Repository\Repository;
 use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
-use EzSystems\RepositoryForms\UserRegister\RegistrationGroupLoader;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserRegisterController extends Controller
@@ -36,14 +34,10 @@ class UserRegisterController extends Controller
 
     public function __construct(
         UserRegisterMapper $userRegisterMapper,
-        RegistrationGroupLoader $registrationGroupLoader,
-        ActionDispatcherInterface $contentActionDispatcher,
-        Repository $repository
+        ActionDispatcherInterface $contentActionDispatcher
     ) {
         $this->userRegisterMapper = $userRegisterMapper;
-        $this->registrationGroupLoader = $registrationGroupLoader;
         $this->contentActionDispatcher = $contentActionDispatcher;
-        $this->repository = $repository;
     }
 
     /**

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -13,6 +13,8 @@ use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
+use EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView;
+use EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserRegisterController extends Controller
@@ -27,28 +29,12 @@ class UserRegisterController extends Controller
      */
     private $contentActionDispatcher;
 
-    /**
-     * @var string
-     */
-    private $pagelayout;
-
     public function __construct(
         UserRegisterMapper $userRegisterMapper,
         ActionDispatcherInterface $contentActionDispatcher
     ) {
         $this->userRegisterMapper = $userRegisterMapper;
         $this->contentActionDispatcher = $contentActionDispatcher;
-    }
-
-    /**
-     * @param string $pagelayout
-     * @return ContentEditController
-     */
-    public function setPagelayout($pagelayout)
-    {
-        $this->pagelayout = $pagelayout;
-
-        return $this;
     }
 
     /**
@@ -83,18 +69,14 @@ class UserRegisterController extends Controller
             }
         }
 
-        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
-            'form' => $form->createView(),
-            'languageCode' => $language,
-            'pagelayout' => $this->pagelayout,
-        ]);
+        return new UserRegisterFormView(
+            null,
+            ['form' => $form->createView()]
+        );
     }
 
     public function registerConfirmAction()
     {
-        return $this->render(
-            '@EzSystemsRepositoryForms/User/register_confirmation.html.twig',
-            ['pagelayout' => $this->pagelayout]
-        );
+        return new UserRegisterConfirmView();
     }
 }

--- a/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -23,12 +23,23 @@ class UserRegistration extends AbstractParser
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
         $nodeBuilder
-            ->arrayNode('users')
-                ->info('Users configuration')
+            ->arrayNode('user_registration')
+                ->info('User registration configuration')
                 ->children()
-                    ->scalarNode('registration_group_id')
+                    ->scalarNode('group_id')
                         ->info('Content id of the user group where users who register are created.')
                         ->defaultValue(11)
+                    ->end()
+                    ->arrayNode('templates')
+                        ->info('User registration templates.')
+                        ->children()
+                            ->scalarNode('form')
+                                ->info('Template to use for registration form rendering.')
+                            ->end()
+                            ->scalarNode('confirmation')
+                                ->info('Template to use for registration confirmation rendering.')
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();
@@ -36,9 +47,33 @@ class UserRegistration extends AbstractParser
 
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
-        if (!empty($scopeSettings['users'])) {
-            $contextualizer->setContextualParameter('users.registration_group', $currentScope,
-                $scopeSettings['users']['registration_group_id']);
+        if (empty($scopeSettings['user_registration'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['user_registration'];
+
+        if (!empty($settings['group_id'])) {
+            $contextualizer->setContextualParameter(
+                'user_registration.group_id',
+                $currentScope,
+                $settings['group_id']);
+        }
+
+        if (!empty($settings['templates']['form'])) {
+            $contextualizer->setContextualParameter(
+                'user_registration.templates.form',
+                $currentScope,
+                $settings['templates']['form']
+            );
+        }
+
+        if (!empty($settings['templates']['confirmation'])) {
+            $contextualizer->setContextualParameter(
+                'user_registration.templates.confirmation',
+                $currentScope,
+                $settings['templates']['confirmation']
+            );
         }
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -1,2 +1,5 @@
 parameters:
-    ezsettings.default.users.registration_group: 11
+    ezsettings.default.user_registration.group_id: 11
+    ezsettings.default.user_registration.templates.form: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
+    ezsettings.default.user_registration.templates.confirmation: "EzSystemsRepositoryFormsBundle:User:register_confirmation.html.twig"
+

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -304,9 +304,7 @@ services:
         class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
         arguments:
             - "@ezrepoforms.form_data_mapper.user_register"
-            - "@ezrepoforms.user_register.registration_group_loader.configurable"
             - "@ezrepoforms.action_dispatcher.content"
-            - "@ezpublish.api.repository"
         parent: ezpublish.controller.base
         calls:
             - [setPagelayout, ["$pagelayout$"]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -306,8 +306,6 @@ services:
             - "@ezrepoforms.form_data_mapper.user_register"
             - "@ezrepoforms.action_dispatcher.content"
         parent: ezpublish.controller.base
-        calls:
-            - [setPagelayout, ["$pagelayout$"]]
 
     ez_content_edit:
         alias: ezrepoforms.controller.content_edit
@@ -317,7 +315,7 @@ services:
         arguments:
             - "@ezpublish.api.repository"
         calls:
-            - [setParam, ["groupId", "$users.registration_group$"]]
+            - [setParam, ["groupId", "$user_registration.group_id$"]]
 
     ezrepoforms.user_register.registration_content_type_loader.configurable:
         class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
@@ -333,3 +331,12 @@ services:
             - "@ezrepoforms.user_register.registration_group_loader.configurable"
         calls:
             - [setParam, ["language", "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]
+
+    ezrepoforms.user_register.view_templates_listener:
+        class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
+        tags:
+            - { name: kernel.event_subscriber }
+        calls:
+            - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView', "$user_registration.templates.form$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
+            - [setPagelayout, ["$pagelayout$"]]

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -10,7 +10,6 @@ namespace EzSystems\RepositoryForms\Features\Context;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext;
@@ -265,9 +264,9 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     }
 
     /**
-     * @Given /^the following configuration:$/
+     * @Given /^the following user registration group configuration:$/
      */
-    public function theFollowingConfiguration(PyStringNode $extraConfigurationString)
+    public function addUserRegistrationConfiguration(PyStringNode $extraConfigurationString)
     {
         $extraConfigurationString = str_replace(
             '<userGroupContentId>',
@@ -275,20 +274,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
             $extraConfigurationString
         );
 
-        $extraConfig = Yaml::parse($extraConfigurationString);
-
-        $platformConfig = Yaml::parse(file_get_contents('app/config/ezplatform_behat.yml'));
-        $platformConfig['ezpublish'] = array_merge(
-            $platformConfig['ezpublish'],
-            $extraConfig['ezpublish']
-        );
-
-        file_put_contents(
-            'app/config/ezplatform_behat.yml',
-            Yaml::dump($platformConfig, 5, 4)
-        );
-
-        echo shell_exec('php app/console --env=behat cache:clear');
+        $this->yamlConfigurationContext->addConfiguration(Yaml::parse($extraConfigurationString));
     }
 
     /**

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -9,8 +9,11 @@ namespace EzSystems\RepositoryForms\Features\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\User;
@@ -18,6 +21,7 @@ use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
 use PHPUnit_Framework_Assert;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
 class UserRegistrationContext extends RawMinkContext implements Context, SnippetAcceptingContext
@@ -39,11 +43,24 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     private $customUserGroup;
 
     /**
+     * @var YamlConfigurationContext
+     */
+    private $yamlConfigurationContext;
+
+    /**
      * @injectService $repository @ezpublish.api.repository
      */
     public function __construct(Repository $repository)
     {
         $this->setRepository($repository);
+    }
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $this->yamlConfigurationContext = $scope->getEnvironment()->getContext(
+            'eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext'
+        );
     }
 
     /**
@@ -300,6 +317,55 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
         PHPUnit_Framework_Assert::assertEquals(
             $this->customUserGroup->id,
             $userGroups[0]->id
+        );
+    }
+
+    /**
+     * @Given /^the following user registration templates configuration:$/
+     */
+    public function addRegistrationTemplatesConfiguration(PyStringNode $string)
+    {
+        $this->yamlConfigurationContext->addConfiguration(Yaml::parse($string));
+    }
+
+    /**
+     * @Given /^the following template in "([^"]*)":$/
+     */
+    public function createTemplateAt($path, PyStringNode $contents)
+    {
+        $fs = new Filesystem();
+        $fs->mkdir(dirname($path));
+        $fs->dumpFile($path, $contents);
+    }
+
+    /**
+     * @Then /^the confirmation page is rendered using the "([^"]*)" template$/
+     * @Then /^the form is rendered using the "([^"]*)" template$/
+     *
+     * @param string $template
+     *        The template path to look for.
+     *        If relative to app/Resources/views (example: user/register.html.twig),
+     *        the path is checked with the :path:file.html.twig syntax as well.
+     */
+    public function thePageIsRenderedUsingTheTemplateConfiguredIn($template)
+    {
+        $html = $this->getSession()->getPage()->getOuterHtml();
+        $found = (strpos($html, sprintf('<!-- STOP %s -->', $template)) !== false);
+
+        if (!$found && strpos($template, ':') === false) {
+            $alternativeTemplate = sprintf(
+                ':%s:%s',
+                dirname($template),
+                basename($template)
+            );
+            $found = (strpos($html, sprintf('<!-- STOP %s -->', $alternativeTemplate)) !== false);
+        }
+
+        PHPUnit_Framework_Assert::assertTrue(
+            $found,
+            "Couldn't find $template " .
+            (isset($alternativeTemplate) ? "nor $alternativeTemplate " : ' ') .
+            "in HTML:\n\n$html"
         );
     }
 }

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -27,8 +27,48 @@ Scenario: The user group where registered users are created can be customized
       ezpublish:
         system:
           default:
-            users:
-              registration_group_id: <userGroupContentId>
+            user_registration:
+              group_id: <userGroupContentId>
       """
      When I register a user account
      Then the user is created in this user group
+
+Scenario: The user registration templates can be customized
+    Given I do have the user/register policy
+    Given the following user registration templates configuration:
+      """
+      ezpublish:
+        system:
+          default:
+            user_registration:
+              templates:
+                form: 'user/registration_form.html.twig'
+                confirmation: 'user/registration_confirmation.html.twig'
+      """
+      And the following template in "app/Resources/views/user/registration_form.html.twig":
+      """
+      {% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
+
+      {% block content %}
+          {% import "EzSystemsRepositoryFormsBundle:Content:content_form.html.twig" as contentForms %}
+
+          <section class="ez-content-edit">
+              {{ contentForms.display_form(form) }}
+          </section>
+      {% endblock %}
+      """
+      And the following template in "app/Resources/views/user/registration_confirmation.html.twig":
+      """
+      {% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
+
+      {% block content %}
+          <h1>Your account has been created</h1>
+          <p class="user-register-confirmation-message">
+              Thank you for registering an account. You can now <a href="{{ path('login') }}">login</a>.
+          </p>
+      {% endblock %}
+      """
+     When I go to "/register"
+     Then the form is rendered using the "user/registration_form.html.twig" template
+     When I register a user account
+     Then the confirmation page is rendered using the "user/registration_confirmation.html.twig" template

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -22,7 +22,7 @@ Scenario: A new user account can be registered from "/register"
 
 Scenario: The user group where registered users are created can be customized
     Given a User Group
-      And the following configuration:
+      And the following user registration group configuration:
       """
       ezpublish:
         system:
@@ -35,7 +35,7 @@ Scenario: The user group where registered users are created can be customized
 
 Scenario: The user registration templates can be customized
     Given I do have the user/register policy
-    Given the following user registration templates configuration:
+      And the following user registration templates configuration:
       """
       ezpublish:
         system:

--- a/lib/EventListener/ViewTemplatesListener.php
+++ b/lib/EventListener/ViewTemplatesListener.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Sets the templates used by the user controller.
+ */
+class ViewTemplatesListener implements EventSubscriberInterface
+{
+    /**
+     * Hash of [View type FQN] => template.
+     * @var array
+     */
+    private $viewTemplates;
+
+    /**
+     * @var string
+     */
+    private $pagelayout;
+
+    public static function getSubscribedEvents()
+    {
+        return [MVCEvents::PRE_CONTENT_VIEW => 'setUserRegistrationTemplates'];
+    }
+
+    /**
+     * Sets the $template to use for objects of class $viewClass.
+     *
+     * @param string $viewClass FQN of a View class
+     * @param string $template
+     */
+    public function setViewTemplate($viewClass, $template)
+    {
+        $this->viewTemplates[$viewClass] = $template;
+    }
+
+    /**
+     * Sets the pagelayout template to assign to views.
+     *
+     * @param string $pagelayout
+     */
+    public function setPagelayout($pagelayout)
+    {
+        $this->pagelayout = $pagelayout;
+    }
+
+    /**
+     * If the event's view has a defined template, sets the view's template identifier,
+     * and the 'pagelayout' parameter.
+     *
+     * @param PreContentViewEvent $event
+     */
+    public function setUserRegistrationTemplates(PreContentViewEvent $event)
+    {
+        $view = $event->getContentView();
+
+        foreach ($this->viewTemplates as $viewClass => $template) {
+            if ($view instanceof $viewClass) {
+                $view->setTemplateIdentifier($template);
+                $view->addParameters(['pagelayout' => $this->pagelayout]);
+            }
+        }
+    }
+}

--- a/lib/UserRegister/View/UserRegisterConfirmView.php
+++ b/lib/UserRegister/View/UserRegisterConfirmView.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\UserRegister\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class UserRegisterConfirmView extends BaseView implements View
+{
+}

--- a/lib/UserRegister/View/UserRegisterFormView.php
+++ b/lib/UserRegister/View/UserRegisterFormView.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\UserRegister\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class UserRegisterFormView extends BaseView implements View
+{
+}


### PR DESCRIPTION
> Implements [EZP-25373](https://jira.ez.no/browse/EZP-25373)
> Status: ready for review
> [Behat scenario](https://github.com/ezsystems/repository-forms/blob/ezp25373-user_registration_templates/features/User/Registration/user_registration.feature#L36-L74)

### Usage
Registration form and confirmation templates can be customized using the `ezpublish.user_registration.templates` siteaccess aware settings:

```twig
ezpublish:
  system:
    default:
      user_registration:
        templates:
          form: 'path/to/user/registration_form.html.twig'
          confirmation: 'path/to/user/registration_confirmation.html.twig'
```

Registration group configuration is adapted to the `users` -> `user_registration` setting modification above:

```
ezpublish:
  system:
    default:
      user_registration:
        group_id: 123
```

### Internal changes
- Changes the UserController to return `View` objects (`UserRegisterFormView` and `UserRegisterConfirmView`)
- Adds `$user_registration.templates.form$` and `$user_registration.templates.confirmation$` siteaccess aware container parameters
- Adds a `UserRegistrationViewTemplates` event listener that receives the configured templates and, when applicable, sets them in the View objects when applicable
- Removes `pagelayout` handling in the controller, and moves it to the event listener

### TODO
- [x] Fix the failures
- [x] Templates semantic config