### PR TITLE
EZP-26700: Implement editing support for more FieldTypes

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -148,6 +148,7 @@ services:
         class: "%ezrepoforms.field_type.form_mapper.ezdate.class%"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: ezdate }
+            - { name: ez.fieldFormMapper.value, fieldType: ezdate }
 
     ezrepoforms.field_type.form_mapper.ezdatetime:
         class: "%ezrepoforms.field_type.form_mapper.ezdatetime.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -153,6 +153,7 @@ services:
         class: "%ezrepoforms.field_type.form_mapper.ezdatetime.class%"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: ezdatetime }
+            - { name: ez.fieldFormMapper.value, fieldType: ezdatetime }
 
     ezrepoforms.field_type.form_mapper.ezfloat:
         class: "%ezrepoforms.field_type.form_mapper.ezfloat.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -36,6 +36,7 @@ parameters:
     ezrepoforms.field_type.form_mapper.eztime.class: EzSystems\RepositoryForms\FieldType\Mapper\TimeFormMapper
     ezrepoforms.field_type.form_mapper.form_type_based.class: EzSystems\RepositoryForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper
     ezrepoforms.field_type.form_mapper.ezuser.class: EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper
+    ezrepoforms.field_type.form_mapper.ezurl.class: EzSystems\RepositoryForms\FieldType\Mapper\UrlFormMapper
 
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
     ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
@@ -245,6 +246,13 @@ services:
         class: "%ezrepoforms.field_type.form_mapper.ezuser.class%"
         tags:
             - { name: ez.fieldFormMapper.value, fieldType: ezuser }
+        arguments:
+            - '@ezpublish.api.service.field_type'
+
+    ezrepoforms.field_type.form_mapper.ezurl:
+        class: "%ezrepoforms.field_type.form_mapper.ezurl.class%"
+        tags:
+            - { name: ez.fieldFormMapper.value, fieldType: ezurl }
         arguments:
             - '@ezpublish.api.service.field_type'
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -224,11 +224,11 @@ services:
 
     ezrepoforms.field_type.form_mapper.eztext:
         class: "%ezrepoforms.field_type.form_mapper.eztext.class%"
+        arguments:
+            - "@ezpublish.api.service.field_type"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: eztext }
             - { name: ez.fieldFormMapper.value, fieldType: eztext }
-        arguments:
-            - "@ezpublish.api.service.field_type"
 
     ezrepoforms.field_type.form_mapper.eztime:
         class: "%ezrepoforms.field_type.form_mapper.eztime.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -235,8 +235,11 @@ services:
 
     ezrepoforms.field_type.form_mapper.eztime:
         class: "%ezrepoforms.field_type.form_mapper.eztime.class%"
+        arguments:
+            - "@ezpublish.api.service.field_type"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: eztime }
+            - { name: ez.fieldFormMapper.value, fieldType: eztime }
 
     ezrepoforms.field_type.form_mapper.form_type_based:
         abstract: true

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -177,6 +177,7 @@ services:
             - "@ezpublish.api.service.field_type"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: ezinteger }
+            - { name: ez.fieldFormMapper.value, fieldType: ezinteger }
 
     ezrepoforms.field_type.form_mapper.ezisbn:
         class: "%ezrepoforms.field_type.form_mapper.ezisbn.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -162,6 +162,7 @@ services:
             - "@ezpublish.api.service.field_type"
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: ezfloat }
+            - { name: ez.fieldFormMapper.value, fieldType: ezfloat }
 
     ezrepoforms.field_type.form_mapper.ezimage:
         class: "%ezrepoforms.field_type.form_mapper.ezimage.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -256,6 +256,14 @@ services:
         arguments:
             - '@ezpublish.api.service.field_type'
 
+    ezrepoforms.field_type.form_mapper.ezemail:
+        class: "%ezrepoforms.field_type.form_mapper.form_type_based.class%"
+        parent: ezrepoforms.field_type.form_mapper.form_type_based
+        tags:
+            - { name: ez.fieldFormMapper.value, fieldType: ezemail }
+        calls:
+            - [setFormType, [\Symfony\Component\Form\Extension\Core\Type\EmailType]]
+
     # Validators
     ezrepoforms.validator.unique_content_type_identifier:
         class: "%ezrepoforms.validator.unique_content_type_identifier.class%"

--- a/bundle/Resources/views/Content/content_form.html.twig
+++ b/bundle/Resources/views/Content/content_form.html.twig
@@ -1,13 +1,28 @@
 {% macro display_form(form) %}
+    {% form_theme form with ['EzSystemsRepositoryFormsBundle:Content:form_fields.html.twig', _self] %}
+
     {{ form_start(form) }}
 
     {% for fieldForm in form.fieldsData %}
-        <div class="ezfield-type-{{ fieldForm.vars.data.fieldDefinition.fieldTypeIdentifier }} ezfield-identifier-{{ fieldForm.vars.data.fieldDefinition.identifier }}">
-            <fieldset>
-                <legend>{{- form_label(fieldForm) -}}</legend>
-                {{- form_errors(fieldForm) -}}
+        {% set row_classes = 'ez-field-edit ez-field-edit-' ~ fieldForm.vars.data.fieldDefinition.fieldTypeIdentifier %}
+
+        {%- if fieldForm.vars.required -%}
+            {% set row_classes = row_classes ~ ' ez-field-edit-required' %}
+        {%- endif %}
+
+        {%- if fieldForm.vars.disabled -%}
+            {% set row_classes = row_classes ~ ' ez-field-edit-disabled' %}
+        {%- endif %}
+
+        <div class="{{ row_classes }}">
+            <div class="ez-field-edit-text-zone">
+                {{- form_label(fieldForm) -}}
                 {%- if fieldForm.value is defined -%}
-                    {{ form_errors(fieldForm.value) }}
+                    {{- form_errors(fieldForm.value) -}}
+                {% endif %}
+            </div>
+            <div class="ez-field-edit-ui">
+                {%- if fieldForm.value is defined -%}
                     {{ form_widget(fieldForm.value, {"contentData": form.vars.data}) }}
                 {%- else -%}
                     <p class="non-editable">
@@ -15,7 +30,7 @@
                     </p>
                     {%- do fieldForm.setRendered() -%}
                 {% endif %}
-            </fieldset>
+            </div>
         </div>
     {% endfor %}
 

--- a/bundle/Resources/views/Content/form_fields.html.twig
+++ b/bundle/Resources/views/Content/form_fields.html.twig
@@ -1,0 +1,39 @@
+{% use 'form_div_layout.html.twig' %}
+
+{% block form_errors %}
+    {%- for error in errors if errors|length > 0 -%}
+        <em class="ez-field-edit-error">{{ error.message }}</em>
+    {%- endfor -%}
+{% endblock form_errors %}
+
+{% block form_label %}
+    {%- if form.value is defined -%}
+        {% set label_attr = label_attr|merge({'for': form.value.vars.id}) %}
+    {%- endif %}
+    {%- if compound is same as(false) -%}
+        {% set label_attr = label_attr|merge({'class': 'ez-sub-field-name'}) %}
+    {%- endif %}
+    {{- parent('form_label') -}}
+{% endblock form_label %}
+
+{%- block form_widget_compound -%}
+    <fieldset>
+        {% for child in form %}
+            <div class="ez-sub-field ez-sub-field-{{ child.vars.name }}">
+                <div class="ez-sub-field-text-zone">
+                    {{- form_label(child) -}}
+                    {{- form_errors(child) -}}
+                </div>
+                <div class="ez-sub-field-ui">
+                    {{- form_widget(child) -}}
+                </div>
+            </div>
+        {% endfor %}
+        {{- form_rest(form) -}}
+    </fieldset>
+{%- endblock form_widget_compound -%}
+
+{%- block number_widget -%}
+    {%- set type = type|default('number') -%}
+    {{ parent('number_widget') }}
+{%- endblock number_widget -%}

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -128,7 +128,7 @@ final class ContentEdit extends MinkContext implements Context, SnippetAccepting
         $this->assertPageAddress($uri);
         $this->assertElementOnPage(
             sprintf(
-                'div.ezfield-identifier-%s input[type=text]',
+                'div.ez-field-edit input#ezrepoforms_content_edit_fieldsData_%s_value',
                 self::$constrainedFieldIdentifier
             )
         );
@@ -139,7 +139,7 @@ final class ContentEdit extends MinkContext implements Context, SnippetAccepting
      */
     public function thereIsARelevantErrorMessageLinkedToTheInvalidField()
     {
-        $selector = sprintf('div.ezfield-identifier-%s ul li', self::$constrainedFieldIdentifier);
+        $selector = 'div.ez-field-edit-ezstring div.ez-field-edit-text-zone em.ez-field-edit-error';
 
         $this->assertSession()->elementExists('css', $selector);
         $this->assertSession()->elementTextContains('css', $selector, 'The string can not be shorter than 5 characters.');

--- a/features/Context/FieldTypeFormContext.php
+++ b/features/Context/FieldTypeFormContext.php
@@ -69,13 +69,13 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     }
 
     /**
-     * @Then /^the edit form should contain a fieldset named after the field definition$/
+     * @Then /^the edit form should contain an identifiable widget for that field definition$/
      */
     public function theEditFormShouldContainAFieldsetNamedAfterTheFieldDefinition()
     {
         $this->assertSession()->elementTextContains(
             'css',
-            sprintf('div.ezfield-identifier-%s fieldset legend', self::$fieldIdentifier),
+            'div.ez-field-edit div.ez-field-edit-text-zone label',
             'Field'
         );
     }
@@ -88,8 +88,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
         $this->assertSession()->elementExists(
             'css',
             sprintf(
-                'div.ezfield-identifier-%s fieldset input[type=%s]',
-                self::$fieldIdentifier,
+                'div.ez-field-edit div.ez-field-edit-ui input[type=%s]',
                 $inputType
             )
         );
@@ -104,7 +103,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
 
         $inputNodeElements = $this->getSession()->getPage()->findAll(
             'css',
-            sprintf('div.ezfield-identifier-%s fieldset input', self::$fieldIdentifier)
+            'div.ez-field-edit-ezuser div.ez-field-edit-ui fieldset div.ez-sub-field div.ez-sub-field-ui input'
         );
 
         /** @var NodeElement $nodeElement */
@@ -153,7 +152,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     {
         $inputNodeElements = $this->getSession()->getPage()->findAll(
             'css',
-            sprintf('div.ezfield-identifier-%s fieldset input', self::$fieldIdentifier)
+            'div.ez-field-edit div.ez-field-edit-ui input'
         );
         Assertion::assertNotEmpty($inputNodeElements, 'The input field is not marked as required');
         foreach ($inputNodeElements as $inputNodeElement) {

--- a/features/Context/SelectionFieldTypeFormContext.php
+++ b/features/Context/SelectionFieldTypeFormContext.php
@@ -50,7 +50,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
         $this->assertSession()->elementExists(
             'css',
             sprintf(
-                'div.ezfield-identifier-%s fieldset select',
+                'div.ez-field-edit div.ez-field-edit-ui select#ezrepoforms_content_edit_fieldsData_%s_value',
                 self::$fieldIdentifier
             )
         );
@@ -63,7 +63,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     {
         $nodeElements = $this->getSession()->getPage()->findAll(
             'css',
-            sprintf('div.ezfield-identifier-%s fieldset select', self::$fieldIdentifier)
+            sprintf('div.ez-field-edit div.ez-field-edit-ui select#ezrepoforms_content_edit_fieldsData_%s_value', self::$fieldIdentifier)
         );
         Assertion::assertNotEmpty($nodeElements, 'The select field is not marked as required');
         foreach ($nodeElements as $nodeElement) {
@@ -86,14 +86,14 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
         $this->assertSession()->elementExists(
             'css',
             sprintf(
-                'div.ezfield-identifier-%s fieldset select',
+                'div.ez-field-edit select#ezrepoforms_content_edit_fieldsData_%s_value',
                 self::$fieldIdentifier
             )
         );
         $this->assertSession()->elementNotContains(
             'css',
             sprintf(
-                'div.ezfield-identifier-%s fieldset select',
+                'div.ez-field-edit select#ezrepoforms_content_edit_fieldsData_%s_value',
                 self::$fieldIdentifier
             ),
             'multiple="multiple"'
@@ -108,7 +108,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
         $this->assertSession()->elementExists(
             'css',
             sprintf(
-                'div.ezfield-identifier-%s fieldset select[multiple=multiple]',
+                'div.ez-field-edit select#ezrepoforms_content_edit_fieldsData_%s_value[multiple=multiple]',
                 self::$fieldIdentifier
             )
         );

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -179,11 +179,11 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
             $this->assertSession()->elementExists(
                 'css',
                 sprintf(
-                    'div.ezfield-type-%s.ezfield-identifier-%s',
-                    $fieldDefinition->fieldTypeIdentifier,
-                    $fieldDefinition->identifier
+                    'div.ez-field-edit-%s',
+                    $fieldDefinition->fieldTypeIdentifier
                 )
             );
+            /** @todo It should also check if there is corresponding input created once all types are implemented */
         }
     }
 

--- a/features/FieldTypeForm/checkbox_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/checkbox_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of the field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain a fieldset named after the field definition
+    Then the edit form should contain an identifiable widget for that field definition
      And it should contain a checkbox input field
 
 Scenario: The input fields are flagged as required when the field definition is required

--- a/features/FieldTypeForm/selection_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/selection_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of the field have a form representation
     Given I view the edit form for this field
-     Then the edit form should contain a fieldset named after the field definition
+     Then the edit form should contain an identifiable widget for that field definition
       And it should contain a select field
 
 Scenario: The options added to a field definition have a form representation

--- a/features/FieldTypeForm/textline_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/textline_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of a textline field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain a fieldset named after the field definition
+    Then the edit form should contain an identifiable widget for that field definition
      And it should contain a text input field
 
 Scenario: The input fields are flagged as required when the field definition is required

--- a/features/FieldTypeForm/user_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/user_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of a user field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain a fieldset named after the field definition
+    Then the edit form should contain an identifiable widget for that field definition
      And it should contain the following set of labels, and input fields of the following types:
          | label | type |
          | Username | text |

--- a/lib/FieldType/DataTransformer/DateTimeValueTransformer.php
+++ b/lib/FieldType/DataTransformer/DateTimeValueTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
+
+use DateTime;
+use eZ\Publish\Core\FieldType\DateAndTime\Value;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * DataTransformer for DateAndTime\Value.
+ */
+class DateTimeValueTransformer implements DataTransformerInterface
+{
+    /**
+     * @param mixed $value
+     *
+     * @return DateTime|null
+     */
+    public function transform($value)
+    {
+        if (!$value instanceof Value) {
+            return null;
+        }
+
+        return $value->value;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Value|null
+     */
+    public function reverseTransform($value)
+    {
+        if ($value === null || !$value instanceof DateTime) {
+            return null;
+        }
+
+        return new Value($value);
+    }
+}

--- a/lib/FieldType/DataTransformer/DateValueTransformer.php
+++ b/lib/FieldType/DataTransformer/DateValueTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\FieldType\DataTransformer;
+
+use DateTime;
+use eZ\Publish\Core\FieldType\Date\Value;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * DataTransformer for Date\Value.
+ */
+class DateValueTransformer implements DataTransformerInterface
+{
+    /**
+     * @param mixed $value
+     *
+     * @return DateTime|null
+     */
+    public function transform($value)
+    {
+        if (!$value instanceof Value) {
+            return null;
+        }
+
+        return $value->date;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Value|null
+     */
+    public function reverseTransform($value)
+    {
+        if ($value === null || !$value instanceof DateTime) {
+            return null;
+        }
+
+        return new Value($value);
+    }
+}

--- a/lib/FieldType/Mapper/CheckboxFormMapper.php
+++ b/lib/FieldType/Mapper/CheckboxFormMapper.php
@@ -16,12 +16,14 @@ use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * FormMapper for ezboolean FieldType.
+ */
 class CheckboxFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
-    /**
-     * @var \eZ\Publish\API\Repository\FieldTypeService
-     */
+    /** @var FieldTypeService */
     private $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
@@ -50,8 +52,6 @@ class CheckboxFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
@@ -59,12 +59,22 @@ class CheckboxFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                     ->create(
                         'value',
                         CheckboxType::class,
-                        ['required' => $fieldDefinition->isRequired, /** @Ignore */'label' => $label]
+                        [
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        ]
                     )
                     ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))
-                    // Deactivate auto-initialize as we're not on the root form.
                     ->setAutoInitialize(false)
                     ->getForm()
             );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'translation_domain' => 'ezrepoforms_content_type',
+            ]);
     }
 }

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -9,12 +9,20 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\Core\FieldType\Date\Type;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\DateValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DateFormMapper implements FieldDefinitionFormMapperInterface
+/**
+ * FormMapper for ezdate FieldType.
+ */
+class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
     {
@@ -35,5 +43,37 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface
                     'translation_domain' => 'ezrepoforms_content_type',
                 ]
             );
+    }
+
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        DateType::class,
+                        [
+                            'input' => 'datetime',
+                            'widget' => 'single_text',
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        ]
+                    )
+                    ->addModelTransformer(new DateValueTransformer())
+                    ->setAutoInitialize(false)
+                    ->getForm()
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'translation_domain' => 'ezrepoforms_content_type',
+            ]);
     }
 }

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -9,18 +9,22 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
-use Symfony\Component\Form\FormInterface;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class IntegerFormMapper implements FieldDefinitionFormMapperInterface
+/**
+ * FormMapper for ezinteger FieldType.
+ */
+class IntegerFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
-    /**
-     * @var \eZ\Publish\API\Repository\FieldTypeService
-     */
+    /** @var FieldTypeService */
     private $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
@@ -60,14 +64,55 @@ class IntegerFormMapper implements FieldDefinitionFormMapperInterface
             ->add($defaultValueForm);
     }
 
-    /**
-     * Fake method to set the translation domain for the extractor.
-     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        IntegerType::class,
+                        [
+                            'block_name' => $fieldDefinition->fieldTypeIdentifier,
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'attr' => $this->getAttributes($fieldDefinition),
+                        ]
+                    )
+                    ->addModelTransformer(
+                        new FieldValueTransformer(
+                            $this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)
+                        )
+                    )
+                    ->setAutoInitialize(false)
+                    ->getForm()
+            );
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([
                 'translation_domain' => 'ezrepoforms_content_type',
             ]);
+    }
+
+    private function getAttributes(FieldDefinition $fieldDefinition)
+    {
+        $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
+        $attributes = ['step' => 1];
+
+        if (null !== $validatorConfiguration['IntegerValueValidator']['minIntegerValue']) {
+            $attributes['min'] = $validatorConfiguration['IntegerValueValidator']['minIntegerValue'];
+        }
+
+        if (null !== $validatorConfiguration['IntegerValueValidator']['maxIntegerValue']) {
+            $attributes['max'] = $validatorConfiguration['IntegerValueValidator']['maxIntegerValue'];
+        }
+
+        return $attributes;
     }
 }

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -14,16 +14,17 @@ use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * FormMapper for eztext FieldType.
+ */
 class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
-    /**
-     * @var \eZ\Publish\API\Repository\FieldTypeService
-     */
+    /** @var FieldTypeService */
     private $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
@@ -47,8 +48,6 @@ class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
@@ -58,20 +57,20 @@ class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
                         TextareaType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $label,
+                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
                             'attr' => ['rows' => $data->fieldDefinition->fieldSettings['textRows']],
                         ]
                     )
-                    ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))
-                    // Deactivate auto-initialize as we're not on the root form.
+                    ->addModelTransformer(
+                        new FieldValueTransformer(
+                            $this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)
+                        )
+                    )
                     ->setAutoInitialize(false)
                     ->getForm()
             );
     }
 
-    /**
-     * Fake method to set the translation domain for the extractor.
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver

--- a/lib/FieldType/Mapper/UrlFormMapper.php
+++ b/lib/FieldType/Mapper/UrlFormMapper.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\FieldType\Mapper;
+
+use eZ\Publish\API\Repository\FieldTypeService;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\FieldType\DataTransformer\FieldValueTransformer;
+use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
+use EzSystems\RepositoryForms\Form\Type\FieldValue\UrlType;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * FormMapper for ezurl FieldType.
+ */
+class UrlFormMapper implements FieldValueFormMapperInterface
+{
+    /** @var FieldTypeService */
+    private $fieldTypeService;
+
+    /**
+     * @param FieldTypeService $fieldTypeService
+     */
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    /**
+     * @param FormInterface $fieldForm
+     * @param FieldData $data
+     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        UrlType::class,
+                        [
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        ]
+                    )
+                    ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))
+                    ->setAutoInitialize(false)
+                    ->getForm()
+            );
+    }
+}

--- a/lib/Form/Type/FieldValue/DateTimeLocalType.php
+++ b/lib/Form/Type/FieldValue/DateTimeLocalType.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\FieldValue;
+
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+/**
+ * Type for ezdatetime providing `datetime-local` HTML input.
+ */
+class DateTimeLocalType extends DateTimeType
+{
+    /**
+     * @param FormView $view
+     * @param FormInterface $form
+     * @param array $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['widget'] = $options['widget'];
+
+        if ($options['html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
+            $view->vars['type'] = 'datetime-local';
+        }
+    }
+}

--- a/lib/Form/Type/FieldValue/UrlType.php
+++ b/lib/Form/Type/FieldValue/UrlType.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\FieldValue;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType as BaseUrlType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Combined Type for ezurl.
+ */
+class UrlType extends AbstractType
+{
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ezrepoforms_fieldtype_url';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'link',
+                BaseUrlType::class,
+                [
+                    'label' => 'content.field_type.ezurl.link',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'text',
+                TextType::class,
+                [
+                    'label' => 'content.field_type.ezurl.text',
+                    'required' => false,
+                ]
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'translation_domain' => 'ezrepoforms_content',
+            ]);
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-26700

# Description
This PR provides basic editing support for:
* `ezstring` [EZP-27627: Implement editing support for TextLine FieldType](https://jira.ez.no/browse/EZP-27627) 
* `eztext` [EZP-27644: Implement editing support for TextBlock FieldType](https://jira.ez.no/browse/EZP-27644) 
* `ezurl` [EZP-27645: Implement editing support for Url FieldType](https://jira.ez.no/browse/EZP-27645) 
* `ezemail` [EZP-27619: Implement editing support for EmailAddress FieldType](https://jira.ez.no/browse/EZP-27619) 
* `ezdatetime` [EZP-27634: Implement editing support for DateAndTime FieldType](https://jira.ez.no/browse/EZP-27634) 
* `ezdate` [EZP-27635: Implement editing support for Date FieldType](https://jira.ez.no/browse/EZP-27635) 
* `eztime` [EZP-27636: Implement editing support for Time FieldType](https://jira.ez.no/browse/EZP-27636) 
* `ezfloat` [EZP-27637: Implement editing support for Float FieldType](https://jira.ez.no/browse/EZP-27637) 
* `ezinteger` [EZP-27620: Implement editing support for Integer FieldType](https://jira.ez.no/browse/EZP-27620) 
* `ezboolean` [EZP-27632: Implement editing support for Checkbox FieldType](https://jira.ez.no/browse/EZP-27632) 

Fields were implemented using built in Symfony form types. They are editable without any JS enhancement needed.

**Support for more advanced FieldTypes will come in form of separate PRs.**

# TODO
- [x] implement views from [EZP-27578](https://jira.ez.no/browse/EZP-27578)
- ~disable non translatable fields when in translation mode~ (see comments)
- ~write unit tests~ (will be taken care of later)
- ~write behat tests (see below)~ (will be taken care of later)


