### PR TITLE
[PHPUnit] Replaced PHPUnit_Framework_Assert with namespaced class reference

### DIFF
--- a/features/Context/ContentType.php
+++ b/features/Context/ContentType.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 final class ContentType extends RawMinkContext implements Context, SnippetAcceptingContext
 {

--- a/features/Context/FieldTypeFormContext.php
+++ b/features/Context/FieldTypeFormContext.php
@@ -11,7 +11,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\MinkExtension\Context\RawMinkContext;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 final class FieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {

--- a/features/Context/PagelayoutContext.php
+++ b/features/Context/PagelayoutContext.php
@@ -8,7 +8,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\RawMinkContext;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 class PagelayoutContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {

--- a/features/Context/SelectionFieldTypeFormContext.php
+++ b/features/Context/SelectionFieldTypeFormContext.php
@@ -7,7 +7,7 @@ namespace EzSystems\RepositoryForms\Features\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 final class SelectionFieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -19,7 +19,7 @@ use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
-use PHPUnit_Framework_Assert;
+use PHPUnit\Framework\Assert as Assertion;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
@@ -300,7 +300,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
         $user = $userService->loadUserByLogin($this->registrationUsername);
         $userGroups = $userService->loadUserGroupsOfUser($user);
 
-        PHPUnit_Framework_Assert::assertEquals(
+        Assertion::assertEquals(
             $this->customUserGroup->id,
             $userGroups[0]->id
         );
@@ -347,7 +347,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
             $found = (strpos($html, sprintf('<!-- STOP %s -->', $alternativeTemplate)) !== false);
         }
 
-        PHPUnit_Framework_Assert::assertTrue(
+        Assertion::assertTrue(
             $found,
             "Couldn't find $template " .
             (isset($alternativeTemplate) ? "nor $alternativeTemplate " : ' ') .


### PR DESCRIPTION
This is a follow-up on #129 changing `PHPUnit_Framework_Assert` to `PHPUnit\Framework\Assert`.

Background: found when [running tests](https://travis-ci.org/ezsystems/ezplatform/jobs/254384022#L1249) on eZ Platform `v2` which installed PHPUnit `6.x`

**TODO**:
- [x] Change PHPUnit_Framework_Assert to PHPUnit\Framework\Assert.
- [x] See if Travis agrees