### PR TITLE
Allow Symfony 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": "~5.5|~7.0",
         "ezsystems/ezpublish-kernel": "^6.4",
-        "symfony/form": "~2.8",
-        "symfony/validator": "~2.8"
+        "symfony/form": "~2.8|~3.0",
+        "symfony/validator": "~2.8|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
> Fixes [EZP-26234](http://jira.ez.no/browse/EZP-26234)

While the kernel accepts Sf 3.0, this package doesn't, thus blocking its installation.

Opened against 1.4 as master is still on this branch.