### PR TITLE
EZP-27762 content/edit routing conflict with legacy

### DIFF
--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -3,8 +3,8 @@ ez_content_create_no_draft:
     defaults:
         _controller: ez_content_edit:createWithoutDraftAction
 
-ez_content_edit:
-    path: /content/edit/{contentId}/{versionNo}/{language}
+ez_content_draft_edit:
+    path: /content/edit/draft/{contentId}/{versionNo}/{language}
     defaults:
         _controller: ez_content_edit:editContentDraftAction
         language: null

--- a/doc/specifications/content_edit.md
+++ b/doc/specifications/content_edit.md
@@ -34,7 +34,7 @@ The actual creation of the draft is delegated to the FormProcessor API, by firin
 ### Editing a draft
 > A route that displays a content editing form, with options to discard, save or publish.
 
-- path: `/content/edit/{contentId}/{versionNo}/{language}`
+- path: `/content/edit/draft/{contentId}/{versionNo}/{language}`
 - controller action: `ContentEditController::editContentDraftAction`
 
 `language` is optional.

--- a/lib/Form/Processor/ContentFormProcessor.php
+++ b/lib/Form/Processor/ContentFormProcessor.php
@@ -59,7 +59,7 @@ class ContentFormProcessor implements EventSubscriberInterface
         $languageCode = $formConfig->getOption('languageCode');
         $draft = $this->saveDraft($data, $languageCode);
 
-        $defaultUrl = $this->router->generate('ez_content_edit', [
+        $defaultUrl = $this->router->generate('ez_content_draft_edit', [
             'contentId' => $draft->id,
             'versionNo' => $draft->getVersionInfo()->versionNo,
             'language' => $languageCode,
@@ -113,7 +113,7 @@ class ContentFormProcessor implements EventSubscriberInterface
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $createContentDraft->fromVersionNo);
         $contentDraft = $this->contentService->createContentDraft($contentInfo, $versionInfo);
 
-        $contentEditUrl = $this->router->generate('ez_content_edit', [
+        $contentEditUrl = $this->router->generate('ez_content_draft_edit', [
             'contentId' => $contentDraft->id,
             'versionNo' => $contentDraft->getVersionInfo()->versionNo,
             'language' => $contentDraft->contentInfo->mainLanguageCode,


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-27762
> Ready for review

Ensure our route doesn't conflict with legacy content edit, by changing `/content/edit/...` to `/content/edit/draft/...`.

Debatable: Renaming the route from `ez_content_edit` to `ez_content_draft_edit`, as I've done. The fix is smaller if we don't.