### PR TITLE
EZP-26608 adding translation for "Metadata"

### DIFF
--- a/bundle/Resources/translations/ezplatform_fields_groups.en.xlf
+++ b/bundle/Resources/translations/ezplatform_fields_groups.en.xlf
@@ -6,6 +6,11 @@
                 <source>content</source>
                 <target>Content</target>
             </trans-unit>
+            <trans-unit id="4c24b2612e94e2ae622e54397663f2b7bf0a2e17" resname="metadata">
+                <source>Metadata</source>
+                <target>Metadata</target>
+                <note>key: metadata</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
This a follow up on https://github.com/ezsystems/ezpublish-kernel/pull/1988 

Adding translation for "Metadata" which was a missing item on default Field Group list

Related Jira issue: https://jira.ez.no/browse/EZP-26608
