### PR TITLE
Use symfony/symfony in require section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "require": {
         "php": "~5.5|~7.0",
         "ezsystems/ezpublish-kernel": "^6.4",
-        "symfony/form": "~2.8",
-        "symfony/validator": "~2.8"
+        "symfony/symfony": "^2.8 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",


### PR DESCRIPTION
Reasoning:

1) This would allow to test eZ Platform 1.5 with Symfony 3.x
2) `require` section is wrong anyhow, since it's missing some other dependencies, like Twig or Symfony Event Dispatcher component, for stuff available in `lib`