### PR TITLE
Fix EZP-25923: Creating a content type without attributes raise a 503 Service Unavailable

### DIFF
--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -67,6 +67,7 @@ class ContentTypeUpdateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $hasFieldDefinition = count($options['data']->fieldDefinitionsData) > 0;
         $translatablePropertyTransformer = new TranslatablePropertyTransformer($options['languageCode']);
         $builder
             ->add(
@@ -126,10 +127,16 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.field_type_selection',
             ])
             ->add('addFieldDefinition', SubmitType::class, ['label' => 'content_type.add_field_definition'])
-            ->add('removeFieldDefinition', SubmitType::class, ['label' => 'content_type.remove_field_definitions'])
+            ->add('removeFieldDefinition', SubmitType::class, [
+                'label' => 'content_type.remove_field_definitions',
+                'disabled' => !$hasFieldDefinition,
+            ])
             ->add('saveContentType', SubmitType::class, ['label' => 'content_type.save'])
             ->add('removeDraft', SubmitType::class, ['label' => 'content_type.remove_draft', 'validation_groups' => false])
-            ->add('publishContentType', SubmitType::class, ['label' => 'content_type.publish']);
+            ->add('publishContentType', SubmitType::class, [
+                'label' => 'content_type.publish',
+                'disabled' => !$hasFieldDefinition,
+            ]);
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25923

# Description

This patch disables the publish button (*OK*) until the Content Type has at least a field definition. While at it, I also disable the *Remove selected field definitions* button under the same condition.

# Test

manual tests