### PR TITLE
Fix EZP-27221: it is not possible to empty the urlAliasSchema field

### DIFF
--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -86,7 +86,7 @@ class ContentTypeUpdateType extends AbstractType
                     ->addModelTransformer($translatablePropertyTransformer)
             )
             ->add('nameSchema', TextType::class, ['required' => false, 'label' => 'content_type.name_schema'])
-            ->add('urlAliasSchema', TextType::class, ['required' => false, 'label' => 'content_type.url_alias_schema'])
+            ->add('urlAliasSchema', TextType::class, ['required' => false, 'label' => 'content_type.url_alias_schema', 'empty_data' => false])
             ->add('isContainer', CheckboxType::class, ['required' => false, 'label' => 'content_type.is_container'])
             ->add('defaultSortField', ChoiceType::class, [
                 'choices' => [


### PR DESCRIPTION
> Fixes [EZP-27221](https://jira.ez.no/browse/EZP-27221)

The [Repository's mapper](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php#L145-L145) will ignore the value if it is set to null. This sets the `empty_value` for the urlAliasSchema to false so that it is not ignored.