### PR TITLE
EZP-26128: As a Developer I want deprecation issues resolved, so that application logs are clean

### DIFF
--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -73,7 +73,7 @@ class ContentEditController extends Controller
             'mainLanguageCode' => $language,
             'parentLocation' => $this->locationService->newLocationCreateStruct($parentLocationId),
         ]);
-        $form = $this->createForm(new ContentEditType(), $data, ['languageCode' => $language]);
+        $form = $this->createForm(ContentEditType::class, $data, ['languageCode' => $language]);
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -56,7 +56,7 @@ class UserRegisterController extends Controller
         $data = $this->userRegisterMapper->mapToFormData();
         $language = $data->mainLanguageCode;
         $form = $this->createForm(
-            new UserRegisterType(),
+            UserRegisterType::class,
             $data,
             ['languageCode' => $language]
         );

--- a/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -54,7 +54,7 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
         $formMappers = $container->findTaggedServiceIds('ez.fieldType.formMapper');
         foreach (array_keys($formMappers) as $serviceId) {
             @trigger_error(
-                'The ez.fieldType.formMapper service tag from $serviceId is deprecated in ezsystems/repository-forms 1.3, ' .
+                "The ez.fieldType.formMapper service tag from $serviceId is deprecated in ezsystems/repository-forms 1.3, " .
                 "and will be removed in version 2.0\n" .
                 'Use ez.fieldFormMapper.value and/or ez.fieldFormMapper.definition instead.',
                 E_USER_DEPRECATED

--- a/bundle/Resources/config/language.yml
+++ b/bundle/Resources/config/language.yml
@@ -6,7 +6,7 @@ parameters:
 services:
     ezrepoforms.validator.unique_language_code:
         class: %ezrepoforms.validator.unique_language_code.class%
-        arguments: [@ezpublish.api.service.language]
+        arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_language_code }
 
@@ -16,6 +16,6 @@ services:
 
     ezrepoforms.form_processor.language:
         class: %ezrepoforms.form_processor.language.class%
-        arguments: [@ezpublish.api.service.language]
+        arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/language.yml
+++ b/bundle/Resources/config/language.yml
@@ -5,17 +5,17 @@ parameters:
 
 services:
     ezrepoforms.validator.unique_language_code:
-        class: %ezrepoforms.validator.unique_language_code.class%
+        class: "%ezrepoforms.validator.unique_language_code.class%"
         arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_language_code }
 
     ezrepoforms.action_dispatcher.language:
-        class: %ezrepoforms.action_dispatcher.language.class%
+        class: "%ezrepoforms.action_dispatcher.language.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.form_processor.language:
-        class: %ezrepoforms.form_processor.language.class%
+        class: "%ezrepoforms.form_processor.language.class%"
         arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -34,156 +34,156 @@ parameters:
 services:
     # Form types
     ezrepoforms.policy.edit.form:
-        class: %ezrepoforms.policy.edit.form.class%
-        arguments: [%ezpublish.api.role.policy_map%, "@translator", "@ezpublish.api.service.role"]
+        class: "%ezrepoforms.policy.edit.form.class%"
+        arguments: ["%ezpublish.api.role.policy_map%", "@translator", "@ezpublish.api.service.role"]
         tags:
             - { name: form.type, alias: ezrepoforms_policy_edit }
 
     ezrepoforms.policy.limitation.form:
-        class: %ezrepoforms.policy.limitation.form.class%
+        class: "%ezrepoforms.policy.limitation.form.class%"
         arguments: ["@ezrepoforms.limitation_form_mapper.registry", "@ezrepoforms.limitation.form_mapper.null"]
         tags:
             - { name: form.type, alias: ezrepoforms_policy_limitation_edit }
 
     # Validators
     ezrepoforms.validator.unique_role_identifier:
-        class: %ezrepoforms.validator.unique_role_identifier.class%
+        class: "%ezrepoforms.validator.unique_role_identifier.class%"
         arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_role_identifier }
 
     # Action dispatchers
     ezrepoforms.action_dispatcher.role:
-        class: %ezrepoforms.action_dispatcher.role.class%
+        class: "%ezrepoforms.action_dispatcher.role.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.action_dispatcher.policy:
-        class: %ezrepoforms.action_dispatcher.policy.class%
+        class: "%ezrepoforms.action_dispatcher.policy.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     # Form processors
     ezrepoforms.form_processor.role:
-        class: %ezrepoforms.form_processor.role.class%
+        class: "%ezrepoforms.form_processor.role.class%"
         arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.policy:
-        class: %ezrepoforms.form_processor.policy.class%
+        class: "%ezrepoforms.form_processor.policy.class%"
         arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.limitation_form_mapper.registry:
-        class: %ezrepoforms.limitation_form_mapper.registry.class%
+        class: "%ezrepoforms.limitation_form_mapper.registry.class%"
 
     ezrepoforms.limitation.form_mapper.multiple_selection:
         class: EzSystems\RepositoryForms\Limitation\Mapper\MultipleSelectionBasedMapper
         abstract: true
         calls:
-            - [setFormTemplate, [%ezrepoforms.limitation.multiple_selection.template%]]
+            - [setFormTemplate, ["%ezrepoforms.limitation.multiple_selection.template%"]]
 
     ezrepoforms.limitation.form_mapper.siteaccess:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.siteaccess.class%
-        arguments: [%ezpublish.siteaccess.list%]
+        class: "%ezrepoforms.limitation.form_mapper.siteaccess.class%"
+        arguments: ["%ezpublish.siteaccess.list%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: SiteAccess }
 
     ezrepoforms.limitation.form_mapper.null:
-        class: %ezrepoforms.limitation.form_mapper.null.class%
-        arguments: [%ezrepoforms.limitation.null.template%]
+        class: "%ezrepoforms.limitation.form_mapper.null.class%"
+        arguments: ["%ezrepoforms.limitation.null.template%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: "Null" }
 
     ezrepoforms.limitation.form_mapper.contenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.contenttype.class%
+        class: "%ezrepoforms.limitation.form_mapper.contenttype.class%"
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Class }
 
     ezrepoforms.limitation.form_mapper.parentcontenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.contenttype.class%
+        class: "%ezrepoforms.limitation.form_mapper.contenttype.class%"
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentClass }
 
     ezrepoforms.limitation.form_mapper.section:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.section.class%
+        class: "%ezrepoforms.limitation.form_mapper.section.class%"
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Section }
 
     ezrepoforms.limitation.form_mapper.newsection:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.section.class%
+        class: "%ezrepoforms.limitation.form_mapper.section.class%"
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewSection }
 
     ezrepoforms.limitation.form_mapper.objectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.objectstate.class%
+        class: "%ezrepoforms.limitation.form_mapper.objectstate.class%"
         arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: State }
 
     ezrepoforms.limitation.form_mapper.newobjectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.objectstate.class%
+        class: "%ezrepoforms.limitation.form_mapper.objectstate.class%"
         arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewState }
 
     ezrepoforms.limitation.form_mapper.language:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.language.class%
+        class: "%ezrepoforms.limitation.form_mapper.language.class%"
         arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Language }
 
     ezrepoforms.limitation.form_mapper.owner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.owner.class%
+        class: "%ezrepoforms.limitation.form_mapper.owner.class%"
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Owner }
 
     ezrepoforms.limitation.form_mapper.parentowner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.owner.class%
+        class: "%ezrepoforms.limitation.form_mapper.owner.class%"
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentOwner }
 
     ezrepoforms.limitation.form_mapper.group:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.group.class%
+        class: "%ezrepoforms.limitation.form_mapper.group.class%"
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Group }
 
     ezrepoforms.limitation.form_mapper.parentgroup:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.group.class%
+        class: "%ezrepoforms.limitation.form_mapper.group.class%"
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentGroup }
 
     ezrepoforms.limitation.form_mapper.parentdepth:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
-        class: %ezrepoforms.limitation.form_mapper.parentdepth.class%
-        arguments: [%ezrepoforms.limitation.form_mapper.parentdepth.maxdepth%]
+        class: "%ezrepoforms.limitation.form_mapper.parentdepth.class%"
+        arguments: ["%ezrepoforms.limitation.form_mapper.parentdepth.maxdepth%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentDepth }
 
     ezrepoforms.limitation.form_mapper.udw_based:
         class: EzSystems\RepositoryForms\Limitation\Mapper\UDWBasedMapper
         calls:
-            - [setFormTemplate, [%ezrepoforms.limitation.udw.template%]]
+            - [setFormTemplate, ["%ezrepoforms.limitation.udw.template%"]]
 
     ezrepoforms.limitation.form_mapper.location:
         parent: ezrepoforms.limitation.form_mapper.udw_based
@@ -192,7 +192,7 @@ services:
 
     ezrepoforms.limitation.form_mapper.subtree:
         parent: ezrepoforms.limitation.form_mapper.udw_based
-        class: %ezrepoforms.limitation.form_mapper.subtree.class%
+        class: "%ezrepoforms.limitation.form_mapper.subtree.class%"
         arguments: ["@ezpublish.api.service.location"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Subtree }

--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -35,20 +35,20 @@ services:
     # Form types
     ezrepoforms.policy.edit.form:
         class: %ezrepoforms.policy.edit.form.class%
-        arguments: [%ezpublish.api.role.policy_map%, @translator, @ezpublish.api.service.role]
+        arguments: [%ezpublish.api.role.policy_map%, "@translator", "@ezpublish.api.service.role"]
         tags:
             - { name: form.type, alias: ezrepoforms_policy_edit }
 
     ezrepoforms.policy.limitation.form:
         class: %ezrepoforms.policy.limitation.form.class%
-        arguments: [@ezrepoforms.limitation_form_mapper.registry, @ezrepoforms.limitation.form_mapper.null]
+        arguments: ["@ezrepoforms.limitation_form_mapper.registry", "@ezrepoforms.limitation.form_mapper.null"]
         tags:
             - { name: form.type, alias: ezrepoforms_policy_limitation_edit }
 
     # Validators
     ezrepoforms.validator.unique_role_identifier:
         class: %ezrepoforms.validator.unique_role_identifier.class%
-        arguments: [@ezpublish.api.service.role]
+        arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_role_identifier }
 
@@ -64,13 +64,13 @@ services:
     # Form processors
     ezrepoforms.form_processor.role:
         class: %ezrepoforms.form_processor.role.class%
-        arguments: [@ezpublish.api.service.role]
+        arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.policy:
         class: %ezrepoforms.form_processor.policy.class%
-        arguments: [@ezpublish.api.service.role]
+        arguments: ["@ezpublish.api.service.role"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -99,77 +99,77 @@ services:
     ezrepoforms.limitation.form_mapper.contenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.contenttype.class%
-        arguments: [@ezpublish.api.service.content_type]
+        arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Class }
 
     ezrepoforms.limitation.form_mapper.parentcontenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.contenttype.class%
-        arguments: [@ezpublish.api.service.content_type]
+        arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentClass }
 
     ezrepoforms.limitation.form_mapper.section:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.section.class%
-        arguments: [@ezpublish.api.service.section]
+        arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Section }
 
     ezrepoforms.limitation.form_mapper.newsection:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.section.class%
-        arguments: [@ezpublish.api.service.section]
+        arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewSection }
 
     ezrepoforms.limitation.form_mapper.objectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.objectstate.class%
-        arguments: [@ezpublish.api.service.object_state]
+        arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: State }
 
     ezrepoforms.limitation.form_mapper.newobjectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.objectstate.class%
-        arguments: [@ezpublish.api.service.object_state]
+        arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewState }
 
     ezrepoforms.limitation.form_mapper.language:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.language.class%
-        arguments: [@ezpublish.api.service.language]
+        arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Language }
 
     ezrepoforms.limitation.form_mapper.owner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.owner.class%
-        arguments: [@translator]
+        arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Owner }
 
     ezrepoforms.limitation.form_mapper.parentowner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.owner.class%
-        arguments: [@translator]
+        arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentOwner }
 
     ezrepoforms.limitation.form_mapper.group:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.group.class%
-        arguments: [@translator]
+        arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Group }
 
     ezrepoforms.limitation.form_mapper.parentgroup:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: %ezrepoforms.limitation.form_mapper.group.class%
-        arguments: [@translator]
+        arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentGroup }
 
@@ -193,6 +193,6 @@ services:
     ezrepoforms.limitation.form_mapper.subtree:
         parent: ezrepoforms.limitation.form_mapper.udw_based
         class: %ezrepoforms.limitation.form_mapper.subtree.class%
-        arguments: [@ezpublish.api.service.location]
+        arguments: ["@ezpublish.api.service.location"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Subtree }

--- a/bundle/Resources/config/section.yml
+++ b/bundle/Resources/config/section.yml
@@ -6,7 +6,7 @@ parameters:
 services:
     ezrepoforms.validator.unique_section_identifier:
         class: %ezrepoforms.validator.unique_section_identifier.class%
-        arguments: [@ezpublish.api.service.section]
+        arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_section_identifier }
 
@@ -16,6 +16,6 @@ services:
 
     ezrepoforms.form_processor.section:
         class: %ezrepoforms.form_processor.section.class%
-        arguments: [@ezpublish.api.service.section]
+        arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/section.yml
+++ b/bundle/Resources/config/section.yml
@@ -5,17 +5,17 @@ parameters:
 
 services:
     ezrepoforms.validator.unique_section_identifier:
-        class: %ezrepoforms.validator.unique_section_identifier.class%
+        class: "%ezrepoforms.validator.unique_section_identifier.class%"
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_section_identifier }
 
     ezrepoforms.action_dispatcher.section:
-        class: %ezrepoforms.action_dispatcher.section.class%
+        class: "%ezrepoforms.action_dispatcher.section.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.form_processor.section:
-        class: %ezrepoforms.form_processor.section.class%
+        class: "%ezrepoforms.form_processor.section.class%"
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/section.yml
+++ b/bundle/Resources/config/section.yml
@@ -2,6 +2,7 @@ parameters:
     ezrepoforms.validator.unique_section_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueSectionIdentifierValidator
     ezrepoforms.action_dispatcher.section.class: EzSystems\RepositoryForms\Form\ActionDispatcher\SectionDispatcher
     ezrepoforms.form_processor.section.class: EzSystems\RepositoryForms\Form\Processor\SectionFormProcessor
+    ezrepoforms.section.delete.form_type.class: EzSystems\RepositoryForms\Form\Type\Section\SectionDeleteType
 
 services:
     ezrepoforms.validator.unique_section_identifier:
@@ -19,3 +20,9 @@ services:
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: kernel.event_subscriber }
+
+    ezrepoforms.section.delete.form_type:
+        class: "%ezrepoforms.section.delete.form_type.class%"
+        arguments: ["@ezpublish.api.service.section"]
+        tags:
+            - {name: form.type, alias: ezrepoforms_section_delete}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -43,7 +43,7 @@ parameters:
     ezrepoforms.form_processor.content_type.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeFormProcessor
     ezrepoforms.form_processor.content_type.options.redirect_route_after_publish: ~
     ezrepoforms.form_processor.content_type.options:
-        redirectRouteAfterPublish: %ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%
+        redirectRouteAfterPublish: "%ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%"
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
     ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
 
@@ -54,19 +54,19 @@ parameters:
 services:
     # deprecated in 1.1, will be removed in 2.0
     ezrepoforms.field_type_form_mapper.registry:
-        class: %ezrepoforms.field_type_form_mapper.registry.class%
+        class: "%ezrepoforms.field_type_form_mapper.registry.class%"
 
     ezrepoforms.field_type_form_mapper.dispatcher:
-        class: %ezrepoforms.field_type_form_mapper.dispatcher.class%
+        class: "%ezrepoforms.field_type_form_mapper.dispatcher.class%"
 
     ezrepoforms.content_type.update.form_type:
-        class: %ezrepoforms.content_type.update.form_type.class%
+        class: "%ezrepoforms.content_type.update.form_type.class%"
         arguments: ["@ezpublish.field_type_collection.factory", "@translator"]
         tags:
             - {name: form.type, alias: ezrepoforms_contenttype_update}
 
     ezrepoforms.field_definition.form_type:
-        class: %ezrepoforms.field_definition.form_type.class%
+        class: "%ezrepoforms.field_definition.form_type.class%"
         arguments: ["@ezrepoforms.field_type_form_mapper.registry", "@ezpublish.api.service.field_type"]
         calls:
             - [setGroupsList, ["@ezpublish.fields_groups.list"]]
@@ -74,7 +74,7 @@ services:
             - { name: form.type, alias: ezrepoforms_fielddefinition_update }
 
     ezrepoforms.field.form_type:
-        class: %ezrepoforms.field.form_type.class%
+        class: "%ezrepoforms.field.form_type.class%"
         arguments: ["@ezrepoforms.field_type_form_mapper.dispatcher"]
         tags:
             - { name: form.type, alias: ezrepoforms_content_field }
@@ -86,101 +86,101 @@ services:
 
     # FieldType form mappers
     ezrepoforms.field_type.form_mapper.ezbinaryfile:
-        class: %ezrepoforms.field_type.form_mapper.ezbinaryfile.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezbinaryfile.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezbinaryfile }
 
     ezrepoforms.field_type.form_mapper.ezboolean:
-        class: %ezrepoforms.field_type.form_mapper.ezboolean.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezboolean.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezboolean }
         arguments:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.ezcountry:
-        class: %ezrepoforms.field_type.form_mapper.ezcountry.class%
-        arguments: [%ezpublish.fieldType.ezcountry.data%]
+        class: "%ezrepoforms.field_type.form_mapper.ezcountry.class%"
+        arguments: ["%ezpublish.fieldType.ezcountry.data%"]
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezcountry }
 
     ezrepoforms.field_type.form_mapper.ezdate:
-        class: %ezrepoforms.field_type.form_mapper.ezdate.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezdate.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezdate }
 
     ezrepoforms.field_type.form_mapper.ezdatetime:
-        class: %ezrepoforms.field_type.form_mapper.ezdatetime.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezdatetime.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezdatetime }
 
     ezrepoforms.field_type.form_mapper.ezfloat:
-        class: %ezrepoforms.field_type.form_mapper.ezfloat.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezfloat.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezfloat }
 
     ezrepoforms.field_type.form_mapper.ezimage:
-        class: %ezrepoforms.field_type.form_mapper.ezimage.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezimage.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezimage }
 
     ezrepoforms.field_type.form_mapper.ezinteger:
-        class: %ezrepoforms.field_type.form_mapper.ezinteger.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezinteger.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezinteger }
 
     ezrepoforms.field_type.form_mapper.ezisbn:
-        class: %ezrepoforms.field_type.form_mapper.ezisbn.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezisbn.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezisbn }
 
     ezrepoforms.field_type.form_mapper.ezmedia:
-        class: %ezrepoforms.field_type.form_mapper.ezmedia.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezmedia.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezmedia }
 
     ezrepoforms.field_type.form_mapper.ezobjectrelation:
-        class: %ezrepoforms.field_type.form_mapper.ezobjectrelation.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezobjectrelation.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezobjectrelation }
 
     ezrepoforms.field_type.form_mapper.ezobjectrelationlist:
-        class: %ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class%"
         arguments: ["@ezpublish.api.service.content_type", "@ezpublish.translation_helper"]
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezobjectrelationlist }
 
     ezrepoforms.field_type.form_mapper.ezpage:
-        class: %ezrepoforms.field_type.form_mapper.ezpage.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezpage.class%"
         arguments: ["@ezpublish.fieldType.ezpage.pageService"]
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezpage }
 
     ezrepoforms.field_type.form_mapper.ezrichtext:
-        class: %ezrepoforms.field_type.form_mapper.ezrichtext.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezrichtext.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezrichtext }
 
     ezrepoforms.field_type.form_mapper.ezselection:
-        class: %ezrepoforms.field_type.form_mapper.ezselection.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezselection.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezselection }
 
     ezrepoforms.field_type.form_mapper.ezstring:
-        class: %ezrepoforms.field_type.form_mapper.ezstring.class%
+        class: "%ezrepoforms.field_type.form_mapper.ezstring.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezstring }
         arguments:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztext:
-        class: %ezrepoforms.field_type.form_mapper.eztext.class%
+        class: "%ezrepoforms.field_type.form_mapper.eztext.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: eztext }
         arguments:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztime:
-        class: %ezrepoforms.field_type.form_mapper.eztime.class%
+        class: "%ezrepoforms.field_type.form_mapper.eztime.class%"
         tags:
             - { name: ez.fieldType.formMapper, fieldType: eztime }
 
@@ -199,7 +199,7 @@ services:
 
     # Validators
     ezrepoforms.validator.unique_content_type_identifier:
-        class: %ezrepoforms.validator.unique_content_type_identifier.class%
+        class: "%ezrepoforms.validator.unique_content_type_identifier.class%"
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_content_type_identifier }
@@ -211,31 +211,31 @@ services:
 
     ezrepoforms.validator.validator_configuration:
         parent: ezrepoforms.validator.field_type.abstract
-        class: %ezrepoforms.validator.validator_configuration.class%
+        class: "%ezrepoforms.validator.validator_configuration.class%"
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.validator_configuration }
 
     ezrepoforms.validator.field_settings:
         parent: ezrepoforms.validator.field_type.abstract
-        class: %ezrepoforms.validator.field_settings.class%
+        class: "%ezrepoforms.validator.field_settings.class%"
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.field_settings }
 
     ezrepoforms.validator.default_field_value:
         parent: ezrepoforms.validator.field_type.abstract
-        class: %ezrepoforms.validator.default_field_value.class%
+        class: "%ezrepoforms.validator.default_field_value.class%"
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.default_field_value }
 
     ezrepoforms.twig.field_edit_rendering_extension:
-        class: %ezrepoforms.twig.field_edit_rendering_extension.class%
+        class: "%ezrepoforms.twig.field_edit_rendering_extension.class%"
         arguments: ["@ezpublish.templating.field_block_renderer"]
         tags:
             - { name: twig.extension }
 
     ezrepoforms.validator.field_value:
         parent: ezrepoforms.validator.field_type.abstract
-        class: %ezrepoforms.validator.field_value.class%
+        class: "%ezrepoforms.validator.field_value.class%"
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.field_value }
 
@@ -247,28 +247,28 @@ services:
             - [setEventDispatcher, ["@event_dispatcher"]]
 
     ezrepoforms.action_dispatcher.content:
-        class: %ezrepoforms.action_dispatcher.content.class%
+        class: "%ezrepoforms.action_dispatcher.content.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.action_dispatcher.content_type:
-        class: %ezrepoforms.action_dispatcher.content_type.class%
+        class: "%ezrepoforms.action_dispatcher.content_type.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     ezrepoforms.action_dispatcher.content_type.group:
-        class: %ezrepoforms.action_dispatcher.content_type.group.class%
+        class: "%ezrepoforms.action_dispatcher.content_type.group.class%"
         parent: ezrepoforms.action_dispatcher.base
 
     # Form processors
     ezrepoforms.form_processor.content_type:
-        class: %ezrepoforms.form_processor.content_type.class%
-        arguments: ["@ezpublish.api.service.content_type", "@router", %ezrepoforms.form_processor.content_type.options%]
+        class: "%ezrepoforms.form_processor.content_type.class%"
+        arguments: ["@ezpublish.api.service.content_type", "@router", "%ezrepoforms.form_processor.content_type.options%"]
         calls:
             - [setGroupsList, ["@ezpublish.fields_groups.list"]]
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.content:
-        class: %ezrepoforms.form_processor.content.class%
+        class: "%ezrepoforms.form_processor.content.class%"
         arguments: ["@ezpublish.api.service.content", "@router"]
         tags:
             - { name: kernel.event_subscriber }
@@ -283,14 +283,14 @@ services:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.content_type_group:
-        class: %ezrepoforms.form_processor.content_type_group.class%
+        class: "%ezrepoforms.form_processor.content_type_group.class%"
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: kernel.event_subscriber }
 
     # Controllers
     ezrepoforms.controller.content_edit:
-        class: %ezrepoforms.controller.content_edit.class%
+        class: "%ezrepoforms.controller.content_edit.class%"
         arguments:
             - "@ezpublish.api.service.content_type"
             - "@ezpublish.api.service.content"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -61,21 +61,21 @@ services:
 
     ezrepoforms.content_type.update.form_type:
         class: %ezrepoforms.content_type.update.form_type.class%
-        arguments: [@ezpublish.field_type_collection.factory, @translator]
+        arguments: ["@ezpublish.field_type_collection.factory", "@translator"]
         tags:
             - {name: form.type, alias: ezrepoforms_contenttype_update}
 
     ezrepoforms.field_definition.form_type:
         class: %ezrepoforms.field_definition.form_type.class%
-        arguments: [@ezrepoforms.field_type_form_mapper.registry, @ezpublish.api.service.field_type]
+        arguments: ["@ezrepoforms.field_type_form_mapper.registry", "@ezpublish.api.service.field_type"]
         calls:
-            - [setGroupsList, [@ezpublish.fields_groups.list]]
+            - [setGroupsList, ["@ezpublish.fields_groups.list"]]
         tags:
             - { name: form.type, alias: ezrepoforms_fielddefinition_update }
 
     ezrepoforms.field.form_type:
         class: %ezrepoforms.field.form_type.class%
-        arguments: [@ezrepoforms.field_type_form_mapper.dispatcher]
+        arguments: ["@ezrepoforms.field_type_form_mapper.dispatcher"]
         tags:
             - { name: form.type, alias: ezrepoforms_content_field }
 
@@ -95,7 +95,7 @@ services:
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezboolean }
         arguments:
-            - @ezpublish.api.service.field_type
+            - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.ezcountry:
         class: %ezrepoforms.field_type.form_mapper.ezcountry.class%
@@ -145,13 +145,13 @@ services:
 
     ezrepoforms.field_type.form_mapper.ezobjectrelationlist:
         class: %ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class%
-        arguments: [@ezpublish.api.service.content_type, @ezpublish.translation_helper]
+        arguments: ["@ezpublish.api.service.content_type", "@ezpublish.translation_helper"]
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezobjectrelationlist }
 
     ezrepoforms.field_type.form_mapper.ezpage:
         class: %ezrepoforms.field_type.form_mapper.ezpage.class%
-        arguments: [@ezpublish.fieldType.ezpage.pageService]
+        arguments: ["@ezpublish.fieldType.ezpage.pageService"]
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezpage }
 
@@ -170,14 +170,14 @@ services:
         tags:
             - { name: ez.fieldType.formMapper, fieldType: ezstring }
         arguments:
-            - @ezpublish.api.service.field_type
+            - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztext:
         class: %ezrepoforms.field_type.form_mapper.eztext.class%
         tags:
             - { name: ez.fieldType.formMapper, fieldType: eztext }
         arguments:
-            - @ezpublish.api.service.field_type
+            - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztime:
         class: %ezrepoforms.field_type.form_mapper.eztime.class%
@@ -188,7 +188,7 @@ services:
         abstract: true
         class: "%ezrepoforms.field_type.form_mapper.form_type_based.class%"
         arguments:
-            - @ezpublish.api.service.field_type
+            - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.ezuser:
         class: 'EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper'
@@ -200,13 +200,13 @@ services:
     # Validators
     ezrepoforms.validator.unique_content_type_identifier:
         class: %ezrepoforms.validator.unique_content_type_identifier.class%
-        arguments: [@ezpublish.api.service.content_type]
+        arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: validator.constraint_validator, alias: ezrepoforms.validator.unique_content_type_identifier }
 
     ezrepoforms.validator.field_type.abstract:
         class: EzSystems\RepositoryForms\Validator\Constraints\FieldTypeValidator
-        arguments: [@ezpublish.api.service.field_type]
+        arguments: ["@ezpublish.api.service.field_type"]
         abstract: true
 
     ezrepoforms.validator.validator_configuration:
@@ -229,7 +229,7 @@ services:
 
     ezrepoforms.twig.field_edit_rendering_extension:
         class: %ezrepoforms.twig.field_edit_rendering_extension.class%
-        arguments: [@ezpublish.templating.field_block_renderer]
+        arguments: ["@ezpublish.templating.field_block_renderer"]
         tags:
             - { name: twig.extension }
 
@@ -244,7 +244,7 @@ services:
         class: EzSystems\RepositoryForms\Form\ActionDispatcher\AbstractActionDispatcher
         abstract: true
         calls:
-            - [setEventDispatcher, [@event_dispatcher]]
+            - [setEventDispatcher, ["@event_dispatcher"]]
 
     ezrepoforms.action_dispatcher.content:
         class: %ezrepoforms.action_dispatcher.content.class%
@@ -261,15 +261,15 @@ services:
     # Form processors
     ezrepoforms.form_processor.content_type:
         class: %ezrepoforms.form_processor.content_type.class%
-        arguments: [@ezpublish.api.service.content_type, @router, %ezrepoforms.form_processor.content_type.options%]
+        arguments: ["@ezpublish.api.service.content_type", "@router", %ezrepoforms.form_processor.content_type.options%]
         calls:
-            - [setGroupsList, [@ezpublish.fields_groups.list]]
+            - [setGroupsList, ["@ezpublish.fields_groups.list"]]
         tags:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.content:
         class: %ezrepoforms.form_processor.content.class%
-        arguments: [@ezpublish.api.service.content, @router]
+        arguments: ["@ezpublish.api.service.content", "@router"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -284,7 +284,7 @@ services:
 
     ezrepoforms.form_processor.content_type_group:
         class: %ezrepoforms.form_processor.content_type_group.class%
-        arguments: [@ezpublish.api.service.content_type]
+        arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -292,10 +292,10 @@ services:
     ezrepoforms.controller.content_edit:
         class: %ezrepoforms.controller.content_edit.class%
         arguments:
-            - @ezpublish.api.service.content_type
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.location
-            - @ezrepoforms.action_dispatcher.content
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.location"
+            - "@ezrepoforms.action_dispatcher.content"
         parent: ezpublish.controller.base
         calls:
             - [setPageLayout, [$pagelayout$]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ imports:
 parameters:
     ezrepoforms.field_type_form_mapper.registry.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistry
     ezrepoforms.field_type_form_mapper.dispatcher.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcher
+    ezrepoforms.content_type.create.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeCreateType
     ezrepoforms.content_type.update.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeUpdateType
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
     ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
@@ -70,6 +71,12 @@ services:
 
     ezrepoforms.field_type_form_mapper.dispatcher:
         class: "%ezrepoforms.field_type_form_mapper.dispatcher.class%"
+
+    ezrepoforms.content_type.create.form_type:
+        class: "%ezrepoforms.content_type.create.form_type.class%"
+        arguments: ["@ezpublish.api.service.content_type"]
+        tags:
+            - {name: form.type, alias: ezrepoforms_contenttype_create}
 
     ezrepoforms.content_type.update.form_type:
         class: "%ezrepoforms.content_type.update.form_type.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -10,6 +10,8 @@ parameters:
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
     ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
 
+    ezrepoforms.field_value.user_type.class: EzSystems\RepositoryForms\Form\Type\User\UserAccountType
+
     ezrepoforms.field_type.form_mapper.ezbinaryfile.class: EzSystems\RepositoryForms\FieldType\Mapper\BinaryFileFormMapper
     ezrepoforms.field_type.form_mapper.ezboolean.class: EzSystems\RepositoryForms\FieldType\Mapper\CheckboxFormMapper
     ezrepoforms.field_type.form_mapper.ezcountry.class: EzSystems\RepositoryForms\FieldType\Mapper\CountryFormMapper
@@ -29,6 +31,7 @@ parameters:
     ezrepoforms.field_type.form_mapper.eztext.class: EzSystems\RepositoryForms\FieldType\Mapper\TextBlockFormMapper
     ezrepoforms.field_type.form_mapper.eztime.class: EzSystems\RepositoryForms\FieldType\Mapper\TimeFormMapper
     ezrepoforms.field_type.form_mapper.form_type_based.class: EzSystems\RepositoryForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper
+    ezrepoforms.field_type.form_mapper.ezuser.class: EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper
 
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
     ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
@@ -37,6 +40,7 @@ parameters:
     ezrepoforms.validator.field_value.class: EzSystems\RepositoryForms\Validator\Constraints\FieldValueValidator
 
     ezrepoforms.twig.field_edit_rendering_extension.class: EzSystems\RepositoryForms\Twig\FieldEditRenderingExtension
+    ezrepoforms.action_dispatcher.base.class: EzSystems\RepositoryForms\Form\ActionDispatcher\AbstractActionDispatcher
     ezrepoforms.action_dispatcher.content_type.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeDispatcher
     ezrepoforms.action_dispatcher.content_type.group.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeGroupDispatcher
     ezrepoforms.action_dispatcher.content.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentDispatcher
@@ -46,8 +50,16 @@ parameters:
         redirectRouteAfterPublish: "%ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%"
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
     ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
+    ezrepoforms.form_processor.user_register.class: EzSystems\RepositoryForms\Form\Processor\UserRegisterFormProcessor
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
+    ezrepoforms.controller.user_register.class: EzSystems\RepositoryFormsBundle\Controller\UserRegisterController
+
+    ezrepoforms.user_register.registration_group_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
+    ezrepoforms.user_register.registration_content_type_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
+    ezrepoforms.user_register.view_templates_listener.class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
+
+    ezrepoforms.form_data_mapper.user_register.class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
 
     ezrepoforms.user_content_type_identifier: "user"
 
@@ -80,7 +92,7 @@ services:
             - { name: form.type, alias: ezrepoforms_content_field }
 
     ezrepoforms.field_value.user_type:
-        class: EzSystems\RepositoryForms\Form\Type\User\UserAccountType
+        class: "%ezrepoforms.field_value.user_type.class%"
         tags:
             - { name: form.type, alias: ezuser }
 
@@ -191,7 +203,7 @@ services:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.ezuser:
-        class: 'EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper'
+        class: "%ezrepoforms.field_type.form_mapper.ezuser.class%"
         tags:
             - { name: ez.fieldFormMapper.value, fieldType: ezuser }
         arguments:
@@ -241,7 +253,7 @@ services:
 
     # Action dispatchers
     ezrepoforms.action_dispatcher.base:
-        class: EzSystems\RepositoryForms\Form\ActionDispatcher\AbstractActionDispatcher
+        class: "%ezrepoforms.action_dispatcher.base.class%"
         abstract: true
         calls:
             - [setEventDispatcher, ["@event_dispatcher"]]
@@ -274,7 +286,7 @@ services:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.user_register:
-        class: 'EzSystems\RepositoryForms\Form\Processor\UserRegisterFormProcessor'
+        class: "%ezrepoforms.form_processor.user_register.class%"
         arguments:
             - '@ezpublish.api.repository'
             - '@ezpublish.api.service.user'
@@ -301,7 +313,7 @@ services:
             - [setPageLayout, [$pagelayout$]]
 
     ezrepoforms.controller.user_register:
-        class: 'EzSystems\RepositoryFormsBundle\Controller\UserRegisterController'
+        class: "%ezrepoforms.controller.user_register.class%"
         arguments:
             - "@ezrepoforms.form_data_mapper.user_register"
             - "@ezrepoforms.action_dispatcher.content"
@@ -311,21 +323,21 @@ services:
         alias: ezrepoforms.controller.content_edit
 
     ezrepoforms.user_register.registration_group_loader.configurable:
-        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
+        class: "%ezrepoforms.user_register.registration_group_loader.configurable.class%"
         arguments:
             - "@ezpublish.api.repository"
         calls:
             - [setParam, ["groupId", "$user_registration.group_id$"]]
 
     ezrepoforms.user_register.registration_content_type_loader.configurable:
-        class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
+        class: "%ezrepoforms.user_register.registration_content_type_loader.configurable.class%"
         arguments:
             - "@ezpublish.api.repository"
         calls:
             - [setParam, ["contentTypeIdentifier", "%ezrepoforms.user_content_type_identifier%"]]
 
     ezrepoforms.form_data_mapper.user_register:
-        class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
+        class: "%ezrepoforms.form_data_mapper.user_register.class%"
         arguments:
             - "@ezrepoforms.user_register.registration_content_type_loader.configurable"
             - "@ezrepoforms.user_register.registration_group_loader.configurable"
@@ -333,7 +345,7 @@ services:
             - [setParam, ["language", "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]
 
     ezrepoforms.user_register.view_templates_listener:
-        class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
+        class: "%ezrepoforms.user_register.view_templates_listener.class%"
         tags:
             - { name: kernel.event_subscriber }
         calls:

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -100,12 +100,12 @@ services:
     ezrepoforms.field_type.form_mapper.ezbinaryfile:
         class: "%ezrepoforms.field_type.form_mapper.ezbinaryfile.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezbinaryfile }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezbinaryfile }
 
     ezrepoforms.field_type.form_mapper.ezboolean:
         class: "%ezrepoforms.field_type.form_mapper.ezboolean.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezboolean }
+            - { name: ez.fieldFormMapper.value, fieldType: ezboolean }
         arguments:
             - "@ezpublish.api.service.field_type"
 
@@ -113,88 +113,91 @@ services:
         class: "%ezrepoforms.field_type.form_mapper.ezcountry.class%"
         arguments: ["%ezpublish.fieldType.ezcountry.data%"]
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezcountry }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezcountry }
 
     ezrepoforms.field_type.form_mapper.ezdate:
         class: "%ezrepoforms.field_type.form_mapper.ezdate.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezdate }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezdate }
 
     ezrepoforms.field_type.form_mapper.ezdatetime:
         class: "%ezrepoforms.field_type.form_mapper.ezdatetime.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezdatetime }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezdatetime }
 
     ezrepoforms.field_type.form_mapper.ezfloat:
         class: "%ezrepoforms.field_type.form_mapper.ezfloat.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezfloat }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezfloat }
 
     ezrepoforms.field_type.form_mapper.ezimage:
         class: "%ezrepoforms.field_type.form_mapper.ezimage.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezimage }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezimage }
 
     ezrepoforms.field_type.form_mapper.ezinteger:
         class: "%ezrepoforms.field_type.form_mapper.ezinteger.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezinteger }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezinteger }
 
     ezrepoforms.field_type.form_mapper.ezisbn:
         class: "%ezrepoforms.field_type.form_mapper.ezisbn.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezisbn }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezisbn }
 
     ezrepoforms.field_type.form_mapper.ezmedia:
         class: "%ezrepoforms.field_type.form_mapper.ezmedia.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezmedia }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezmedia }
 
     ezrepoforms.field_type.form_mapper.ezobjectrelation:
         class: "%ezrepoforms.field_type.form_mapper.ezobjectrelation.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezobjectrelation }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezobjectrelation }
 
     ezrepoforms.field_type.form_mapper.ezobjectrelationlist:
         class: "%ezrepoforms.field_type.form_mapper.ezobjectrelationlist.class%"
         arguments: ["@ezpublish.api.service.content_type", "@ezpublish.translation_helper"]
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezobjectrelationlist }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezobjectrelationlist }
 
     ezrepoforms.field_type.form_mapper.ezpage:
         class: "%ezrepoforms.field_type.form_mapper.ezpage.class%"
         arguments: ["@ezpublish.fieldType.ezpage.pageService"]
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezpage }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezpage }
 
     ezrepoforms.field_type.form_mapper.ezrichtext:
         class: "%ezrepoforms.field_type.form_mapper.ezrichtext.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezrichtext }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezrichtext }
 
     ezrepoforms.field_type.form_mapper.ezselection:
         class: "%ezrepoforms.field_type.form_mapper.ezselection.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezselection }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezselection }
+            - { name: ez.fieldFormMapper.value, fieldType: ezselection }
 
     ezrepoforms.field_type.form_mapper.ezstring:
         class: "%ezrepoforms.field_type.form_mapper.ezstring.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: ezstring }
+            - { name: ez.fieldFormMapper.definition, fieldType: ezstring }
+            - { name: ez.fieldFormMapper.value, fieldType: ezstring }
         arguments:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztext:
         class: "%ezrepoforms.field_type.form_mapper.eztext.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: eztext }
+            - { name: ez.fieldFormMapper.definition, fieldType: eztext }
+            - { name: ez.fieldFormMapper.value, fieldType: eztext }
         arguments:
             - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztime:
         class: "%ezrepoforms.field_type.form_mapper.eztime.class%"
         tags:
-            - { name: ez.fieldType.formMapper, fieldType: eztime }
+            - { name: ez.fieldFormMapper.definition, fieldType: eztime }
 
     ezrepoforms.field_type.form_mapper.form_type_based:
         abstract: true

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -79,7 +79,7 @@ services:
 
     ezrepoforms.field_definition.form_type:
         class: "%ezrepoforms.field_definition.form_type.class%"
-        arguments: ["@ezrepoforms.field_type_form_mapper.registry", "@ezpublish.api.service.field_type"]
+        arguments: ["@ezrepoforms.field_type_form_mapper.dispatcher", "@ezpublish.api.service.field_type"]
         calls:
             - [setGroupsList, ["@ezpublish.fields_groups.list"]]
         tags:

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": "~5.5|~7.0",
         "ezsystems/ezpublish-kernel": "^6.4@dev",
-        "symfony/form": "~2.7",
-        "symfony/validator": "~2.7"
+        "symfony/form": "~2.8",
+        "symfony/validator": "~2.8"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": "~5.5|~7.0",
         "ezsystems/ezpublish-kernel": "^6.4@dev",
         "symfony/form": "~2.7",
         "symfony/validator": "~2.7"

--- a/lib/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/lib/FieldType/Mapper/BinaryFileFormMapper.php
@@ -5,21 +5,20 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class BinaryFileFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('maxSize', 'integer', [
+            ->add('maxSize', IntegerType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[FileSizeValidator][maxFileSize]',
                 'label' => 'field_definition.ezbinaryfile.max_file_size',

--- a/lib/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/lib/FieldType/Mapper/BinaryFileFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class BinaryFileFormMapper implements FieldTypeFormMapperInterface
+class BinaryFileFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/CheckboxFormMapper.php
+++ b/lib/FieldType/Mapper/CheckboxFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -14,6 +12,7 @@ use eZ\Publish\API\Repository\FieldTypeService;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormInterface;
 
 class CheckboxFormMapper implements FieldValueFormMapperInterface
@@ -39,7 +38,7 @@ class CheckboxFormMapper implements FieldValueFormMapperInterface
                 $formConfig->getFormFactory()->createBuilder()
                     ->create(
                         'value',
-                        'checkbox',
+                        CheckboxType::class,
                         ['required' => $fieldDefinition->isRequired, 'label' => $label]
                     )
                     ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))

--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -14,6 +12,8 @@ use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\CountryValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 class CountryFormMapper implements FieldDefinitionFormMapperInterface
@@ -36,7 +36,7 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface
         $fieldDefinitionForm
             ->add(
                 'isMultiple',
-                'checkbox', [
+                CheckboxType::class, [
                     'required' => false,
                     'property_path' => 'fieldSettings[isMultiple]',
                     'label' => 'field_definition.ezcountry.is_multiple',
@@ -47,7 +47,7 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface
                 $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()
                     ->create(
                         'defaultValue',
-                        'choice', [
+                        ChoiceType::class, [
                             'choice_list' => new ChoiceList(
                                 array_map(
                                     function ($country) {

--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -12,11 +12,11 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\CountryValueTransformer;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
 use Symfony\Component\Form\FormInterface;
 
-class CountryFormMapper implements FieldTypeFormMapperInterface
+class CountryFormMapper implements FieldDefinitionFormMapperInterface
 {
     /**
      * @var array Array of countries from ezpublish.fieldType.ezcountry.data

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -5,14 +5,13 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Date\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 class DateFormMapper implements FieldDefinitionFormMapperInterface
@@ -22,7 +21,7 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface
         $fieldDefinitionForm
             ->add(
                 'defaultType',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         Type::DEFAULT_EMPTY => 'field_definition.ezdate.default_type_empty',

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -12,10 +12,10 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Date\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class DateFormMapper implements FieldTypeFormMapperInterface
+class DateFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -14,6 +12,8 @@ use eZ\Publish\Core\FieldType\DateAndTime\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\Form\Type\DateTimeIntervalType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 class DateTimeFormMapper implements FieldDefinitionFormMapperInterface
@@ -21,12 +21,12 @@ class DateTimeFormMapper implements FieldDefinitionFormMapperInterface
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('useSeconds', 'checkbox', [
+            ->add('useSeconds', CheckboxType::class, [
                 'required' => false,
                 'property_path' => 'fieldSettings[useSeconds]',
                 'label' => 'field_definition.ezdatetime.use_seconds',
             ])
-            ->add('defaultType', 'choice', [
+            ->add('defaultType', ChoiceType::class, [
                 'choices' => [
                     Type::DEFAULT_EMPTY => 'field_definition.ezdatetime.default_type_empty',
                     Type::DEFAULT_CURRENT_DATE => 'field_definition.ezdatetime.default_type_current',
@@ -37,7 +37,7 @@ class DateTimeFormMapper implements FieldDefinitionFormMapperInterface
                 'property_path' => 'fieldSettings[defaultType]',
                 'label' => 'field_definition.ezdatetime.default_type',
             ])
-            ->add('dateInterval', new DateTimeIntervalType(), [
+            ->add('dateInterval', DateTimeIntervalType::class, [
                 'required' => false,
                 'property_path' => 'fieldSettings[dateInterval]',
                 'label' => 'field_definition.ezdatetime.date_interval',

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -12,11 +12,11 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\DateAndTime\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\Form\Type\DateTimeIntervalType;
 use Symfony\Component\Form\FormInterface;
 
-class DateTimeFormMapper implements FieldTypeFormMapperInterface
+class DateTimeFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/FloatFormMapper.php
+++ b/lib/FieldType/Mapper/FloatFormMapper.php
@@ -5,13 +5,12 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormInterface;
 
 class FloatFormMapper implements FieldDefinitionFormMapperInterface
@@ -20,14 +19,14 @@ class FloatFormMapper implements FieldDefinitionFormMapperInterface
     {
         $fieldDefinitionForm
             ->add(
-                'minValue', 'number', [
+                'minValue', NumberType::class, [
                     'required' => false,
                     'property_path' => 'validatorConfiguration[FloatValueValidator][minFloatValue]',
                     'label' => 'field_definition.ezfloat.min_value',
                 ]
             )
             ->add(
-                'maxValue', 'number', [
+                'maxValue', NumberType::class, [
                     'required' => false,
                     'property_path' => 'validatorConfiguration[FloatValueValidator][maxFloatValue]',
                     'label' => 'field_definition.ezfloat.max_value',

--- a/lib/FieldType/Mapper/FloatFormMapper.php
+++ b/lib/FieldType/Mapper/FloatFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class FloatFormMapper implements FieldTypeFormMapperInterface
+class FloatFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
+++ b/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
  * This file is part of the eZ RepositoryForms package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -33,7 +33,7 @@ use Symfony\Component\Form\FormInterface;
 final class FormTypeBasedFieldValueFormMapper implements FieldValueFormMapperInterface
 {
     /**
-     * The FormType used by the mapper. Example: 'text'.
+     * The FormType used by the mapper. Example: '\Symfony\Component\Form\Extension\Core\Type\TextType'.
      * @var string
      */
     private $formType;

--- a/lib/FieldType/Mapper/ISBNFormMapper.php
+++ b/lib/FieldType/Mapper/ISBNFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class ISBNFormMapper implements FieldTypeFormMapperInterface
+class ISBNFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/ISBNFormMapper.php
+++ b/lib/FieldType/Mapper/ISBNFormMapper.php
@@ -5,13 +5,12 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormInterface;
 
 class ISBNFormMapper implements FieldDefinitionFormMapperInterface
@@ -20,7 +19,7 @@ class ISBNFormMapper implements FieldDefinitionFormMapperInterface
     {
         $fieldDefinitionForm
             ->add(
-                'isISBN13', 'checkbox', [
+                'isISBN13', CheckboxType::class, [
                     'required' => false,
                     'property_path' => 'fieldSettings[isISBN13]',
                     'label' => 'field_definition.ezisbn.is_isbn13',

--- a/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/lib/FieldType/Mapper/ImageFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class ImageFormMapper implements FieldTypeFormMapperInterface
+class ImageFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/lib/FieldType/Mapper/ImageFormMapper.php
@@ -5,21 +5,20 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class ImageFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('maxSize', 'integer', [
+            ->add('maxSize', IntegerType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[FileSizeValidator][maxFileSize]',
                 'label' => 'field_definition.ezimage.max_file_size',

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -5,14 +5,13 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class IntegerFormMapper implements FieldDefinitionFormMapperInterface
 {
@@ -20,14 +19,14 @@ class IntegerFormMapper implements FieldDefinitionFormMapperInterface
     {
         $fieldDefinitionForm
             ->add(
-                'minValue', 'integer', [
+                'minValue', IntegerType::class, [
                     'required' => false,
                     'property_path' => 'validatorConfiguration[IntegerValueValidator][minIntegerValue]',
                     'label' => 'field_definition.ezinteger.min_value',
                 ]
             )
             ->add(
-                'maxValue', 'integer', [
+                'maxValue', IntegerType::class, [
                     'required' => false,
                     'property_path' => 'validatorConfiguration[IntegerValueValidator][maxIntegerValue]',
                     'label' => 'field_definition.ezinteger.max_value',

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class IntegerFormMapper implements FieldTypeFormMapperInterface
+class IntegerFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -5,27 +5,27 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Media\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class MediaFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('maxSize', 'integer', [
+            ->add('maxSize', IntegerType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[FileSizeValidator][maxFileSize]',
                 'label' => 'field_definition.ezmedia.max_file_size',
             ])
-            ->add('mediaType', 'choice', [
+            ->add('mediaType', ChoiceType::class, [
                 'choices' => [
                     Type::TYPE_HTML5_VIDEO => 'field_definition.ezmedia.type_html5_video',
                     Type::TYPE_FLASH => 'field_definition.ezmedia.type_flash',

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -12,10 +12,10 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Media\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class MediaFormMapper implements FieldTypeFormMapperInterface
+class MediaFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/PageFormMapper.php
+++ b/lib/FieldType/Mapper/PageFormMapper.php
@@ -5,14 +5,13 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Page\PageService;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 class PageFormMapper implements FieldDefinitionFormMapperInterface
@@ -35,7 +34,7 @@ class PageFormMapper implements FieldDefinitionFormMapperInterface
         $availableLayouts = $this->pageService->getAvailableZoneLayouts();
 
         $fieldDefinitionForm
-            ->add('defaultLayout', 'choice', [
+            ->add('defaultLayout', ChoiceType::class, [
                 'choices' => array_combine($availableLayouts, $availableLayouts),
                 'multiple' => false,
                 'expanded' => false,

--- a/lib/FieldType/Mapper/PageFormMapper.php
+++ b/lib/FieldType/Mapper/PageFormMapper.php
@@ -12,10 +12,10 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Page\PageService;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class PageFormMapper implements FieldTypeFormMapperInterface
+class PageFormMapper implements FieldDefinitionFormMapperInterface
 {
     /**
      * @var PageService Provides layout list used in form selector

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class RelationFormMapper implements FieldTypeFormMapperInterface
+class RelationFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -5,13 +5,12 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormInterface;
 
 class RelationFormMapper implements FieldDefinitionFormMapperInterface
@@ -19,7 +18,7 @@ class RelationFormMapper implements FieldDefinitionFormMapperInterface
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('selectionRoot', 'hidden', [
+            ->add('selectionRoot', HiddenType::class, [
                 'required' => false,
                 'property_path' => 'fieldSettings[selectionRoot]',
                 'label' => 'field_definition.ezobjectrelation.selection_root',

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -15,6 +13,8 @@ use eZ\Publish\Core\FieldType\RelationList\Type;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormInterface;
 
 class RelationListFormMapper implements FieldDefinitionFormMapperInterface
@@ -51,12 +51,12 @@ class RelationListFormMapper implements FieldDefinitionFormMapperInterface
         asort($contentTypeHash);
 
         $fieldDefinitionForm
-            ->add('selectionDefaultLocation', 'hidden', [
+            ->add('selectionDefaultLocation', HiddenType::class, [
                 'required' => false,
                 'property_path' => 'fieldSettings[selectionDefaultLocation]',
                 'label' => 'field_definition.ezobjectrelationlist.selection_default_location',
             ])
-            ->add('selectionContentTypes', 'choice', [
+            ->add('selectionContentTypes', ChoiceType::class, [
                 'choices' => $contentTypeHash,
                 'expanded' => false,
                 'multiple' => true,

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -14,10 +14,10 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\FieldType\RelationList\Type;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class RelationListFormMapper implements FieldTypeFormMapperInterface
+class RelationListFormMapper implements FieldDefinitionFormMapperInterface
 {
     /**
      * @var ContentTypeService Used to fetch list of available content types

--- a/lib/FieldType/Mapper/RichTextFormMapper.php
+++ b/lib/FieldType/Mapper/RichTextFormMapper.php
@@ -5,21 +5,20 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class RichTextFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('numRows', 'integer', [
+            ->add('numRows', IntegerType::class, [
                 'empty_data' => 10,
                 'required' => true,
                 'property_path' => 'fieldSettings[numRows]',

--- a/lib/FieldType/Mapper/RichTextFormMapper.php
+++ b/lib/FieldType/Mapper/RichTextFormMapper.php
@@ -11,10 +11,10 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class RichTextFormMapper implements FieldTypeFormMapperInterface
+class RichTextFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -16,6 +14,10 @@ use EzSystems\RepositoryForms\FieldType\DataTransformer\MultiSelectionValueTrans
 use EzSystems\RepositoryForms\FieldType\DataTransformer\SingleSelectionValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 
 class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
@@ -32,14 +34,14 @@ class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('isMultiple', 'checkbox', [
+            ->add('isMultiple', CheckboxType::class, [
                 'required' => false,
                 'property_path' => 'fieldSettings[isMultiple]',
                 'label' => 'field_definition.ezselection.is_multiple',
             ])
-            ->add('options', 'collection', [
-                'type' => 'text',
-                'options' => ['required' => false],
+            ->add('options', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'entry_options' => ['required' => false],
                 'allow_add' => true,
                 'allow_delete' => true,
                 'delete_empty' => true,
@@ -62,7 +64,7 @@ class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
                 $formConfig->getFormFactory()->createBuilder()
                     ->create(
                         'value',
-                        'choice',
+                        ChoiceType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
                             'label' => $label,

--- a/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -14,11 +14,11 @@ use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\MultiSelectionValueTransformer;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\SingleSelectionValueTransformer;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class SelectionFormMapper implements FieldTypeFormMapperInterface, FieldValueFormMapperInterface
+class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
     /**
      * Selection items can be added and removed, the collection field type is used for this.

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -14,11 +14,11 @@ use eZ\Publish\API\Repository\FieldTypeService;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class TextBlockFormMapper implements FieldTypeFormMapperInterface, FieldValueFormMapperInterface
+class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
     /**
      * @var \eZ\Publish\API\Repository\FieldTypeService

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -16,7 +14,9 @@ use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
@@ -34,7 +34,7 @@ class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
     {
         $fieldDefinitionForm
             ->add(
-                'textRows', 'integer', [
+                'textRows', IntegerType::class, [
                     'required' => false,
                     'property_path' => 'fieldSettings[textRows]',
                     'label' => 'field_definition.eztext.text_rows',
@@ -53,7 +53,7 @@ class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
                 $formConfig->getFormFactory()->createBuilder()
                     ->create(
                         'value',
-                        'textarea',
+                        TextareaType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
                             'label' => $label,

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -17,7 +15,9 @@ use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\TextLineValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
@@ -34,13 +34,13 @@ class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
         $fieldDefinitionForm
-            ->add('minLength', 'integer', [
+            ->add('minLength', IntegerType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][minStringLength]',
                 'label' => 'field_definition.ezstring.min_length',
                 'attr' => ['min' => 0],
             ])
-            ->add('maxLength', 'integer', [
+            ->add('maxLength', IntegerType::class, [
                 'required' => false,
                 'property_path' => 'validatorConfiguration[StringLengthValidator][maxStringLength]',
                 'label' => 'field_definition.ezstring.max_length',
@@ -49,7 +49,7 @@ class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
             ->add(
                 // Creating from FormBuilder as we need to add a DataTransformer.
                 $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()
-                    ->create('defaultValue', 'text', [
+                    ->create('defaultValue', TextType::class, [
                         'required' => false,
                         'label' => 'field_definition.ezstring.default_value',
                     ])
@@ -70,7 +70,7 @@ class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                 $formConfig->getFormFactory()->createBuilder()
                     ->create(
                         'value',
-                        'text',
+                        TextType::class,
                         ['required' => $fieldDefinition->isRequired, 'label' => $label]
                     )
                     ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -15,11 +15,11 @@ use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\TextLineValueTransformer;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class TextLineFormMapper implements FieldTypeFormMapperInterface, FieldValueFormMapperInterface
+class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
     /**
      * @var \eZ\Publish\API\Repository\FieldTypeService

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -5,14 +5,14 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Time\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 class TimeFormMapper implements FieldDefinitionFormMapperInterface
@@ -22,7 +22,7 @@ class TimeFormMapper implements FieldDefinitionFormMapperInterface
         $fieldDefinitionForm
             ->add(
                 'useSeconds',
-                'checkbox',
+                CheckboxType::class,
                 [
                     'required' => false,
                     'property_path' => 'fieldSettings[useSeconds]',
@@ -31,7 +31,7 @@ class TimeFormMapper implements FieldDefinitionFormMapperInterface
             )
             ->add(
                 'defaultType',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         Type::DEFAULT_EMPTY => 'field_definition.eztime.default_type_empty',

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -12,10 +12,10 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Time\Type;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class TimeFormMapper implements FieldTypeFormMapperInterface
+class TimeFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {

--- a/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
+++ b/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
@@ -1,11 +1,10 @@
 <?php
+
 /**
  * This file is part of the eZ RepositoryForms package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
@@ -14,6 +13,7 @@ use eZ\Publish\Core\FieldType\User\Value as ApiUserValue;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\User\UserAccountFieldData;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use EzSystems\RepositoryForms\Form\Type\User\UserAccountType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormInterface;
 
@@ -47,7 +47,7 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
         $fieldForm
             ->add(
                 $formConfig->getFormFactory()->createBuilder()
-                    ->create('value', 'ezuser', ['required' => $fieldDefinition->isRequired, 'label' => $label])
+                    ->create('value', UserAccountType::class, ['required' => $fieldDefinition->isRequired, 'label' => $label])
                     ->addModelTransformer(
                         new CallbackTransformer(
                             function (ApiUserValue $data) {

--- a/lib/Form/Type/Content/ContentEditType.php
+++ b/lib/Form/Type/Content/ContentEditType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Content;
 
@@ -23,6 +22,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ContentEditType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_content_edit';
     }

--- a/lib/Form/Type/Content/ContentEditType.php
+++ b/lib/Form/Type/Content/ContentEditType.php
@@ -9,6 +9,9 @@
 namespace EzSystems\RepositoryForms\Form\Type\Content;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,18 +30,18 @@ class ContentEditType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('fieldsData', 'collection', [
-                'type' => 'ezrepoforms_content_field',
+            ->add('fieldsData', CollectionType::class, [
+                'entry_type' => ContentFieldType::class,
                 'label' => 'ezrepoforms.content.fields',
-                'options' => ['languageCode' => $options['languageCode']],
+                'entry_options' => ['languageCode' => $options['languageCode']],
             ])
-            ->add('redirectUrlAfterPublish', 'hidden', ['required' => false, 'mapped' => false])
-            ->add('publish', 'submit', ['label' => 'content.publish_button']);
+            ->add('redirectUrlAfterPublish', HiddenType::class, ['required' => false, 'mapped' => false])
+            ->add('publish', SubmitType::class, ['label' => 'content.publish_button']);
 
         if ($options['drafts_enabled']) {
             $builder
-                ->add('saveDraft', 'submit', ['label' => 'content.save_button'])
-                ->add('cancel', 'submit', [
+                ->add('saveDraft', SubmitType::class, ['label' => 'content.save_button'])
+                ->add('cancel', SubmitType::class, [
                     'label' => 'content.cancel_button',
                     'attr' => ['formnovalidate' => 'formnovalidate'],
                 ]);

--- a/lib/Form/Type/Content/ContentFieldType.php
+++ b/lib/Form/Type/Content/ContentFieldType.php
@@ -27,7 +27,7 @@ class ContentFieldType extends AbstractType
         $this->fieldTypeFormMapper = $fieldTypeFormMapper;
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_content_field';
     }

--- a/lib/Form/Type/Content/ContentFieldType.php
+++ b/lib/Form/Type/Content/ContentFieldType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Content;
 
@@ -25,6 +24,11 @@ class ContentFieldType extends AbstractType
     public function __construct(FieldTypeFormMapperDispatcherInterface $fieldTypeFormMapper)
     {
         $this->fieldTypeFormMapper = $fieldTypeFormMapper;
+    }
+
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 
     public function getBlockPrefix()

--- a/lib/Form/Type/ContentType/ContentTypeCreateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeCreateType.php
@@ -11,6 +11,8 @@ namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Callback;
@@ -44,7 +46,7 @@ class ContentTypeCreateType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('contentTypeGroupId', 'hidden', [
+            ->add('contentTypeGroupId', HiddenType::class, [
                 'constraints' => new Callback(
                     function ($contentTypeGroupId, ExecutionContextInterface $context) {
                         try {
@@ -58,6 +60,6 @@ class ContentTypeCreateType extends AbstractType
                     }
                 ),
             ])
-            ->add('create', 'submit', ['label' => 'content_type.create']);
+            ->add('create', SubmitType::class, ['label' => 'content_type.create']);
     }
 }

--- a/lib/Form/Type/ContentType/ContentTypeCreateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeCreateType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
@@ -31,6 +30,11 @@ class ContentTypeCreateType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_contenttype_create';
     }

--- a/lib/Form/Type/ContentType/ContentTypeDeleteType.php
+++ b/lib/Form/Type/ContentType/ContentTypeDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ContentTypeDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_contenttype_delete';
     }

--- a/lib/Form/Type/ContentType/ContentTypeDeleteType.php
+++ b/lib/Form/Type/ContentType/ContentTypeDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -30,7 +32,7 @@ class ContentTypeDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('contentTypeId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'content_type.delete']);
+            ->add('contentTypeId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'content_type.delete']);
     }
 }

--- a/lib/Form/Type/ContentType/ContentTypeGroupDeleteType.php
+++ b/lib/Form/Type/ContentType/ContentTypeGroupDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ContentTypeGroupDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_content_type_group_delete';
     }

--- a/lib/Form/Type/ContentType/ContentTypeGroupDeleteType.php
+++ b/lib/Form/Type/ContentType/ContentTypeGroupDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,8 +24,8 @@ class ContentTypeGroupDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('contentTypeGroupId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'content_type.group.delete']);
+            ->add('contentTypeGroupId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'content_type.group.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/ContentType/ContentTypeGroupType.php
+++ b/lib/Form/Type/ContentType/ContentTypeGroupType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,8 +19,8 @@ class ContentTypeGroupType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('identifier', 'text', ['label' => 'content_type.group.identifier'])
-            ->add('save', 'submit', ['label' => 'content_type.group.save']);
+            ->add('identifier', TextType::class, ['label' => 'content_type.group.identifier'])
+            ->add('save', SubmitType::class, ['label' => 'content_type.group.save']);
     }
 
     public function getName()

--- a/lib/Form/Type/ContentType/ContentTypeGroupType.php
+++ b/lib/Form/Type/ContentType/ContentTypeGroupType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
@@ -24,6 +23,11 @@ class ContentTypeGroupType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_content_type_group_edit';
     }

--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -13,7 +13,13 @@ namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;
+use EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -60,23 +66,23 @@ class ContentTypeUpdateType extends AbstractType
         $builder
             ->add(
                 $builder
-                    ->create('name', 'text', ['property_path' => 'names', 'label' => 'content_type.name'])
+                    ->create('name', TextType::class, ['property_path' => 'names', 'label' => 'content_type.name'])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('identifier', 'text', ['label' => 'content_type.identifier'])
+            ->add('identifier', TextType::class, ['label' => 'content_type.identifier'])
             ->add(
                 $builder
-                    ->create('description', 'text', [
+                    ->create('description', TextType::class, [
                         'property_path' => 'descriptions',
                         'required' => false,
                         'label' => 'content_type.description',
                     ])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('nameSchema', 'text', ['required' => false, 'label' => 'content_type.name_schema'])
-            ->add('urlAliasSchema', 'text', ['required' => false, 'label' => 'content_type.url_alias_schema'])
-            ->add('isContainer', 'checkbox', ['required' => false, 'label' => 'content_type.is_container'])
-            ->add('defaultSortField', 'choice', [
+            ->add('nameSchema', TextType::class, ['required' => false, 'label' => 'content_type.name_schema'])
+            ->add('urlAliasSchema', TextType::class, ['required' => false, 'label' => 'content_type.url_alias_schema'])
+            ->add('isContainer', CheckboxType::class, ['required' => false, 'label' => 'content_type.is_container'])
+            ->add('defaultSortField', ChoiceType::class, [
                 'choices' => [
                     Location::SORT_FIELD_NAME => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_NAME, [], 'ezrepoforms_content_type'),
                     Location::SORT_FIELD_CLASS_NAME => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_CLASS_NAME, [], 'ezrepoforms_content_type'),
@@ -90,32 +96,32 @@ class ContentTypeUpdateType extends AbstractType
                 ],
                 'label' => 'content_type.default_sort_field',
             ])
-            ->add('defaultSortOrder', 'choice', [
+            ->add('defaultSortOrder', ChoiceType::class, [
                 'choices' => [
                     Location::SORT_ORDER_ASC => $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_ASC, [], 'ezrepoforms_content_type'),
                     Location::SORT_ORDER_DESC => $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_DESC, [], 'ezrepoforms_content_type'),
                 ],
                 'label' => 'content_type.default_sort_order',
             ])
-            ->add('defaultAlwaysAvailable', 'checkbox', [
+            ->add('defaultAlwaysAvailable', CheckboxType::class, [
                 'required' => false,
                 'label' => 'content_type.default_always_available',
             ])
-            ->add('fieldDefinitionsData', 'collection', [
-                'type' => 'ezrepoforms_fielddefinition_update',
-                'options' => ['languageCode' => $options['languageCode']],
+            ->add('fieldDefinitionsData', CollectionType::class, [
+                'entry_type' => FieldDefinitionType::class,
+                'entry_options' => ['languageCode' => $options['languageCode']],
                 'label' => 'content_type.field_definitions_data',
             ])
-            ->add('fieldTypeSelection', 'choice', [
+            ->add('fieldTypeSelection', ChoiceType::class, [
                 'choices' => $this->getFieldTypeList(),
                 'mapped' => false,
                 'label' => 'content_type.field_type_selection',
             ])
-            ->add('addFieldDefinition', 'submit', ['label' => 'content_type.add_field_definition'])
-            ->add('removeFieldDefinition', 'submit', ['label' => 'content_type.remove_field_definitions'])
-            ->add('saveContentType', 'submit', ['label' => 'content_type.save'])
-            ->add('removeDraft', 'submit', ['label' => 'content_type.remove_draft', 'validation_groups' => false])
-            ->add('publishContentType', 'submit', ['label' => 'content_type.publish']);
+            ->add('addFieldDefinition', SubmitType::class, ['label' => 'content_type.add_field_definition'])
+            ->add('removeFieldDefinition', SubmitType::class, ['label' => 'content_type.remove_field_definitions'])
+            ->add('saveContentType', SubmitType::class, ['label' => 'content_type.save'])
+            ->add('removeDraft', SubmitType::class, ['label' => 'content_type.remove_draft', 'validation_groups' => false])
+            ->add('publishContentType', SubmitType::class, ['label' => 'content_type.publish']);
     }
 
     /**

--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -47,6 +47,11 @@ class ContentTypeUpdateType extends AbstractType
 
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
         return 'ezrepoforms_contenttype_update';
     }
 

--- a/lib/Form/Type/DateTimeIntervalType.php
+++ b/lib/Form/Type/DateTimeIntervalType.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type;
 
@@ -26,6 +24,11 @@ class DateTimeIntervalType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'datetimeinterval';
     }

--- a/lib/Form/Type/DateTimeIntervalType.php
+++ b/lib/Form/Type/DateTimeIntervalType.php
@@ -12,6 +12,7 @@ namespace EzSystems\RepositoryForms\Form\Type;
 
 use EzSystems\RepositoryForms\Form\DataTransformer\DateIntervalToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -36,11 +37,11 @@ class DateTimeIntervalType extends AbstractType
     {
         $builder
             ->addViewTransformer(new DateIntervalToArrayTransformer())
-            ->add('year', 'integer')
-            ->add('month', 'integer')
-            ->add('day', 'integer')
-            ->add('hour', 'integer')
-            ->add('minute', 'integer')
-            ->add('second', 'integer');
+            ->add('year', IntegerType::class)
+            ->add('month', IntegerType::class)
+            ->add('day', IntegerType::class)
+            ->add('hour', IntegerType::class)
+            ->add('minute', IntegerType::class)
+            ->add('second', IntegerType::class);
     }
 }

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -12,7 +12,7 @@ namespace EzSystems\RepositoryForms\Form\Type\FieldDefinition;
 
 use eZ\Publish\API\Repository\FieldTypeService;
 use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
-use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcherInterface;
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -26,9 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class FieldDefinitionType extends AbstractType
 {
     /**
-     * @var FieldTypeFormMapperRegistryInterface
+     * @var \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcherInterface
      */
-    private $fieldTypeMapperRegistry;
+    private $fieldTypeMapperDispatcher;
 
     /**
      * @var FieldTypeService
@@ -40,9 +40,9 @@ class FieldDefinitionType extends AbstractType
      */
     private $groupsList;
 
-    public function __construct(FieldTypeFormMapperRegistryInterface $fieldTypeMapperRegistry, FieldTypeService $fieldTypeService)
+    public function __construct(FieldTypeFormMapperDispatcherInterface $fieldTypeMapperDispatcher, FieldTypeService $fieldTypeService)
     {
-        $this->fieldTypeMapperRegistry = $fieldTypeMapperRegistry;
+        $this->fieldTypeMapperDispatcher = $fieldTypeMapperDispatcher;
         $this->fieldTypeService = $fieldTypeService;
     }
 
@@ -112,10 +112,7 @@ class FieldDefinitionType extends AbstractType
             ]);
 
             // Let fieldType mappers do their jobs to complete the form.
-            if ($this->fieldTypeMapperRegistry->hasMapper($fieldTypeIdentifier)) {
-                $mapper = $this->fieldTypeMapperRegistry->getMapper($fieldTypeIdentifier);
-                $mapper->mapFieldDefinitionForm($form, $data);
-            }
+            $this->fieldTypeMapperDispatcher->map($form, $data);
         });
     }
 

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -15,6 +15,10 @@ use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
 use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcherInterface;
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -71,31 +75,31 @@ class FieldDefinitionType extends AbstractType
         $translatablePropertyTransformer = new TranslatablePropertyTransformer($options['languageCode']);
         $builder
             ->add(
-                $builder->create('name', 'text', ['property_path' => 'names', 'label' => 'field_definition.name'])
+                $builder->create('name', TextType::class, ['property_path' => 'names', 'label' => 'field_definition.name'])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('identifier', 'text', ['label' => 'field_definition.identifier'])
+            ->add('identifier', TextType::class, ['label' => 'field_definition.identifier'])
             ->add(
-                $builder->create('description', 'text', [
+                $builder->create('description', TextType::class, [
                     'property_path' => 'descriptions',
                     'required' => false,
                     'label' => 'field_definition.description',
                 ])
                     ->addModelTransformer($translatablePropertyTransformer)
             )
-            ->add('isRequired', 'checkbox', ['required' => false, 'label' => 'field_definition.is_required'])
-            ->add('isTranslatable', 'checkbox', ['required' => false, 'label' => 'field_definition.is_translatable'])
+            ->add('isRequired', CheckboxType::class, ['required' => false, 'label' => 'field_definition.is_required'])
+            ->add('isTranslatable', CheckboxType::class, ['required' => false, 'label' => 'field_definition.is_translatable'])
             ->add(
                 'fieldGroup',
-                'choice', [
+                ChoiceType::class, [
                     'choices' => $fieldsGroups,
                     'choices_as_values' => true,
                     'required' => false,
                     'label' => 'field_definition.field_group',
                 ]
             )
-            ->add('position', 'integer', ['label' => 'field_definition.position'])
-            ->add('selected', 'checkbox', ['required' => false, 'mapped' => false]);
+            ->add('position', IntegerType::class, ['label' => 'field_definition.position'])
+            ->add('selected', CheckboxType::class, ['required' => false, 'mapped' => false]);
 
         // Hook on form generation for specific FieldType needs
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
@@ -105,7 +109,7 @@ class FieldDefinitionType extends AbstractType
             $fieldTypeIdentifier = $data->getFieldTypeIdentifier();
             $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
             // isSearchable field should be present only if the FieldType allows it.
-            $form->add('isSearchable', 'checkbox', [
+            $form->add('isSearchable', CheckboxType::class, [
                 'required' => false,
                 'disabled' => !$fieldType->isSearchable(),
                 'label' => 'field_definition.is_searchable',

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\FieldDefinition;
 
@@ -121,6 +119,11 @@ class FieldDefinitionType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_fielddefinition_update';
     }

--- a/lib/Form/Type/Language/LanguageDeleteType.php
+++ b/lib/Form/Type/Language/LanguageDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Language;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,8 +24,8 @@ class LanguageDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('languageId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'language.form.delete']);
+            ->add('languageId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'language.form.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/Language/LanguageDeleteType.php
+++ b/lib/Form/Type/Language/LanguageDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Language;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class LanguageDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_language_delete';
     }

--- a/lib/Form/Type/Language/LanguageType.php
+++ b/lib/Form/Type/Language/LanguageType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Language;
 
@@ -27,6 +26,11 @@ class LanguageType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_language_edit';
     }

--- a/lib/Form/Type/Language/LanguageType.php
+++ b/lib/Form/Type/Language/LanguageType.php
@@ -9,6 +9,9 @@
 namespace EzSystems\RepositoryForms\Form\Type\Language;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,10 +20,10 @@ class LanguageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text')
-            ->add('languageCode', 'text')
-            ->add('enabled', 'checkbox', ['required' => false])
-            ->add('save', 'submit', ['label' => 'language.form.save']);
+            ->add('name', TextType::class)
+            ->add('languageCode', TextType::class)
+            ->add('enabled', CheckboxType::class, ['required' => false])
+            ->add('save', SubmitType::class, ['label' => 'language.form.save']);
     }
 
     public function getName()

--- a/lib/Form/Type/Role/LimitationType.php
+++ b/lib/Form/Type/Role/LimitationType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -83,6 +82,11 @@ class LimitationType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_policy_limitation_edit';
     }

--- a/lib/Form/Type/Role/PolicyDeleteType.php
+++ b/lib/Form/Type/Role/PolicyDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PolicyDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_policy_delete';
     }

--- a/lib/Form/Type/Role/PolicyDeleteType.php
+++ b/lib/Form/Type/Role/PolicyDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,9 +24,9 @@ class PolicyDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('policyId', 'hidden')
-            ->add('roleId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'role.policy.form.delete']);
+            ->add('policyId', HiddenType::class)
+            ->add('roleId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'role.policy.form.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/Role/PolicyType.php
+++ b/lib/Form/Type/Role/PolicyType.php
@@ -10,6 +10,9 @@ namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use eZ\Publish\API\Repository\RoleService;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -86,13 +89,13 @@ class PolicyType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('moduleFunction', 'choice', [
+            ->add('moduleFunction', ChoiceType::class, [
                 'choices' => $this->policyChoices,
                 'label' => 'role.policy.type',
                 'placeholder' => 'role.policy.type.choose',
             ])
-            ->add('removeDraft', 'submit', ['label' => 'role.cancel', 'validation_groups' => false])
-            ->add('savePolicy', 'submit', ['label' => 'role.policy.save']);
+            ->add('removeDraft', SubmitType::class, ['label' => 'role.cancel', 'validation_groups' => false])
+            ->add('savePolicy', SubmitType::class, ['label' => 'role.policy.save']);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             /** @var \EzSystems\RepositoryForms\Data\Role\PolicyCreateData|\EzSystems\RepositoryForms\Data\Role\PolicyUpdateData $data */
@@ -101,12 +104,12 @@ class PolicyType extends AbstractType
 
             if ($module = $data->getModule()) {
                 $form
-                    ->add('limitationsData', 'collection', [
+                    ->add('limitationsData', CollectionType::class, [
                         'type' => 'ezrepoforms_policy_limitation_edit',
                         'label' => 'role.policy.available_limitations',
                     ]);
             } else {
-                $form->add('saveAndAddLimitation', 'submit', ['label' => 'role.policy.save_and_add_limitation']);
+                $form->add('saveAndAddLimitation', SubmitType::class, ['label' => 'role.policy.save_and_add_limitation']);
             }
         });
     }

--- a/lib/Form/Type/Role/PolicyType.php
+++ b/lib/Form/Type/Role/PolicyType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -115,6 +114,11 @@ class PolicyType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_policy_edit';
     }

--- a/lib/Form/Type/Role/RoleAssignmentDeleteType.php
+++ b/lib/Form/Type/Role/RoleAssignmentDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RoleAssignmentDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_role_assignmentdelete';
     }

--- a/lib/Form/Type/Role/RoleAssignmentDeleteType.php
+++ b/lib/Form/Type/Role/RoleAssignmentDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,8 +24,8 @@ class RoleAssignmentDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('assignmentId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'role.assignment.form.delete']);
+            ->add('assignmentId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'role.assignment.form.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/Role/RoleCreateType.php
+++ b/lib/Form/Type/Role/RoleCreateType.php
@@ -9,6 +9,7 @@
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,6 +27,6 @@ class RoleCreateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('create', 'submit', ['label' => 'role.create']);
+        $builder->add('create', SubmitType::class, ['label' => 'role.create']);
     }
 }

--- a/lib/Form/Type/Role/RoleCreateType.php
+++ b/lib/Form/Type/Role/RoleCreateType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -16,6 +15,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RoleCreateType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_role_create';
     }

--- a/lib/Form/Type/Role/RoleDeleteType.php
+++ b/lib/Form/Type/Role/RoleDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -17,6 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RoleDeleteType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_role_delete';
     }

--- a/lib/Form/Type/Role/RoleDeleteType.php
+++ b/lib/Form/Type/Role/RoleDeleteType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,8 +24,8 @@ class RoleDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('roleId', 'hidden')
-            ->add('delete', 'submit', ['label' => 'role.form.delete']);
+            ->add('roleId', HiddenType::class)
+            ->add('delete', SubmitType::class, ['label' => 'role.form.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/Role/RoleUpdateType.php
+++ b/lib/Form/Type/Role/RoleUpdateType.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
@@ -22,6 +20,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RoleUpdateType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_role_update';
     }

--- a/lib/Form/Type/Role/RoleUpdateType.php
+++ b/lib/Form/Type/Role/RoleUpdateType.php
@@ -11,6 +11,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -36,8 +38,8 @@ class RoleUpdateType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('identifier', 'text', ['label' => 'role.identifier'])
-            ->add('saveRole', 'submit', ['label' => 'role.save'])
-            ->add('removeDraft', 'submit', ['label' => 'role.remove_draft', 'validation_groups' => false]);
+            ->add('identifier', TextType::class, ['label' => 'role.identifier'])
+            ->add('saveRole', SubmitType::class, ['label' => 'role.save'])
+            ->add('removeDraft', SubmitType::class, ['label' => 'role.remove_draft', 'validation_groups' => false]);
     }
 }

--- a/lib/Form/Type/Section/SectionDeleteType.php
+++ b/lib/Form/Type/Section/SectionDeleteType.php
@@ -10,6 +10,8 @@ namespace EzSystems\RepositoryForms\Form\Type\Section;
 
 use eZ\Publish\API\Repository\SectionService;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Callback;
@@ -35,7 +37,7 @@ class SectionDeleteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('sectionId', 'hidden', [
+            ->add('sectionId', HiddenType::class, [
                 'constraints' => new Callback(
                     function ($sectionId, ExecutionContextInterface $context) {
                         $contentCount = $this->sectionService->countAssignedContents(
@@ -50,7 +52,7 @@ class SectionDeleteType extends AbstractType
                     }
                 ),
             ])
-            ->add('delete', 'submit', ['label' => 'section.form.delete']);
+            ->add('delete', SubmitType::class, ['label' => 'section.form.delete']);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/lib/Form/Type/Section/SectionDeleteType.php
+++ b/lib/Form/Type/Section/SectionDeleteType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Section;
 
@@ -30,6 +29,11 @@ class SectionDeleteType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_section_delete';
     }

--- a/lib/Form/Type/Section/SectionType.php
+++ b/lib/Form/Type/Section/SectionType.php
@@ -9,6 +9,8 @@
 namespace EzSystems\RepositoryForms\Form\Type\Section;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,9 +19,9 @@ class SectionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text')
-            ->add('identifier', 'text')
-            ->add('save', 'submit', ['label' => 'section.form.save']);
+            ->add('name', TextType::class)
+            ->add('identifier', TextType::class)
+            ->add('save', SubmitType::class, ['label' => 'section.form.save']);
     }
 
     public function getName()

--- a/lib/Form/Type/Section/SectionType.php
+++ b/lib/Form/Type/Section/SectionType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\Section;
 
@@ -25,6 +24,11 @@ class SectionType extends AbstractType
     }
 
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezrepoforms_section_edit';
     }

--- a/lib/Form/Type/User/UserAccountType.php
+++ b/lib/Form/Type/User/UserAccountType.php
@@ -9,6 +9,10 @@
 namespace EzSystems\RepositoryForms\Form\Type\User;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,19 +26,19 @@ class UserAccountType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('username', 'text', [
+            ->add('username', TextType::class, [
                 'property_path' => 'username',
                 'label' => 'content.field_type.ezuser.username',
                 'required' => $options['required'],
             ])
-            ->add('password', 'repeated', [
-                'type' => 'password',
+            ->add('password', RepeatedType::class, [
+                'type' => PasswordType::class,
                 'required' => true,
                 'property_path' => 'password',
                 'first_options' => ['label' => 'content.field_type.ezuser.password'],
                 'second_options' => ['label' => 'content.field_type.ezuser.password_confirm'],
             ])
-            ->add('email', 'email', [
+            ->add('email', EmailType::class, [
                 'label' => 'content.field_type.ezuser.email',
             ]);
     }

--- a/lib/Form/Type/User/UserAccountType.php
+++ b/lib/Form/Type/User/UserAccountType.php
@@ -4,7 +4,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\RepositoryForms\Form\Type\User;
 
@@ -19,6 +18,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class UserAccountType extends AbstractType
 {
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
     {
         return 'ezuser';
     }

--- a/lib/Form/Type/User/UserRegisterType.php
+++ b/lib/Form/Type/User/UserRegisterType.php
@@ -7,7 +7,11 @@
  */
 namespace EzSystems\RepositoryForms\Form\Type\User;
 
+use EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -28,14 +32,14 @@ class UserRegisterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('fieldsData', 'collection', [
-                'type' => 'ezrepoforms_content_field',
+            ->add('fieldsData', CollectionType::class, [
+                'entry_type' => ContentFieldType::class,
                 'label' => 'ezrepoforms.content.fields',
-                'options' => ['languageCode' => $options['languageCode']],
+                'entry_options' => ['languageCode' => $options['languageCode']],
             ])
-            ->add('redirectUrlAfterPublish', 'hidden', ['required' => false, 'mapped' => false])
+            ->add('redirectUrlAfterPublish', HiddenType::class, ['required' => false, 'mapped' => false])
             // @todo add the string to its own domain
-            ->add('publish', 'submit', ['label' => 'user.register_button'])
+            ->add('publish', SubmitType::class, ['label' => 'user.register_button'])
             ->addEventListener(
                 FormEvents::POST_SUBMIT,
                 array($this, 'mapUserFieldToUserCreate')

--- a/lib/Form/Type/User/UserRegisterType.php
+++ b/lib/Form/Type/User/UserRegisterType.php
@@ -26,6 +26,11 @@ class UserRegisterType extends AbstractType
 {
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
         return 'ezrepoforms_user_register';
     }
 

--- a/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
+++ b/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
@@ -10,6 +10,7 @@ namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
 /**
@@ -34,7 +35,7 @@ abstract class MultipleSelectionBasedMapper implements LimitationFormMapperInter
         $choices = $this->getSelectionChoices();
         asort($choices, SORT_NATURAL | SORT_FLAG_CASE);
         $options += ['choices' => $choices];
-        $form->add('limitationValues', 'choice', $options);
+        $form->add('limitationValues', ChoiceType::class, $options);
     }
 
     /**

--- a/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -11,6 +11,7 @@ namespace EzSystems\RepositoryForms\Limitation\Mapper;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueTransformer;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormInterface;
 
 /**
@@ -40,7 +41,7 @@ class UDWBasedMapper implements LimitationFormMapperInterface
         $form->add(
             // Creating from FormBuilder as we need to add a DataTransformer.
             $form->getConfig()->getFormFactory()->createBuilder()
-                ->create('limitationValues', 'hidden', [
+                ->create('limitationValues', HiddenType::class, [
                     'required' => false,
                     'label' => $data->getIdentifier(),
                 ])

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,9 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          syntaxCheck="true">
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
     <testsuites>
         <testsuite name="RepositoryForms tests">
             <directory suffix="Test.php">./tests/</directory>


### PR DESCRIPTION
JIRA Story: [EZP-26128](https://jira.ez.no/browse/EZP-26128)

**TODO**:
- [x] Quote service references in Yaml files (3e12b51).
- [x] Quote parameter references in Yaml files (93996e2).
- [x] Make sure tests are run with full error reporting (5ffa8a7).
- [x] Cleanup `services.yml` to keep the code consistent (2a86fb4).
- [x] Replace references of deprecated `FieldTypeFormMapperInterface` with `FieldDefinitionFormMapperInterface` (cb8a97c).
- [x] Replace references of deprecated ez.fieldType.formMapper service tag with `ez.fieldFormMapper.value` or/and  `ez.fieldFormMapper.definition` depending on an interface a mapper implements (c7e291b).
- [x] Replace string references of form field types with fully-qualified type class names (d1ac248).
- [x] Replaced deprecated FormTypeInterface::getName with getBlockPrefix (9d35c16).
- [x] Create missing services for some custom form types defined in `EzSystems\RepositoryForms\Form\Type` namespace to be able to reference them with fully-qualified class name instead of [instantiating them manually](https://github.com/ezsystems/PlatformUIBundle/blob/1.4/Controller/SectionController.php#L84) which is deprecated.

@glye: thanks for help with this :)