### PR TITLE
EZP-25197: Missing validation of the role form

### DIFF
--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -60,9 +60,14 @@ EzSystems\RepositoryForms\Data\FieldDefinitionData:
             - Type:
                 type: integer
 
-EzSystems\RepositoryForms\Data\RoleData:
+EzSystems\RepositoryForms\Data\Role\RoleData:
     constraints:
         - EzSystems\RepositoryForms\Validator\Constraints\UniqueRoleIdentifier: ~
+    properties:
+        identifier:
+            - NotBlank: ~
+            - Length:
+                max: 255
 
 eZ\Publish\API\Repository\Values\Content\SectionStruct:
     constraints:

--- a/bundle/Resources/translations/validators.en.xlf
+++ b/bundle/Resources/translations/validators.en.xlf
@@ -36,6 +36,11 @@
         <target>Section identifier may only contain letters from "a" to "z", numbers and underscores.</target>
         <note>key: ez.section.identifier.format</note>
       </trans-unit>
+      <trans-unit id="963a415cd08151ecf8726e651a7a36140e05f4b5" resname="ez.role.identifier.unique">
+        <source>The role identifier "%identifier%" is used by another role. You must enter a unique identifier.</source>
+        <target>The role identifier "%identifier%" is used by another role. You must enter a unique identifier.</target>
+        <note>key: ez.role.identifier.unique</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueRoleIdentifier;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Validator\Constraint;
+
+class UniqueRoleIdentifierTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $constraint = new UniqueRoleIdentifier();
+        self::assertSame('ez.role.identifier.unique', $constraint->message);
+    }
+
+    public function testValidateBy()
+    {
+        $constraint = new UniqueRoleIdentifier();
+        self::assertSame('ezrepoforms.validator.unique_role_identifier', $constraint->validatedBy());
+    }
+
+    public function testGetTargets()
+    {
+        $constraint = new UniqueRoleIdentifier();
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+}

--- a/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierValidatorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Tests\Validator\Constraints;
+
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\RoleDraft;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\RoleService;
+use EzSystems\RepositoryForms\Data\Role\RoleData;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueRoleIdentifier;
+use EzSystems\RepositoryForms\Validator\Constraints\UniqueRoleIdentifierValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+class UniqueRoleIdentifierValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $roleService;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $executionContext;
+
+    /**
+     * @var UniqueRoleIdentifierValidator
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->roleService = $this->getMock(RoleService::class);
+        $this->executionContext = $this->getMock(ExecutionContextInterface::class);
+        $this->validator = new UniqueRoleIdentifierValidator($this->roleService);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    public function testNotRoleData()
+    {
+        $value = new stdClass();
+        $this->roleService
+            ->expects($this->never())
+            ->method('loadRoleByIdentifier');
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($value, new UniqueRoleIdentifier());
+    }
+
+    public function testValid()
+    {
+        $identifier = 'foo_identifier';
+        $value = new RoleData(['identifier' => $identifier]);
+        $this->roleService
+            ->expects($this->once())
+            ->method('loadRoleByIdentifier')
+            ->with($identifier)
+            ->willThrowException(new NotFoundException('foo', 'bar'));
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildVioloation');
+
+        $this->validator->validate($value, new UniqueRoleIdentifier());
+    }
+
+    public function testEditingRoleDraftFromExistingRoleIsValid()
+    {
+        $identifier = 'foo_identifier';
+        $roleId = 123;
+        $roleDraft = $this->getMockBuilder(RoleDraft::class)
+            ->setConstructorArgs([['id' => $roleId]])
+            ->getMockForAbstractClass();
+        $value = new RoleData([
+            'identifier' => $identifier,
+            'roleDraft' => $roleDraft,
+        ]);
+        $returnedRole = $this->getMockBuilder(Role::class)
+            ->setConstructorArgs([['id' => $roleId]])
+            ->getMockForAbstractClass();
+        $this->roleService
+            ->expects($this->once())
+            ->method('loadRoleByIdentifier')
+            ->with($identifier)
+            ->willReturn($returnedRole);
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildVioloation');
+
+        $this->validator->validate($value, new UniqueRoleIdentifier());
+    }
+
+    public function testInvalid()
+    {
+        $identifier = 'foo_identifier';
+        $roleDraft = $this->getMockBuilder(RoleDraft::class)
+            ->setConstructorArgs([['id' => 456]])
+            ->getMockForAbstractClass();
+        $value = new RoleData([
+            'identifier' => $identifier,
+            'roleDraft' => $roleDraft,
+        ]);
+        $constraint = new UniqueRoleIdentifier();
+        $constraintViolationBuilder = $this->getMock(ConstraintViolationBuilderInterface::class);
+        $returnedRole = $this->getMockBuilder(Role::class)
+            ->setConstructorArgs([['id' => 123]])
+            ->getMockForAbstractClass();
+        $this->roleService
+            ->expects($this->once())
+            ->method('loadRoleByIdentifier')
+            ->with($identifier)
+            ->willReturn($returnedRole);
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('atPath')
+            ->with('identifier')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('%identifier%', $identifier)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($value, $constraint);
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-25197

# Description

This PR adds missing validation of the role form, especially:

* Uniqueness of the role name (fixed incorrect FQN of RoleData class in validation.yml)
* Not blank role name (currently there is only required attribute on `<input />` tag)
* Max length of the role name
