### PR TITLE
EZP-26128: Fix deprecated form field ChoiceType options

### DIFF
--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -11,7 +11,6 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\CountryValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
-use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
@@ -48,20 +47,8 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface
                     ->create(
                         'defaultValue',
                         ChoiceType::class, [
-                            'choice_list' => new ChoiceList(
-                                array_map(
-                                    function ($country) {
-                                        return $country['Alpha2'];
-                                    },
-                                    $this->countriesInfo
-                                ),
-                                array_map(
-                                    function ($country) {
-                                        return $country['Name'];
-                                    },
-                                    $this->countriesInfo
-                                )
-                            ),
+                            'choices' => $this->getCountryChoices($this->countriesInfo),
+                            'choices_as_values' => true,
                             'multiple' => true,
                             'expanded' => false,
                             'required' => false,
@@ -72,5 +59,15 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface
                     // Deactivate auto-initialize as we're not on the root form.
                     ->setAutoInitialize(false)->getForm()
             );
+    }
+
+    private function getCountryChoices(array $countriesInfo)
+    {
+        $choices = [];
+        foreach ($countriesInfo as $country) {
+            $choices[$country['Name']] = $country['Alpha2'];
+        }
+
+        return $choices;
     }
 }

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -24,9 +24,10 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface
                 ChoiceType::class,
                 [
                     'choices' => [
-                        Type::DEFAULT_EMPTY => 'field_definition.ezdate.default_type_empty',
-                        Type::DEFAULT_CURRENT_DATE => 'field_definition.ezdate.default_type_current',
+                        'field_definition.ezdate.default_type_empty' => Type::DEFAULT_EMPTY,
+                        'field_definition.ezdate.default_type_current' => Type::DEFAULT_CURRENT_DATE,
                     ],
+                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'property_path' => 'fieldSettings[defaultType]',

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -28,10 +28,11 @@ class DateTimeFormMapper implements FieldDefinitionFormMapperInterface
             ])
             ->add('defaultType', ChoiceType::class, [
                 'choices' => [
-                    Type::DEFAULT_EMPTY => 'field_definition.ezdatetime.default_type_empty',
-                    Type::DEFAULT_CURRENT_DATE => 'field_definition.ezdatetime.default_type_current',
-                    Type::DEFAULT_CURRENT_DATE_ADJUSTED => 'field_definition.ezdatetime.default_type_adjusted',
+                    'field_definition.ezdatetime.default_type_empty' => Type::DEFAULT_EMPTY,
+                    'field_definition.ezdatetime.default_type_current' => Type::DEFAULT_CURRENT_DATE,
+                    'field_definition.ezdatetime.default_type_adjusted' => Type::DEFAULT_CURRENT_DATE_ADJUSTED,
                 ],
+                'choices_as_values' => true,
                 'expanded' => true,
                 'required' => true,
                 'property_path' => 'fieldSettings[defaultType]',

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -27,14 +27,15 @@ class MediaFormMapper implements FieldDefinitionFormMapperInterface
             ])
             ->add('mediaType', ChoiceType::class, [
                 'choices' => [
-                    Type::TYPE_HTML5_VIDEO => 'field_definition.ezmedia.type_html5_video',
-                    Type::TYPE_FLASH => 'field_definition.ezmedia.type_flash',
-                    Type::TYPE_QUICKTIME => 'field_definition.ezmedia.type_quick_time',
-                    Type::TYPE_REALPLAYER => 'field_definition.ezmedia.type_real_player',
-                    Type::TYPE_SILVERLIGHT => 'field_definition.ezmedia.type_silverlight',
-                    Type::TYPE_WINDOWSMEDIA => 'field_definition.ezmedia.type_windows_media_player',
-                    Type::TYPE_HTML5_AUDIO => 'field_definition.ezmedia.type_html5_audio',
+                    'field_definition.ezmedia.type_html5_video' => Type::TYPE_HTML5_VIDEO,
+                    'field_definition.ezmedia.type_flash' => Type::TYPE_FLASH,
+                    'field_definition.ezmedia.type_quick_time' => Type::TYPE_QUICKTIME,
+                    'field_definition.ezmedia.type_real_player' => Type::TYPE_REALPLAYER,
+                    'field_definition.ezmedia.type_silverlight' => Type::TYPE_SILVERLIGHT,
+                    'field_definition.ezmedia.type_windows_media_player' => Type::TYPE_WINDOWSMEDIA,
+                    'field_definition.ezmedia.type_html5_audio' => Type::TYPE_HTML5_AUDIO,
                 ],
+                'choices_as_values' => true,
                 'required' => true,
                 'property_path' => 'fieldSettings[mediaType]',
                 'label' => 'field_definition.ezmedia.media_type',

--- a/lib/FieldType/Mapper/PageFormMapper.php
+++ b/lib/FieldType/Mapper/PageFormMapper.php
@@ -36,6 +36,7 @@ class PageFormMapper implements FieldDefinitionFormMapperInterface
         $fieldDefinitionForm
             ->add('defaultLayout', ChoiceType::class, [
                 'choices' => array_combine($availableLayouts, $availableLayouts),
+                'choices_as_values' => true,
                 'multiple' => false,
                 'expanded' => false,
                 'required' => false,

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -45,10 +45,10 @@ class RelationListFormMapper implements FieldDefinitionFormMapperInterface
         $contentTypeHash = [];
         foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
             foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
-                $contentTypeHash[$contentType->identifier] = $this->translationHelper->getTranslatedByProperty($contentType, 'names');
+                $contentTypeHash[$this->translationHelper->getTranslatedByProperty($contentType, 'names')] = $contentType->identifier;
             }
         }
-        asort($contentTypeHash);
+        ksort($contentTypeHash);
 
         $fieldDefinitionForm
             ->add('selectionDefaultLocation', HiddenType::class, [
@@ -58,6 +58,7 @@ class RelationListFormMapper implements FieldDefinitionFormMapperInterface
             ])
             ->add('selectionContentTypes', ChoiceType::class, [
                 'choices' => $contentTypeHash,
+                'choices_as_values' => true,
                 'expanded' => false,
                 'multiple' => true,
                 'required' => false,

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -34,9 +34,10 @@ class TimeFormMapper implements FieldDefinitionFormMapperInterface
                 ChoiceType::class,
                 [
                     'choices' => [
-                        Type::DEFAULT_EMPTY => 'field_definition.eztime.default_type_empty',
-                        Type::DEFAULT_CURRENT_TIME => 'field_definition.eztime.default_type_current',
+                        'field_definition.eztime.default_type_empty' => Type::DEFAULT_EMPTY,
+                        'field_definition.eztime.default_type_current' => Type::DEFAULT_CURRENT_TIME,
                     ],
+                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'property_path' => 'fieldSettings[defaultType]',

--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -89,23 +89,25 @@ class ContentTypeUpdateType extends AbstractType
             ->add('isContainer', CheckboxType::class, ['required' => false, 'label' => 'content_type.is_container'])
             ->add('defaultSortField', ChoiceType::class, [
                 'choices' => [
-                    Location::SORT_FIELD_NAME => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_NAME, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_CLASS_NAME => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_CLASS_NAME, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_CLASS_IDENTIFIER => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_CLASS_IDENTIFIER, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_DEPTH => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_DEPTH, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_PATH => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PATH, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_PRIORITY => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PRIORITY, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_MODIFIED => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_MODIFIED, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_PUBLISHED => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PUBLISHED, [], 'ezrepoforms_content_type'),
-                    Location::SORT_FIELD_SECTION => $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_SECTION, [], 'ezrepoforms_content_type'),
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_NAME, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_NAME,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_CLASS_NAME, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_CLASS_NAME,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_CLASS_IDENTIFIER, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_CLASS_IDENTIFIER,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_DEPTH, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_DEPTH,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PATH, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PATH,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PRIORITY, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PRIORITY,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_MODIFIED, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_MODIFIED,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_PUBLISHED, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PUBLISHED,
+                    $this->translator->trans('content_type.sort_field.' . Location::SORT_FIELD_SECTION, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_SECTION,
                 ],
+                'choices_as_values' => true,
                 'label' => 'content_type.default_sort_field',
             ])
             ->add('defaultSortOrder', ChoiceType::class, [
                 'choices' => [
-                    Location::SORT_ORDER_ASC => $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_ASC, [], 'ezrepoforms_content_type'),
-                    Location::SORT_ORDER_DESC => $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_DESC, [], 'ezrepoforms_content_type'),
+                    $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_ASC, [], 'ezrepoforms_content_type') => Location::SORT_ORDER_ASC,
+                    $this->translator->trans('content_type.sort_order.' . Location::SORT_ORDER_DESC, [], 'ezrepoforms_content_type') => Location::SORT_ORDER_DESC,
                 ],
+                'choices_as_values' => true,
                 'label' => 'content_type.default_sort_order',
             ])
             ->add('defaultAlwaysAvailable', CheckboxType::class, [
@@ -118,7 +120,8 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.field_definitions_data',
             ])
             ->add('fieldTypeSelection', ChoiceType::class, [
-                'choices' => $this->getFieldTypeList(),
+                'choices' => array_flip($this->getFieldTypeList()),
+                'choices_as_values' => true,
                 'mapped' => false,
                 'label' => 'content_type.field_type_selection',
             ])

--- a/lib/Form/Type/DateTimeIntervalType.php
+++ b/lib/Form/Type/DateTimeIntervalType.php
@@ -10,6 +10,7 @@ namespace EzSystems\RepositoryForms\Form\Type;
 
 use EzSystems\RepositoryForms\Form\DataTransformer\DateIntervalToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -20,7 +21,7 @@ class DateTimeIntervalType extends AbstractType
 {
     public function getParent()
     {
-        return 'form';
+        return FormType::class;
     }
 
     public function getName()

--- a/lib/Form/Type/Role/PolicyType.php
+++ b/lib/Form/Type/Role/PolicyType.php
@@ -51,16 +51,16 @@ class PolicyType extends AbstractType
      */
     private function buildPolicyChoicesFromMap($policyMap)
     {
-        $policyChoices = ['role.policy.all_modules' => ['*|*' => 'role.policy.all_modules_all_functions']];
+        $policyChoices = ['role.policy.all_modules' => ['role.policy.all_modules_all_functions' => '*|*']];
         foreach ($policyMap as $module => $functionList) {
             $humanizedModule = $this->humanize($module);
             // For each module, add possibility to grant access to all functions.
             $policyChoices[$humanizedModule] = [
-                "$module|*" => "$humanizedModule / " . $this->translator->trans('role.policy.all_functions', [], 'ezrepoforms_role'),
+                "$humanizedModule / " . $this->translator->trans('role.policy.all_functions', [], 'ezrepoforms_role') => "$module|*",
             ];
 
             foreach ($functionList as $function => $limitationList) {
-                $policyChoices[$humanizedModule]["$module|$function"] = $humanizedModule . ' / ' . $this->humanize($function);
+                $policyChoices[$humanizedModule][$humanizedModule . ' / ' . $this->humanize($function)] = "$module|$function";
             }
         }
 
@@ -90,6 +90,7 @@ class PolicyType extends AbstractType
         $builder
             ->add('moduleFunction', ChoiceType::class, [
                 'choices' => $this->policyChoices,
+                'choices_as_values' => true,
                 'label' => 'role.policy.type',
                 'placeholder' => 'role.policy.type.choose',
             ])
@@ -104,7 +105,7 @@ class PolicyType extends AbstractType
             if ($module = $data->getModule()) {
                 $form
                     ->add('limitationsData', CollectionType::class, [
-                        'type' => 'ezrepoforms_policy_limitation_edit',
+                        'entry_type' => LimitationType::class,
                         'label' => 'role.policy.available_limitations',
                     ]);
             } else {

--- a/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
+++ b/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
@@ -34,7 +34,7 @@ abstract class MultipleSelectionBasedMapper implements LimitationFormMapperInter
         ];
         $choices = $this->getSelectionChoices();
         asort($choices, SORT_NATURAL | SORT_FLAG_CASE);
-        $options += ['choices' => $choices];
+        $options += ['choices' => array_flip($choices), 'choices_as_values' => true];
         $form->add('limitationValues', ChoiceType::class, $options);
     }
 


### PR DESCRIPTION
This PR is related to [EZP-26128](https://jira.ez.no/browse/EZP-26128) and fixes deprecations related to `choices_as_values` option of `ChoiceType` form field. Required changes are described in [upgrade notes](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form).

**TODO**:
- [x] Set `choices_as_values` option of `ChoiceType` form field to `true` and flip an array of options (by default it is set to `false` which generates deprecation warnings).
- [x] Replace deprecated string type name returned by `FormTypeInterface::getParent` with FQCN.

*This should be a part of #93 but I've missed those warnings before, sorry for the mess.*
