### PR TITLE
Fix EZP-25923: disable content-type form buttons when not usable

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,27 +1,31 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingLinter(false)
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        'concat_with_spaces',
-        '-concat_without_spaces',
-        '-empty_return',
-        '-phpdoc_params',
-        '-phpdoc_separation',
-        '-phpdoc_to_comment',
-        '-spaces_cast',
-        '-blankline_after_open_tag',
-        '-single_blank_line_before_namespace',
-        // psr0 has weird issues with our PSR-4 layout, so deactivating it.
-        '-psr0',
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'array_syntax' => false,
+        'simplified_null_return' => false,
+        'phpdoc_align' => false,
+        'phpdoc_separation' => false,
+        'phpdoc_to_comment' => false,
+        'cast_spaces' => false,
+        'blank_line_after_opening_tag' => false,
+        'single_blank_line_before_namespace' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_no_alias_tag' => false,
+        'space_after_semicolon' => false,
     ])
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->exclude([
+                'bin/.travis',
+                'docs',
                 'vendor',
             ])
+            ->files()->name('*.php')
     )
 ;

--- a/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -67,6 +67,7 @@ class ContentTypeUpdateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $hasFieldDefinition = count($options['data']->fieldDefinitionsData) > 0;
         $translatablePropertyTransformer = new TranslatablePropertyTransformer($options['languageCode']);
         $builder
             ->add(
@@ -126,10 +127,16 @@ class ContentTypeUpdateType extends AbstractType
                 'label' => 'content_type.field_type_selection',
             ])
             ->add('addFieldDefinition', SubmitType::class, ['label' => 'content_type.add_field_definition'])
-            ->add('removeFieldDefinition', SubmitType::class, ['label' => 'content_type.remove_field_definitions'])
+            ->add('removeFieldDefinition', SubmitType::class, [
+                'label' => 'content_type.remove_field_definitions',
+                'disabled' => !$hasFieldDefinition,
+            ])
             ->add('saveContentType', SubmitType::class, ['label' => 'content_type.save'])
             ->add('removeDraft', SubmitType::class, ['label' => 'content_type.remove_draft', 'validation_groups' => false])
-            ->add('publishContentType', SubmitType::class, ['label' => 'content_type.publish']);
+            ->add('publishContentType', SubmitType::class, [
+                'label' => 'content_type.publish',
+                'disabled' => !$hasFieldDefinition,
+            ]);
     }
 
     /**


### PR DESCRIPTION
# Description
This is a port of https://github.com/ezsystems/repository-forms/pull/117 for `1.5` version
This fixes the https://jira.ez.no/browse/EZP-25923 for `Platform 1.7` as this version relies on `Repository-Forms` in version `1.5`