### PR TITLE
[EZP-27435] Show state group in state option label

### DIFF
--- a/lib/Limitation/Mapper/ObjectStateLimitationMapper.php
+++ b/lib/Limitation/Mapper/ObjectStateLimitationMapper.php
@@ -27,7 +27,7 @@ class ObjectStateLimitationMapper extends MultipleSelectionBasedMapper
         $choices = [];
         foreach ($this->objectStateService->loadObjectStateGroups() as $group) {
             foreach ($this->objectStateService->loadObjectStates($group) as $state) {
-                $choices[$state->id] = $state->getName($state->defaultLanguageCode);
+                $choices[$state->id] = $state->getObjectStateGroup()->getName($state->defaultLanguageCode) . ':' . $state->getName($state->defaultLanguageCode);
             }
         }
 


### PR DESCRIPTION
When multiple states have the same name the group is needed to differentiate the two.