### PR TITLE
EZP-27793: fix updating ContentType with required value

### DIFF
--- a/lib/Validator/Constraints/FieldValueValidator.php
+++ b/lib/Validator/Constraints/FieldValueValidator.php
@@ -13,6 +13,7 @@ namespace EzSystems\RepositoryForms\Validator\Constraints;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\FieldType\ValidationError;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -36,7 +37,7 @@ class FieldValueValidator extends FieldTypeValidator
         $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
 
         $validationErrors = [];
-        if ($fieldType->isEmptyValue($fieldValue)) {
+        if (!($value instanceof FieldDefinitionData) && $fieldType->isEmptyValue($fieldValue)) {
             if ($fieldDefinition->isRequired) {
                 $validationErrors = [
                     new ValidationError(


### PR DESCRIPTION
This allows ContentTypes to have an empty value even when marked as required.

My interpretation of 'required' applies to the the ContentField not the Type.

https://jira.ez.no/browse/EZP-27793