### PR TITLE
EZP-26878: ezinteger is not accepting value 0 as default value

### DIFF
--- a/lib/FieldType/DataTransformer/FieldValueTransformer.php
+++ b/lib/FieldType/DataTransformer/FieldValueTransformer.php
@@ -55,7 +55,7 @@ class FieldValueTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
-        if (!$value) {
+        if ($value === null) {
             return $this->fieldType->getEmptyValue();
         }
 

--- a/lib/FieldType/DataTransformer/FieldValueTransformer.php
+++ b/lib/FieldType/DataTransformer/FieldValueTransformer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 class FieldValueTransformer implements DataTransformerInterface
 {
     /**
-     * @var FieldType
+     * @var eZ\Publish\API\Repository\FieldType
      */
     private $fieldType;
 
@@ -32,7 +32,7 @@ class FieldValueTransformer implements DataTransformerInterface
      * Transforms a FieldType Value into a hash using `FieldTpe::toHash()`.
      * This hash is compatible with `reverseTransform()`.
      *
-     * @param \eZ\Publish\SPI\FieldType\Value $value
+     * @param mixed $value
      *
      * @return array|null the value's hash, or null if $value was not a FieldType Value
      */
@@ -49,7 +49,7 @@ class FieldValueTransformer implements DataTransformerInterface
      * Transforms a hash into a FieldType Value using `FieldType::fromHash()`.
      * The FieldValue is compatible with `transform()`.
      *
-     * @param array $value
+     * @param mixed $value
      *
      * @return \eZ\Publish\SPI\FieldType\Value
      */

--- a/tests/RepositoryForms/FieldType/DataTransformer/FieldValueTransformerTest.php
+++ b/tests/RepositoryForms/FieldType/DataTransformer/FieldValueTransformerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Tests\FieldType\DataTransformer;
+
+use eZ\Publish\API\Repository\FieldType;
+use eZ\Publish\SPI\FieldType\Value;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+class FieldValueTransformerTest extends PHPUnit_Framework_TestCase
+{
+    public function testTransformNull()
+    {
+        $value = new stdClass();
+
+        $fieldType = $this->getMock(FieldType::class);
+        $fieldType
+            ->expects($this->never())
+            ->method('toHash');
+
+        $result = (new FieldValueTransformer($fieldType))->transform($value);
+
+        $this->assertNull($result);
+    }
+
+    public function testTransform()
+    {
+        $value = $this->getMock(Value::class);
+        $valueHash = ['lorem' => 'Lorem ipsum dolor...'];
+
+        $fieldType = $this->getMock(FieldType::class);
+        $fieldType
+            ->expects($this->once())
+            ->method('toHash')
+            ->with($value)
+            ->willReturn($valueHash);
+
+        $result = (new FieldValueTransformer($fieldType))->transform($value);
+
+        $this->assertEquals($result, $valueHash);
+    }
+
+    public function testReverseTransformNull()
+    {
+        $emptyValue = $this->getMock(Value::class);
+
+        $fieldType = $this->getMock(FieldType::class);
+        $fieldType
+            ->expects($this->once())
+            ->method('getEmptyValue')
+            ->willReturn($emptyValue);
+        $fieldType
+            ->expects($this->never())
+            ->method('fromHash');
+
+        $result = (new FieldValueTransformer($fieldType))->reverseTransform(null);
+
+        $this->assertSame($emptyValue, $result);
+    }
+
+    public function testReverseTransform()
+    {
+        $value = 'Lorem ipsum dolor...';
+        $expected = $this->getMock(Value::class);
+
+        $fieldType = $this->getMock(FieldType::class);
+        $fieldType
+            ->expects($this->never())
+            ->method('getEmptyValue');
+        $fieldType
+            ->expects($this->once())
+            ->method('fromHash')
+            ->willReturn($expected);
+
+        $result = (new FieldValueTransformer($fieldType))->reverseTransform($value);
+
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-26878

# Description 

This PR allow to set default value of ezinteger to 0 and also adds a missing unit tests for  `EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer`. Malfunctioning found by QA when https://github.com/ezsystems/repository-forms/pull/119 was tested.
