### PR TITLE
Throw an UnauthorizedHttpException if not allowed to register

### DIFF
--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -16,6 +16,7 @@ use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
 use EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView;
 use EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UserRegisterController extends Controller
 {
@@ -49,7 +50,7 @@ class UserRegisterController extends Controller
     public function registerAction(Request $request)
     {
         if (!$this->isGranted(new Attribute('user', 'register'))) {
-            throw new \Exception('You are not allowed to register a new account');
+            throw new UnauthorizedHttpException('You are not allowed to register a new account');
         }
 
         $data = $this->userRegisterMapper->mapToFormData();


### PR DESCRIPTION
Changes the exception thrown when the user doesn't have the `user/register` policy from a basic `Exception` to `UnauthorizedHttpException`.

Benefit is that it shows a permission error and not a system one in production mode.