### PR TITLE
EZP-25007: "Number of text rows in the editor" should be removed from RichText fieldtype

### DIFF
--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -414,12 +414,6 @@
         <note>key: field_definition.ezpage.default_layout</note>
         <jms:reference-file line="45">lib/FieldType/Mapper/PageFormMapper.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="5f4e08d826e58f0be9e678f7c7a60068fd63b567" resname="field_definition.ezrichtext.num_rows">
-        <source>Number of text rows in the editor</source>
-        <target>Number of text rows in the editor</target>
-        <note>key: field_definition.ezrichtext.num_rows</note>
-        <jms:reference-file line="26">lib/FieldType/Mapper/RichTextFormMapper.php</jms:reference-file>
-      </trans-unit>
       <trans-unit id="e9e5a43d734719bf6ca42940c1cf5bc78b234e2b" resname="field_definition.ezselection.is_multiple">
         <source>Multiple choice</source>
         <target>Multiple choice</target>

--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -168,14 +168,6 @@
     </div>
 {% endblock %}
 
-{% block ezrichtext_field_definition_edit %}
-    <div class="ezrichtext-settings num-rows{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_label(form.numRows) -}}
-        {{- form_errors(form.numRows) -}}
-        {{- form_widget(form.numRows) -}}
-    </div>
-{% endblock %}
-
 {% block ezselection_field_definition_edit %}
     <div class="ezselection-settings is-multiple{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_label(form.isMultiple) -}}

--- a/lib/FieldType/Mapper/RichTextFormMapper.php
+++ b/lib/FieldType/Mapper/RichTextFormMapper.php
@@ -11,20 +11,12 @@ namespace EzSystems\RepositoryForms\FieldType\Mapper;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RichTextFormMapper implements FieldDefinitionFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
-        $fieldDefinitionForm
-            ->add('numRows', IntegerType::class, [
-                'empty_data' => 10,
-                'required' => true,
-                'property_path' => 'fieldSettings[numRows]',
-                'label' => 'field_definition.ezrichtext.num_rows',
-            ]);
     }
 
     /**


### PR DESCRIPTION
> Fixes [EZP-25007](https://jira.ez.no/browse/EZP-25007)
> **IMPORTANT**: It has to be merged along with [Kernel PR #1915](https://github.com/ezsystems/ezpublish-kernel/pull/1915).

This PR removes `numRows` setting from the `RichText` Field Type and will also have its ezpublish-kernel counterpart.

**TODO**:
- [x] Remove all references of `numRows` setting from repository-forms.
- [x] Create corresponding ezpublish-kernel PR ([#1915](https://github.com/ezsystems/ezpublish-kernel/pull/1915)).
- [ ] Create test (?).