### PR TITLE
EZP-26700: Provide better theming support to allow overwriting content editing form rows

### DIFF
--- a/bundle/Resources/views/Content/content_form.html.twig
+++ b/bundle/Resources/views/Content/content_form.html.twig
@@ -2,37 +2,6 @@
     {% form_theme form with ['EzSystemsRepositoryFormsBundle:Content:form_fields.html.twig', _self] %}
 
     {{ form_start(form) }}
-
-    {% for fieldForm in form.fieldsData %}
-        {% set row_classes = 'ez-field-edit ez-field-edit-' ~ fieldForm.vars.data.fieldDefinition.fieldTypeIdentifier %}
-
-        {%- if fieldForm.vars.required -%}
-            {% set row_classes = row_classes ~ ' ez-field-edit-required' %}
-        {%- endif %}
-
-        {%- if fieldForm.vars.disabled -%}
-            {% set row_classes = row_classes ~ ' ez-field-edit-disabled' %}
-        {%- endif %}
-
-        <div class="{{ row_classes }}">
-            <div class="ez-field-edit-text-zone">
-                {{- form_label(fieldForm) -}}
-                {%- if fieldForm.value is defined -%}
-                    {{- form_errors(fieldForm.value) -}}
-                {% endif %}
-            </div>
-            <div class="ez-field-edit-ui">
-                {%- if fieldForm.value is defined -%}
-                    {{ form_widget(fieldForm.value, {"contentData": form.vars.data}) }}
-                {%- else -%}
-                    <p class="non-editable">
-                        {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
-                    </p>
-                    {%- do fieldForm.setRendered() -%}
-                {% endif %}
-            </div>
-        </div>
-    {% endfor %}
-
+    {{- form_widget(form.fieldsData) -}}
     {{ form_end(form) }}
 {% endmacro %}

--- a/bundle/Resources/views/Content/form_fields.html.twig
+++ b/bundle/Resources/views/Content/form_fields.html.twig
@@ -1,39 +1,116 @@
-{% use 'form_div_layout.html.twig' %}
+{% extends 'form_div_layout.html.twig' %}
 
-{% block form_errors %}
+{# Important overrides to hide labels and errors on some structural fields #}
+
+{%- block ezrepoforms_content_field_row -%}
+    {{ block('form_rows') }}
+{%- endblock ezrepoforms_content_field_row -%}
+
+{%- block _ezrepoforms_user_register_fieldsData_entry_row -%}
+    {% if form.children.value is defined %}
+        {{- form_row(form) -}}
+    {% else %}
+        <div class="ez-field-edit ez-field-edit-{{ form.vars.value.fieldDefinition.fieldTypeIdentifier }}">
+            <div class="ez-field-edit-text-zone">
+                {{ form_label(form) }}
+                {{ form_errors(form) }}
+            </div>
+            <div class="ez-field-edit-ui">
+                <p class="non-editable">
+                    {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
+                </p>
+            </div>
+        </div>
+        {%- do form.setRendered() -%}
+    {% endif %}
+{%- endblock _ezrepoforms_user_register_fieldsData_entry_row -%}
+
+{%- block _ezrepoforms_content_edit_fieldsData_widget -%}
+    {% for field in form %}
+        {% if field.value is defined %}
+            {{- form_row(field) -}}
+        {% else %}
+            <div class="ez-field-edit ez-field-edit-{{ field.vars.value.fieldDefinition.fieldTypeIdentifier }}">
+                <div class="ez-field-edit-text-zone">
+                    {{ form_label(field) }}
+                    {{ form_errors(field) }}
+                </div>
+                <div class="ez-field-edit-ui">
+                    <p class="non-editable">
+                        {{ "content.field.non_editable"|trans({}, "ezrepoforms_content") }}
+                    </p>
+                </div>
+            </div>
+            {%- do field.setRendered() -%}
+        {% endif %}
+    {% endfor %}
+{%- endblock _ezrepoforms_content_edit_fieldsData_widget -%}
+
+{# General form theming #}
+
+{%- block form_row -%}
+    {% set is_fieldtype = form.parent.vars.value.fieldDefinition is defined %}
+    {% set class_prefix = 'field-edit' %}
+
+    {% if is_fieldtype is same as(false) %}
+        {% set class_prefix = 'sub-field' %}
+    {% endif %}
+    {%- set row_classes -%}
+        {% spaceless %}
+            ez-{{ class_prefix }}
+            {%- if is_fieldtype %} ez-field-edit-{{ form.parent.vars.value.fieldDefinition.fieldTypeIdentifier }}{% else %} ez-sub-field-{{ form.vars.name }}{% endif -%}
+            {%- if required %} ez-{{ class_prefix }}-required{% endif -%}
+            {%- if disabled %} ez-{{ class_prefix }}-disabled{% endif -%}
+        {% endspaceless %}
+    {%- endset -%}
+
+    <div class="{{ row_classes }}">
+        <div class="ez-{{ class_prefix }}-text-zone">
+            {{ form_label(form) }}
+            {{ form_errors(form) }}
+        </div>
+        <div class="ez-{{ class_prefix }}-ui">
+            {{ form_widget(form) }}
+        </div>
+    </div>
+{%- endblock form_row -%}
+
+{%- block form_label -%}
+    {# Based on default Symfony label. Removed "required" class. #}
+    {% if label is not same as(false) -%}
+        {% if not compound -%}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif -%}
+        {% if label is empty -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <label{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</label>
+    {%- endif -%}
+{%- endblock form_label -%}
+
+{%- block form_errors -%}
     {%- for error in errors if errors|length > 0 -%}
         <em class="ez-field-edit-error">{{ error.message }}</em>
     {%- endfor -%}
-{% endblock form_errors %}
-
-{% block form_label %}
-    {%- if form.value is defined -%}
-        {% set label_attr = label_attr|merge({'for': form.value.vars.id}) %}
-    {%- endif %}
-    {%- if compound is same as(false) -%}
-        {% set label_attr = label_attr|merge({'class': 'ez-sub-field-name'}) %}
-    {%- endif %}
-    {{- parent('form_label') -}}
-{% endblock form_label %}
+{%- endblock form_errors -%}
 
 {%- block form_widget_compound -%}
-    <fieldset>
-        {% for child in form %}
-            <div class="ez-sub-field ez-sub-field-{{ child.vars.name }}">
-                <div class="ez-sub-field-text-zone">
-                    {{- form_label(child) -}}
-                    {{- form_errors(child) -}}
-                </div>
-                <div class="ez-sub-field-ui">
-                    {{- form_widget(child) -}}
-                </div>
-            </div>
-        {% endfor %}
+    <fieldset {{ block('widget_container_attributes') }}>
+        {{- block('form_rows') -}}
         {{- form_rest(form) -}}
     </fieldset>
 {%- endblock form_widget_compound -%}
 
+{# Enrichements to default Symfony types #}
+
 {%- block number_widget -%}
     {%- set type = type|default('number') -%}
-    {{ parent('number_widget') }}
+    {{ parent() }}
 {%- endblock number_widget -%}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-26700

# Description
This PR improves theming for content editing form. It allows to overwrite whole rows which is a ground base for some fieldtypes with specific markup i.e. `ezauthor`.

# TODO
- [x] fix behat tests

