### PR TITLE
Fix EZP-27513: Disable checking uniqueness of role identifier for null

### DIFF
--- a/lib/Validator/Constraints/UniqueRoleIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueRoleIdentifierValidator.php
@@ -36,7 +36,7 @@ class UniqueRoleIdentifierValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$value instanceof RoleData) {
+        if (!$value instanceof RoleData || $value->identifier === null) {
             return;
         }
 

--- a/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueRoleIdentifierValidatorTest.php
@@ -61,6 +61,19 @@ class UniqueRoleIdentifierValidatorTest extends PHPUnit_Framework_TestCase
         $this->validator->validate($value, new UniqueRoleIdentifier());
     }
 
+    public function testNullRoleIdentifier()
+    {
+        $value = new RoleData(['identifier' => null]);
+        $this->roleService
+            ->expects($this->never())
+            ->method('loadRoleByIdentifier');
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($value, new UniqueRoleIdentifier());
+    }
+
     public function testValid()
     {
         $identifier = 'foo_identifier';


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27512

# Description

`UniqueRoleIdentifier` validator should not be executed when `identifier` is `null`, instead error should be raised by `NotBlank` validator (already configured https://github.com/ezsystems/repository-forms/blob/master/bundle/Resources/config/validation.yml#L68). 

# Steps to reproduce
1. Create a new role
2. Set the name as a space
3. Save the role
4. Error `Failed to load 'http://.../pjax/role/update/8` instead of `Invalid form data` is displayed to user


