### PR TITLE
Fix EZP-27690: Disable checking uniqueness of content type identifier for null

### DIFF
--- a/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
+++ b/lib/Validator/Constraints/UniqueContentTypeIdentifierValidator.php
@@ -41,7 +41,7 @@ class UniqueContentTypeIdentifierValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$value instanceof ContentTypeData) {
+        if (!$value instanceof ContentTypeData || $value->identifier === null) {
             return;
         }
 

--- a/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
+++ b/tests/RepositoryForms/Validator/Constraints/UniqueContentTypeIdentifierValidatorTest.php
@@ -56,6 +56,19 @@ class UniqueContentTypeIdentifierValidatorTest extends PHPUnit_Framework_TestCas
         $this->validator->validate($value, new UniqueContentTypeIdentifier());
     }
 
+    public function testNullContentTypeIdentifier()
+    {
+        $value = new ContentTypeData(['identifier' => null]);
+        $this->contentTypeService
+            ->expects($this->never())
+            ->method('loadContentTypeByIdentifier');
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($value, new UniqueContentTypeIdentifier());
+    }
+
     public function testValid()
     {
         $identifier = 'foo_identifier';


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27690

# Description
As same as https://github.com/ezsystems/repository-forms/pull/137: `UniqueContentTypeIdentifier` validator should not be executed when identifier is `null`, instead, an error should be raised by `NotBlank` validator (already configured https://github.com/ezsystems/repository-forms/blob/master/bundle/Resources/config/validation.yml#L6).

# Steps to reproduce
1.  Create a new content type
2. Set the identifier as a space
3. Save the content type
4.  Notification contains text
`Failed to load 'http://192.168.56.102/pjax/contenttype/update/2/eng-GB'`
instead of a regular validation error message. Error labels aren't displayed under form fields.

