### PR TITLE
EZP-27659 Subtree and Node policy limitations can't be viewed

### DIFF
--- a/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
+++ b/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
@@ -9,9 +9,9 @@
 >{{ "role.policy.limitation.location.udw_button"|trans({}, "ezrepoforms_role") }}</button>
 <div>
     <ul id="{{form.limitationValues.vars.id}}-selected-location">
-        {% for limitationValue in form.limitationValues.vars.value %}
+        {% for limitationValue in form.limitationValues.vars.value|split(',') %}
         <li>
-            {{ render( controller( "ez_content:view", {'contentId': limitationValue, 'viewType': '_platformui_content_name'} ) ) }}
+            {{ render( controller( "ez_content:viewAction", {'locationId': limitationValue, 'viewType': '_platformui_content_name'} ) ) }}
         </li>
         {% endfor %}
     </ul>

--- a/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
@@ -24,7 +24,12 @@ class UDWBasedValueTransformer implements DataTransformerInterface
             return null;
         }
 
-        return implode(',', $value);
+        $locations = [];
+        foreach ($value as $key => $path) {
+            $locations[] = $this->extractLocationIdFromPath($path);
+        }
+
+        return implode(',', $locations);
     }
 
     public function reverseTransform($value)
@@ -34,5 +39,19 @@ class UDWBasedValueTransformer implements DataTransformerInterface
         }
 
         return explode(',', $value);
+    }
+
+    /**
+     * Extracts and returns an item id from a path, e.g. /1/2/58 => 58.
+     *
+     * @param string $path
+     *
+     * @return mixed
+     */
+    private function extractLocationIdFromPath($path)
+    {
+        $pathParts = explode('/', trim($path, '/'));
+
+        return array_pop($pathParts);
     }
 }


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-27659
> QA

Existing node/subtree limitations are not displayed when editing a policy. This ensures they are visible.

Fixes:
- [x] Subtreelimitation saves paths (legacy), UDW wants location IDs. Add conversion in the transformer.
- [x] The form (hidden input text line) needs the IDs comma separated, so that's what the value is, but we have to split them in the template to render their names
- [x] The IDs are locations not content, so render them correctly as locations
- [x] ~Preselect node/subtree limitations in UDW~ Skipped, as that is a separate issue