### PR TITLE
EZP-27287: Extract FieldTypeChoiceType, SortFieldChoiceType, SortOrde…

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -8,6 +8,9 @@ parameters:
     ezrepoforms.field_type_form_mapper.dispatcher.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcher
     ezrepoforms.content_type.create.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeCreateType
     ezrepoforms.content_type.update.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeUpdateType
+    ezrepoforms.content_type.field_type_choice.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\FieldTypeChoiceType
+    ezrepoforms.content_type.sort_field_choice.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\SortFieldChoiceType
+    ezrepoforms.content_type.sort_order_choice.form_type.class: EzSystems\RepositoryForms\Form\Type\ContentType\SortOrderChoiceType
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
     ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
 
@@ -80,9 +83,26 @@ services:
 
     ezrepoforms.content_type.update.form_type:
         class: "%ezrepoforms.content_type.update.form_type.class%"
-        arguments: ["@ezpublish.field_type_collection.factory", "@translator"]
         tags:
             - {name: form.type, alias: ezrepoforms_contenttype_update}
+
+    ezrepoforms.content_type.field_type_choice.form_type:
+        class: "%ezrepoforms.content_type.field_type_choice.form_type.class%"
+        arguments: ["@ezpublish.field_type_collection.factory", "@translator"]
+        tags:
+            - { name: form.type, alias: ezrepoforms_contenttype_field_type_choice }
+
+    ezrepoforms.content_type.sort_field_choice.form_type:
+        class: "%ezrepoforms.content_type.sort_field_choice.form_type.class%"
+        arguments: ["@translator"]
+        tags:
+            - { name: form.type, alias: ezrepoforms_contenttype_sort_field_choice }
+
+    ezrepoforms.content_type.sort_order_choice.form_type:
+        class: "%ezrepoforms.content_type.sort_order_choice.form_type.class%"
+        arguments: ["@translator"]
+        tags:
+            - { name: form.type, alias: ezrepoforms_contenttype_sort_order_choice }
 
     ezrepoforms.field_definition.form_type:
         class: "%ezrepoforms.field_definition.form_type.class%"

--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -10,41 +10,21 @@
  */
 namespace EzSystems\RepositoryForms\Form\Type\ContentType;
 
-use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
 use EzSystems\RepositoryForms\Form\DataTransformer\TranslatablePropertyTransformer;
 use EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Form type for ContentType update.
  */
 class ContentTypeUpdateType extends AbstractType
 {
-    /**
-     * @var FieldTypeCollectionFactory
-     */
-    private $fieldTypeCollectionFactory;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(FieldTypeCollectionFactory $fieldTypeCollectionFactory, TranslatorInterface $translator)
-    {
-        $this->fieldTypeCollectionFactory = $fieldTypeCollectionFactory;
-        $this->translator = $translator;
-    }
-
     public function getName()
     {
         return $this->getBlockPrefix();
@@ -88,27 +68,10 @@ class ContentTypeUpdateType extends AbstractType
             ->add('nameSchema', TextType::class, ['required' => false, 'label' => 'content_type.name_schema'])
             ->add('urlAliasSchema', TextType::class, ['required' => false, 'label' => 'content_type.url_alias_schema', 'empty_data' => false])
             ->add('isContainer', CheckboxType::class, ['required' => false, 'label' => 'content_type.is_container'])
-            ->add('defaultSortField', ChoiceType::class, [
-                'choices' => [
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_NAME, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_NAME,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_CLASS_NAME, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_CLASS_NAME,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_CLASS_IDENTIFIER, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_CLASS_IDENTIFIER,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_DEPTH, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_DEPTH,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_PATH, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PATH,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_PRIORITY, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PRIORITY,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_MODIFIED, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_MODIFIED,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_PUBLISHED, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_PUBLISHED,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_field.' . Location::SORT_FIELD_SECTION, [], 'ezrepoforms_content_type') => Location::SORT_FIELD_SECTION,
-                ],
-                'choices_as_values' => true,
+            ->add('defaultSortField', SortFieldChoiceType::class, [
                 'label' => 'content_type.default_sort_field',
             ])
-            ->add('defaultSortOrder', ChoiceType::class, [
-                'choices' => [
-                    $this->translator->trans(/** @Ignore */'content_type.sort_order.' . Location::SORT_ORDER_ASC, [], 'ezrepoforms_content_type') => Location::SORT_ORDER_ASC,
-                    $this->translator->trans(/** @Ignore */'content_type.sort_order.' . Location::SORT_ORDER_DESC, [], 'ezrepoforms_content_type') => Location::SORT_ORDER_DESC,
-                ],
-                'choices_as_values' => true,
+            ->add('defaultSortOrder', SortOrderChoiceType::class, [
                 'label' => 'content_type.default_sort_order',
             ])
             ->add('defaultAlwaysAvailable', CheckboxType::class, [
@@ -120,9 +83,7 @@ class ContentTypeUpdateType extends AbstractType
                 'entry_options' => ['languageCode' => $options['languageCode']],
                 'label' => 'content_type.field_definitions_data',
             ])
-            ->add('fieldTypeSelection', ChoiceType::class, [
-                'choices' => array_flip($this->getFieldTypeList()),
-                'choices_as_values' => true,
+            ->add('fieldTypeSelection', FieldTypeChoiceType::class, [
                 'mapped' => false,
                 'label' => 'content_type.field_type_selection',
             ])
@@ -137,22 +98,5 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.publish',
                 'disabled' => !$hasFieldDefinition,
             ]);
-    }
-
-    /**
-     * Returns a hash, with fieldType identifiers as keys and human readable names as values.
-     *
-     * @return array
-     */
-    private function getFieldTypeList()
-    {
-        $list = [];
-        foreach ($this->fieldTypeCollectionFactory->getConcreteFieldTypesIdentifiers() as $fieldTypeIdentifier) {
-            $list[$fieldTypeIdentifier] = $this->translator->trans(/** @Ignore */"$fieldTypeIdentifier.name", [], 'fieldtypes');
-        }
-
-        asort($list, SORT_NATURAL);
-
-        return $list;
     }
 }

--- a/lib/Form/Type/ContentType/FieldTypeChoiceType.php
+++ b/lib/Form/Type/ContentType/FieldTypeChoiceType.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\ContentType;
+
+use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Form type for field type selection.
+ */
+class FieldTypeChoiceType extends AbstractType
+{
+    /**
+     * @var eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory
+     */
+    private $fieldTypeCollectionFactory;
+
+    /**
+     * @var Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(FieldTypeCollectionFactory $fieldTypeCollectionFactory, TranslatorInterface $translator)
+    {
+        $this->fieldTypeCollectionFactory = $fieldTypeCollectionFactory;
+        $this->translator = $translator;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ezrepoforms_contenttype_field_type_choice';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->getFieldTypeChoices(),
+            'choices_as_values' => true,
+        ]);
+    }
+
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * Returns a hash, with fieldType identifiers as keys and human readable names as values.
+     *
+     * @return array
+     */
+    private function getFieldTypeChoices()
+    {
+        $choices = [];
+        foreach ($this->fieldTypeCollectionFactory->getConcreteFieldTypesIdentifiers() as $fieldTypeIdentifier) {
+            $choices[$this->getFieldTypeLabel($fieldTypeIdentifier)] = $fieldTypeIdentifier;
+        }
+
+        asort($choices, SORT_NATURAL);
+
+        return $choices;
+    }
+
+    /**
+     * Generate a human readable name for field type identifier.
+     *
+     * @param string $fieldTypeIdentifier
+     * @return string
+     */
+    private function getFieldTypeLabel($fieldTypeIdentifier)
+    {
+        return $this->translator->trans(/** @Ignore */$fieldTypeIdentifier . '.name', [], 'fieldtypes');
+    }
+}

--- a/lib/Form/Type/ContentType/SortFieldChoiceType.php
+++ b/lib/Form/Type/ContentType/SortFieldChoiceType.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\ContentType;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Form type for sort field selection.
+ */
+class SortFieldChoiceType extends AbstractType
+{
+    /**
+     * @var Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ezrepoforms_contenttype_sort_field_choice';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->getSortFieldChoices(),
+            'choices_as_values' => true,
+        ]);
+    }
+
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * Generate sort field options available to choose.
+     *
+     * @return array
+     */
+    private function getSortFieldChoices()
+    {
+        $choices = [];
+        foreach ($this->getSortFieldValues() as $sortField) {
+            $choices[$this->getSortFieldLabel($sortField)] = $sortField;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Generate human readable label for sort field.
+     *
+     * @param string $sortField
+     * @return string
+     */
+    private function getSortFieldLabel($sortField)
+    {
+        return $this->translator->trans(/** @Ignore */'content_type.sort_field.' . $sortField, [], 'ezrepoforms_content_type');
+    }
+
+    /**
+     * Returns available sort field values.
+     *
+     * @return array
+     */
+    private function getSortFieldValues()
+    {
+        return [
+            Location::SORT_FIELD_NAME,
+            Location::SORT_FIELD_CLASS_NAME,
+            Location::SORT_FIELD_CLASS_IDENTIFIER,
+            Location::SORT_FIELD_DEPTH,
+            Location::SORT_FIELD_PATH,
+            Location::SORT_FIELD_PRIORITY,
+            Location::SORT_FIELD_MODIFIED,
+            Location::SORT_FIELD_PUBLISHED,
+            Location::SORT_FIELD_SECTION,
+        ];
+    }
+}

--- a/lib/Form/Type/ContentType/SortOrderChoiceType.php
+++ b/lib/Form/Type/ContentType/SortOrderChoiceType.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\ContentType;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Form type for sort order selection.
+ */
+class SortOrderChoiceType extends AbstractType
+{
+    /**
+     * @var Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ezrepoforms_contenttype_sort_order_choice';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->getSortOrderChoices(),
+            'choices_as_values' => true,
+        ]);
+    }
+
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * Generate sort order options available to choose.
+     *
+     * @return array
+     */
+    private function getSortOrderChoices()
+    {
+        $choices = [];
+        foreach ($this->getSortOrderValues() as $value) {
+            $choices[$this->getSortOrderLabel($value)] = $value;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Generate human readable label for sort order.
+     *
+     * @param string $sortOrder
+     * @return string
+     */
+    private function getSortOrderLabel($sortOrder)
+    {
+        return $this->translator->trans(/** @Ignore */'content_type.sort_order.' . $sortOrder, [], 'ezrepoforms_content_type');
+    }
+
+    /**
+     * Get available sort order values.
+     *
+     * @return array
+     */
+    private function getSortOrderValues()
+    {
+        return [
+            Location::SORT_ORDER_ASC,
+            Location::SORT_ORDER_DESC,
+        ];
+    }
+}


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-27287

# Description

This PR extracts logic responsible for creating choice field with field type, sort field and sort order 
from `EzSystems\RepositoryForms\Form\Type\ContentType\ContentTypeUpdateType` to separate classes:
* `EzSystems\RepositoryForms\Form\Type\ContentType\FieldTypeChoiceType` (Field type selection)
* `EzSystems\RepositoryForms\Form\Type\ContentType\SortFieldChoiceType` (Sort field selection)
* `EzSystems\RepositoryForms\Form\Type\ContentType\SortOrderChoiceType` (Sort order selection)

