### PR TITLE
EZP-26728: removed PHP 5.5 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ matrix:
   # mark as finished before allow_failures are run
   fast_finish: true
   include:
-    # 5.5
-    - php: 5.5
-      env: TEST_CONFIG="phpunit.xml.dist"
-    - php: 5.5
-      env: BEHAT_OPTS="--profile=repository-forms"
-     # 5.6
+    # 5.6
     - php: 5.6
       env: TEST_CONFIG="phpunit.xml.dist"
     - php: 5.6


### PR DESCRIPTION
> [EZP-26728](http://jira.ez.no/browse/EZP-26728)