### PR TITLE
[WIP] Custom ez-field-edit element (EZP-27576)

### DIFF
--- a/bundle/Resources/views/Content/content_form.html.twig
+++ b/bundle/Resources/views/Content/content_form.html.twig
@@ -1,37 +1,46 @@
 {% macro display_form(form) %}
+    {# Should be a property we get from the FieldMapper #}
+    {% set fieldEditTag = 'ez-field-edit' %}
     {% form_theme form with ['EzSystemsRepositoryFormsBundle:Content:form_fields.html.twig', _self] %}
 
     {{ form_start(form) }}
 
     {% for fieldForm in form.fieldsData %}
-        {% set row_classes = 'ez-field-edit ez-field-edit-' ~ fieldForm.vars.data.fieldDefinition.fieldTypeIdentifier %}
+        {% set fieldDefinition = fieldForm.vars.data.fieldDefinition %}
+        <{{ fieldEditTag }}
+                fieldtype="{{ fieldDefinition.fieldTypeIdentifier }}"
+                field-settings="{{ fieldDefinition.fieldSettings|json_encode()|escape('html_attr') }}"
+                validator-configuration="{{ fieldDefinition.validatorConfiguration|json_encode()|escape('html_attr') }}"
+        >
+            {% set row_classes = 'ez-field-edit ez-field-edit-' ~ fieldDefinition.fieldTypeIdentifier %}
 
-        {%- if fieldForm.vars.required -%}
-            {% set row_classes = row_classes ~ ' ez-field-edit-required' %}
-        {%- endif %}
+            {%- if fieldForm.vars.required -%}
+                {% set row_classes = row_classes ~ ' ez-field-edit-required' %}
+            {%- endif %}
 
-        {%- if fieldForm.vars.disabled -%}
-            {% set row_classes = row_classes ~ ' ez-field-edit-disabled' %}
-        {%- endif %}
+            {%- if fieldForm.vars.disabled -%}
+                {% set row_classes = row_classes ~ ' ez-field-edit-disabled' %}
+            {%- endif %}
 
-        <div class="{{ row_classes }}">
-            <div class="ez-field-edit-text-zone">
-                {{- form_label(fieldForm) -}}
-                {%- if fieldForm.value is defined -%}
-                    {{- form_errors(fieldForm.value) -}}
-                {% endif %}
+            <div class="{{ row_classes }}">
+                <div class="ez-field-edit-text-zone">
+                    {{- form_label(fieldForm) -}}
+                    {%- if fieldForm.value is defined -%}
+                        {{- form_errors(fieldForm.value) -}}
+                    {% endif %}
+                </div>
+                <div class="ez-field-edit-ui">
+                    {%- if fieldForm.value is defined -%}
+                        {{ form_widget(fieldForm.value, {"contentData": form.vars.data}) }}
+                    {%- else -%}
+                        <p class="non-editable">
+                            {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
+                        </p>
+                        {%- do fieldForm.setRendered() -%}
+                    {% endif %}
+                </div>
             </div>
-            <div class="ez-field-edit-ui">
-                {%- if fieldForm.value is defined -%}
-                    {{ form_widget(fieldForm.value, {"contentData": form.vars.data}) }}
-                {%- else -%}
-                    <p class="non-editable">
-                        {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
-                    </p>
-                    {%- do fieldForm.setRendered() -%}
-                {% endif %}
-            </div>
-        </div>
+        </{{ fieldEditTag }}>
     {% endfor %}
 
     {{ form_end(form) }}


### PR DESCRIPTION
> [EZP-27576](http://jira.ez.no/browse/EZP-27576)

Wraps field edit forms into a customizable (not yet) `<ez-field-edit />` element:

```html
<ez-field-edit fieldtype="ezstring" field-settings="{}" validator-configuration='{"StringLengthValidator":{"maxStringLength":20,"minStringLength":10}}'>
  <!-- markup for TextLine -->
</ez-field-edit>
```

This is implemented in `@EzSystemsRepositoryFormsBundle/Content/content_form.html.twig`, by serializing the `FieldDefinition` into attributes.

### TODO
- [ ] Make the custom element customizable
- [ ] Figure out if escaping should be modified, or if it's okay