### PR TITLE
Fix EZP-26148: String length validation error contains %-symbols

### DIFF
--- a/lib/Validator/Constraints/FieldTypeValidator.php
+++ b/lib/Validator/Constraints/FieldTypeValidator.php
@@ -39,9 +39,7 @@ abstract class FieldTypeValidator extends ConstraintValidator
             $message = $error->getTranslatableMessage();
             /** @var \Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface $violationBuilder */
             $violationBuilder = $this->context->buildViolation($message instanceof Plural ? $message->plural : $message->message);
-            foreach ($message->values as $parameter => $parameterValue) {
-                $violationBuilder->setParameter("%$parameter%", $parameterValue);
-            }
+            $violationBuilder->setParameters($message->values);
 
             $propertyPath = $this->generatePropertyPath($i, $error->getTarget());
             if ($propertyPath) {

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
@@ -81,7 +81,7 @@ class FieldSettingsValidatorTest extends PHPUnit_Framework_TestCase
     {
         $fieldTypeIdentifier = 'ezstring';
         $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
-        $fieldSettings = ['foo' => 'bar'];
+        $fieldSettings = ['%foo%' => 'bar'];
         $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'fieldSettings' => $fieldSettings]);
         $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
         $this->fieldTypeService

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
@@ -110,8 +110,8 @@ class FieldSettingsValidatorTest extends PHPUnit_Framework_TestCase
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
             ->expects($this->once())
-            ->method('setParameter')
-            ->with('%foo%', $errorParameter)
+            ->method('setParameters')
+            ->with(['%foo%' => $errorParameter])
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
             ->expects($this->once())

--- a/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/FieldSettingsValidatorTest.php
@@ -96,7 +96,7 @@ class FieldSettingsValidatorTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('validateFieldSettings')
             ->with($fieldSettings)
-            ->willReturn([new ValidationError($errorMessage, null, ['foo' => $errorParameter])]);
+            ->willReturn([new ValidationError($errorMessage, null, ['%foo%' => $errorParameter])]);
 
         $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
         $this->executionContext

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
@@ -110,8 +110,8 @@ class ValidatorConfigurationValidatorTest extends PHPUnit_Framework_TestCase
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
             ->expects($this->once())
-            ->method('setParameter')
-            ->with('%foo%', $errorParameter)
+            ->method('setParameters')
+            ->with(['%foo%' => $errorParameter])
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
             ->expects($this->once())

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
@@ -81,7 +81,7 @@ class ValidatorConfigurationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $fieldTypeIdentifier = 'ezstring';
         $fieldDefinition = new FieldDefinition(['fieldTypeIdentifier' => $fieldTypeIdentifier]);
-        $validatorConfiguration = ['foo' => 'bar'];
+        $validatorConfiguration = ['%foo%' => 'bar'];
         $fieldDefData = new FieldDefinitionData(['identifier' => 'foo', 'fieldDefinition' => $fieldDefinition, 'validatorConfiguration' => $validatorConfiguration]);
         $fieldType = $this->getMock('\eZ\Publish\API\Repository\FieldType');
         $this->fieldTypeService

--- a/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/ValidatorConfigurationValidatorTest.php
@@ -96,7 +96,7 @@ class ValidatorConfigurationValidatorTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('validateValidatorConfiguration')
             ->with($validatorConfiguration)
-            ->willReturn([new ValidationError($errorMessage, null, ['foo' => $errorParameter])]);
+            ->willReturn([new ValidationError($errorMessage, null, ['%foo%' => $errorParameter])]);
 
         $constraintViolationBuilder = $this->getMock('\Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
         $this->executionContext


### PR DESCRIPTION
> Follow up to https://jira.ez.no/browse/EZP-26148
> Status: Ready for review

During https://github.com/ezsystems/repository-forms/pull/93 it was found that https://github.com/ezsystems/ezpublish-kernel/pull/1749 introduced a regression in repoforms. It turns out that repoforms automatically wraps field error parameters in `%`s, while kernel REST doesn't. So the fix in the kernel meant we got double-wrapped params in repoforms.

This undoes the wrapping in repoforms, while simplifying the code.

**Alternative:** Introduce automatic %-wrapping in REST. I'm not a fan, because a) KISS, and b) Symfony docs assume no automagic, let's stay in sync with that: http://symfony.com/doc/2.7/components/translation/usage.html#message-placeholders