### PR TITLE
EZP-27646: Implement editing support for User FieldType

### DIFF
--- a/bundle/Controller/UserController.php
+++ b/bundle/Controller/UserController.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryFormsBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use EzSystems\RepositoryForms\Data\Mapper\UserCreateMapper;
+use EzSystems\RepositoryForms\Data\Mapper\UserUpdateMapper;
+use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
+use EzSystems\RepositoryForms\Form\Type\User\UserCreateType;
+use EzSystems\RepositoryForms\Form\Type\User\UserUpdateType;
+use EzSystems\RepositoryForms\User\View\UserCreateView;
+use EzSystems\RepositoryForms\User\View\UserUpdateView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\Exception\AccessException;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
+use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class UserController extends Controller
+{
+    /** @var ContentTypeService */
+    private $contentTypeService;
+
+    /** @var UserService */
+    private $userService;
+
+    /** @var LocationService */
+    private $locationService;
+
+    /** @var LanguageService */
+    private $languageService;
+
+    /** @var ActionDispatcherInterface */
+    private $userActionDispatcher;
+
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        UserService $userService,
+        LocationService $locationService,
+        LanguageService $languageService,
+        ActionDispatcherInterface $userActionDispatcher
+    ) {
+        $this->contentTypeService = $contentTypeService;
+        $this->userService = $userService;
+        $this->locationService = $locationService;
+        $this->languageService = $languageService;
+        $this->userActionDispatcher = $userActionDispatcher;
+    }
+
+    /**
+     * Displays and processes a user creation form.
+     *
+     * @param string $contentTypeIdentifier ContentType id to create
+     * @param string $language Language code to create the content in (eng-GB, ger-DE, ...))
+     * @param int $parentLocationId Location the content should be a child of
+     * @param Request $request
+     *
+     * @return UserCreateView|Response
+     *
+     * @throws InvalidArgumentType
+     * @throws InvalidArgumentException
+     * @throws UnauthorizedException
+     * @throws UndefinedOptionsException
+     * @throws OptionDefinitionException
+     * @throws NoSuchOptionException
+     * @throws MissingOptionsException
+     * @throws InvalidOptionsException
+     * @throws AccessException
+     * @throws NotFoundException
+     */
+    public function createAction(
+        string $contentTypeIdentifier,
+        string $language,
+        int $parentLocationId,
+        Request $request
+    ) {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        $location = $this->locationService->loadLocation($parentLocationId);
+        $language = $this->languageService->loadLanguage($language);
+        $parentGroup = $this->userService->loadUserGroup($location->contentId);
+
+        $data = (new UserCreateMapper())->mapToFormData($contentType, [$parentGroup], [
+            'mainLanguageCode' => $language->languageCode,
+        ]);
+        $form = $this->createForm(UserCreateType::class, $data, [
+            'languageCode' => $language->languageCode,
+            'mainLanguageCode' => $language->languageCode,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->userActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
+            if ($response = $this->userActionDispatcher->getResponse()) {
+                return $response;
+            }
+        }
+
+        return new UserCreateView(null, [
+            'form' => $form->createView(),
+            'language' => $language,
+            'contentType' => $contentType,
+            'parentGroup' => $parentGroup,
+        ]);
+    }
+
+    /**
+     * Displays a user update form that updates user data and related content item.
+     *
+     * @param int|null $contentId ContentType id to create
+     * @param int|null $versionNo Version number the version should be created from. Defaults to the currently published one.
+     * @param string|null $language Language code to create the version in (eng-GB, ger-DE, ...))
+     * @param Request $request
+     *
+     * @return UserUpdateView|Response
+     *
+     * @throws \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
+     * @throws \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
+     * @throws \Symfony\Component\OptionsResolver\Exception\NoSuchOptionException
+     * @throws \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
+     * @throws InvalidArgumentType
+     * @throws UnauthorizedException
+     * @throws NotFoundException
+     * @throws BadStateException If the version isn't editable, or if there is no editable version.
+     */
+    public function editAction(
+        int $contentId,
+        ?int $versionNo = null,
+        ?string $language = null,
+        Request $request
+    ) {
+        $user = $this->userService->loadUser($contentId);
+        $contentType = $this->contentTypeService->loadContentType($user->contentInfo->contentTypeId);
+
+        $userUpdate = (new UserUpdateMapper())->mapToFormData($user, $contentType, [
+            'languageCode' => $language,
+        ]);
+        $form = $this->createForm(
+            UserUpdateType::class,
+            $userUpdate,
+            [
+                'languageCode' => $language,
+                'mainLanguageCode' => $user->contentInfo->mainLanguageCode,
+            ]
+        );
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->userActionDispatcher->dispatchFormAction($form, $userUpdate, $form->getClickedButton()->getName());
+            if ($response = $this->userActionDispatcher->getResponse()) {
+                return $response;
+            }
+        }
+
+        return new UserUpdateView(null, [
+            'form' => $form->createView(),
+            'languageCode' => $language,
+            'contentType' => $contentType,
+            'user' => $user,
+        ]);
+    }
+}

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -13,9 +13,10 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
-use EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView;
-use EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView;
+use EzSystems\RepositoryForms\User\View\UserRegisterConfirmView;
+use EzSystems\RepositoryForms\User\View\UserRegisterFormView;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UserRegisterController extends Controller
@@ -28,14 +29,14 @@ class UserRegisterController extends Controller
     /**
      * @var ActionDispatcherInterface
      */
-    private $contentActionDispatcher;
+    private $userActionDispatcher;
 
     public function __construct(
         UserRegisterMapper $userRegisterMapper,
-        ActionDispatcherInterface $contentActionDispatcher
+        ActionDispatcherInterface $userActionDispatcher
     ) {
         $this->userRegisterMapper = $userRegisterMapper;
-        $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->userActionDispatcher = $userActionDispatcher;
     }
 
     /**
@@ -43,7 +44,9 @@ class UserRegisterController extends Controller
      *
      * @param Request $request
      *
-     * @return \EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView|\Symfony\Component\HttpFoundation\Response * @throws \Exception if the current user isn't allowed to register an account
+     * @return UserRegisterFormView|Response
+     *
+     * @throws \Exception if the current user isn't allowed to register an account
      */
     public function registerAction(Request $request)
     {
@@ -61,9 +64,9 @@ class UserRegisterController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
-            $this->contentActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
-            if ($response = $this->contentActionDispatcher->getResponse()) {
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->userActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
+            if ($response = $this->userActionDispatcher->getResponse()) {
                 return $response;
             }
         }

--- a/bundle/DependencyInjection/Configuration/Parser/UserEdit.php
+++ b/bundle/DependencyInjection/Configuration/Parser/UserEdit.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class UserEdit extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('user_edit')
+                ->info('Content edit configuration')
+                ->children()
+                    ->arrayNode('templates')
+                        ->info('Content edit templates.')
+                        ->children()
+                            ->scalarNode('update')
+                                ->info('Template to use for user edit form rendering.')
+                            ->end()
+                            ->scalarNode('create')
+                                ->info('Template to use for user create form rendering.')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (empty($scopeSettings['user_edit'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['user_edit'];
+
+        if (!empty($settings['templates']['update'])) {
+            $contextualizer->setContextualParameter(
+                'user_edit.templates.update',
+                $currentScope,
+                $settings['templates']['update']
+            );
+        }
+
+        if (!empty($settings['templates']['create'])) {
+            $contextualizer->setContextualParameter(
+                'user_edit.templates.create',
+                $currentScope,
+                $settings['templates']['create']
+            );
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -14,9 +14,10 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
-use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEdit;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationValueMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEdit;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\LimitationValueTemplates;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserEdit;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -35,6 +36,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
         $eZExtension->addConfigParser(new UserRegistration());
         $eZExtension->addConfigParser(new ContentEdit());
+        $eZExtension->addConfigParser(new UserEdit());
         $eZExtension->addConfigParser(new LimitationValueTemplates());
         $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -5,5 +5,7 @@ parameters:
     ezsettings.default.content_edit.templates.edit: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.content_edit.templates.create: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.content_edit.templates.create_draft: "EzSystemsRepositoryFormsBundle:Content:content_create_draft.html.twig"
+    ezsettings.default.user_edit.templates.update: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
+    ezsettings.default.user_edit.templates.create: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.limitation_value_templates:
         - { template: 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig', priority: 0 }

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -25,11 +25,21 @@ ez_content_draft_create:
         expose: true
 
 ez_user_register:
-  path: /register
-  defaults:
-      _controller: "ezrepoforms.controller.user_register:registerAction"
+    path: /register
+    defaults:
+        _controller: "ezrepoforms.controller.user_register:registerAction"
 
 ez_user_register_confirmation:
-  path: /register-confirm
-  defaults:
-      _controller: "ezrepoforms.controller.user_register:registerConfirmAction"
+    path: /register-confirm
+    defaults:
+        _controller: "ezrepoforms.controller.user_register:registerConfirmAction"
+
+ez_user_create:
+    path: /user/create
+    defaults:
+        _controller: "ezrepoforms.controller.user:createAction"
+
+ez_user_update:
+    path: /user/update
+    defaults:
+        _controller: "ezrepoforms.controller.user:updateAction"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -15,8 +15,6 @@ parameters:
     ezrepoforms.field_definition.form_type.class: EzSystems\RepositoryForms\Form\Type\FieldDefinition\FieldDefinitionType
     ezrepoforms.field.form_type.class: EzSystems\RepositoryForms\Form\Type\Content\ContentFieldType
 
-    ezrepoforms.field_value.user_type.class: EzSystems\RepositoryForms\Form\Type\User\UserAccountType
-
     ezrepoforms.validator.unique_content_type_identifier.class: EzSystems\RepositoryForms\Validator\Constraints\UniqueContentTypeIdentifierValidator
     ezrepoforms.validator.validator_configuration.class: EzSystems\RepositoryForms\Validator\Constraints\ValidatorConfigurationValidator
     ezrepoforms.validator.field_settings.class: EzSystems\RepositoryForms\Validator\Constraints\FieldSettingsValidator
@@ -31,21 +29,27 @@ parameters:
     ezrepoforms.action_dispatcher.content_type.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeDispatcher
     ezrepoforms.action_dispatcher.content_type.group.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeGroupDispatcher
     ezrepoforms.action_dispatcher.content.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentDispatcher
+    ezrepoforms.action_dispatcher.user.class: EzSystems\RepositoryForms\Form\ActionDispatcher\UserDispatcher
     ezrepoforms.form_processor.content_type.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeFormProcessor
     ezrepoforms.form_processor.content_type.options.redirect_route_after_publish: ~
     ezrepoforms.form_processor.content_type.options:
         redirectRouteAfterPublish: "%ezrepoforms.form_processor.content_type.options.redirect_route_after_publish%"
     ezrepoforms.form_processor.content_type_group.class: EzSystems\RepositoryForms\Form\Processor\ContentTypeGroupFormProcessor
     ezrepoforms.form_processor.content.class: EzSystems\RepositoryForms\Form\Processor\ContentFormProcessor
-    ezrepoforms.form_processor.user_register.class: EzSystems\RepositoryForms\Form\Processor\UserRegisterFormProcessor
+    ezrepoforms.form_processor.user_create.class: EzSystems\RepositoryForms\Form\Processor\User\UserCreateFormProcessor
+    ezrepoforms.form_processor.user_update.class: EzSystems\RepositoryForms\Form\Processor\User\UserUpdateFormProcessor
+    ezrepoforms.form_processor.user_register.class: EzSystems\RepositoryForms\Form\Processor\User\UserRegisterFormProcessor
+    ezrepoforms.form_processor.user_cancel.class: EzSystems\RepositoryForms\Form\Processor\User\UserCancelFormProcessor
 
     ezrepoforms.controller.content_edit.class: EzSystems\RepositoryFormsBundle\Controller\ContentEditController
     ezrepoforms.controller.user_register.class: EzSystems\RepositoryFormsBundle\Controller\UserRegisterController
+    ezrepoforms.controller.user.class: EzSystems\RepositoryFormsBundle\Controller\UserController
 
-    ezrepoforms.user_register.registration_group_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
-    ezrepoforms.user_register.registration_content_type_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
+    ezrepoforms.user_register.registration_group_loader.configurable.class: EzSystems\RepositoryForms\User\ConfigurableRegistrationGroupLoader
+    ezrepoforms.user_register.registration_content_type_loader.configurable.class: EzSystems\RepositoryForms\User\ConfigurableRegistrationContentTypeLoader
     ezrepoforms.view_templates_listener.class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
     ezrepoforms.user_register.view_templates_listener.class: '%ezrepoforms.view_templates_listener.class%' # Deprecated in 1.10, to be removed in 2.0
+    ezrepoforms.user_edit_listener.class: EzSystems\RepositoryForms\EventListener\UserEditListener
 
     ezrepoforms.form_data_mapper.user_register.class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
 
@@ -101,11 +105,6 @@ services:
         arguments: ["@ezrepoforms.field_type_form_mapper.dispatcher"]
         tags:
             - { name: form.type, alias: ezrepoforms_content_field }
-
-    ezrepoforms.field_value.user_type:
-        class: "%ezrepoforms.field_value.user_type.class%"
-        tags:
-            - { name: form.type, alias: ezuser }
 
     # Validators
     ezrepoforms.validator.unique_content_type_identifier:
@@ -183,6 +182,10 @@ services:
         class: "%ezrepoforms.action_dispatcher.content_type.group.class%"
         parent: ezrepoforms.action_dispatcher.base
 
+    ezrepoforms.action_dispatcher.user:
+        class: "%ezrepoforms.action_dispatcher.user.class%"
+        parent: ezrepoforms.action_dispatcher.base
+
     # Form processors
     ezrepoforms.form_processor.content_type:
         class: "%ezrepoforms.form_processor.content_type.class%"
@@ -201,11 +204,35 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezrepoforms.form_processor.user_create:
+        class: "%ezrepoforms.form_processor.user_create.class%"
+        arguments:
+            - '@ezpublish.api.service.user'
+            - '@router'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.form_processor.user_update:
+        class: "%ezrepoforms.form_processor.user_update.class%"
+        arguments:
+            - '@ezpublish.api.service.user'
+            - '@ezpublish.api.service.content'
+            - '@router'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezrepoforms.form_processor.user_register:
         class: "%ezrepoforms.form_processor.user_register.class%"
         arguments:
             - '@ezpublish.api.repository'
             - '@ezpublish.api.service.user'
+            - '@router'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezrepoforms.form_processor.user:
+        class: "%ezrepoforms.form_processor.user_cancel.class%"
+        arguments:
             - '@router'
         tags:
             - { name: kernel.event_subscriber }
@@ -229,11 +256,21 @@ services:
         calls:
             - [setPageLayout, [$pagelayout$]]
 
+    ezrepoforms.controller.user:
+        class: "%ezrepoforms.controller.user.class%"
+        arguments:
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.user"
+            - "@ezpublish.api.service.location"
+            - "@ezpublish.api.service.language"
+            - "@ezrepoforms.action_dispatcher.user"
+        parent: ezpublish.controller.base
+
     ezrepoforms.controller.user_register:
         class: "%ezrepoforms.controller.user_register.class%"
         arguments:
             - "@ezrepoforms.form_data_mapper.user_register"
-            - "@ezrepoforms.action_dispatcher.content"
+            - "@ezrepoforms.action_dispatcher.user"
         parent: ezpublish.controller.base
 
     ez_content_edit:
@@ -266,8 +303,10 @@ services:
         tags:
             - { name: kernel.event_subscriber }
         calls:
-            - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView', "$user_registration.templates.form$"]]
-            - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserCreateView', "$user_edit.templates.create$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserUpdateView', "$user_edit.templates.update$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserRegisterFormView', "$user_registration.templates.form$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentEditView', "$content_edit.templates.edit$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateView', "$content_edit.templates.create$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateDraftView', "$content_edit.templates.create_draft$"]]
@@ -276,6 +315,15 @@ services:
     ezrepoforms.user_register.view_templates_listener:
         alias: ezrepoforms.view_templates_listener
         deprecated: 'The "%service_id%" service is deprecated since 1.10 and will be removed in 2.0. Use "ezrepoforms.view_templates_listener" instead.'
+
+    ezrepoforms.user_edit_listener:
+        class: "%ezrepoforms.user_edit_listener.class%"
+        arguments:
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.content"
+            - "@ezrepoforms.controller.user"
+        tags:
+            - { name: kernel.event_subscriber }
 
     ezrepoforms.translation.extractor.sorting:
         class: EzSystems\RepositoryForms\Translation\SortingTranslationExtractor

--- a/bundle/Resources/config/validation.yml
+++ b/bundle/Resources/config/validation.yml
@@ -96,6 +96,33 @@ EzSystems\RepositoryForms\Data\Content\ContentUpdateData:
         fieldsData:
             - Valid: ~
 
+EzSystems\RepositoryForms\Data\User\UserCreateData:
+    properties:
+        login:
+            - NotBlank: ~
+        email:
+            - NotBlank: ~
+        password:
+            - NotBlank: ~
+        fieldsData:
+            - Valid: ~
+
+EzSystems\RepositoryForms\Data\User\UserUpdateData:
+    properties:
+        fieldsData:
+            - Valid: ~
+
+EzSystems\RepositoryForms\Data\User\UserRegisterData:
+    properties:
+        fieldsData:
+            - Valid: ~
+
+EzSystems\RepositoryForms\Data\User\UserAccountFieldData:
+    properties:
+        username:
+            - Valid: ~
+            - NotBlank: ~
+
 EzSystems\RepositoryForms\Data\Content\FieldData:
     constraints:
         - EzSystems\RepositoryForms\Validator\Constraints\FieldValue: ~

--- a/bundle/Resources/translations/ezrepoforms_content.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-10-19T13:02:12Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,73 +10,61 @@
         <source>Cancel</source>
         <target>Cancel</target>
         <note>key: content.cancel_button</note>
-        <jms:reference-file line="49">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/Content/ContentEditType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db5d6f82fe5ba6f40d1d159dca89c659c76aad06" resname="content.field_type.ezauthor.email">
         <source>E-mail</source>
         <target>E-mail</target>
         <note>key: content.field_type.ezauthor.email</note>
-        <jms:reference-file line="66">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/Author/AuthorEntryType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="05fe48833d61c38f4c532c34c4b6fdad323e1fe1" resname="content.field_type.ezauthor.name">
         <source>Name</source>
         <target>Name</target>
         <note>key: content.field_type.ezauthor.name</note>
-        <jms:reference-file line="57">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/Author/AuthorEntryType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="25850f96dbb0457a35063e29e92a26cbba2de07d" resname="content.field_type.ezurl.link">
         <source>URL</source>
-        <target state="new">URL</target>
+        <target>URL</target>
         <note>key: content.field_type.ezurl.link</note>
-        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/UrlFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6ca454559e2a762b64c43847db1e227b3077540" resname="content.field_type.ezurl.text">
         <source>Text</source>
-        <target state="new">Text</target>
+        <target>Text</target>
         <note>key: content.field_type.ezurl.text</note>
-        <jms:reference-file line="54">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/UrlFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7a3eb3ea13db1c9d6a0bd64c7d249a45e7b83b52" resname="content.field_type.ezuser.email">
-        <source>E-mail:</source>
-        <target>E-mail:</target>
+        <source>E-mail</source>
+        <target>E-mail</target>
         <note>key: content.field_type.ezuser.email</note>
-        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/User/UserAccountType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4c65e5d17516c19e311161e374bbd39f053b5e6b" resname="content.field_type.ezuser.password">
-        <source>Password:</source>
-        <target>Password:</target>
+        <source>Password</source>
+        <target>Password</target>
         <note>key: content.field_type.ezuser.password</note>
-        <jms:reference-file line="42">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/User/UserAccountType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d2fe533f4032896195d524038c3abeb2209adece" resname="content.field_type.ezuser.password_confirm">
-        <source>Confirm password:</source>
-        <target>Confirm password:</target>
+        <source>Confirm password</source>
+        <target>Confirm password</target>
         <note>key: content.field_type.ezuser.password_confirm</note>
-        <jms:reference-file line="43">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/User/UserAccountType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d1f5c5fcee7eb206e496dd5073b0f95427431a1c" resname="content.field_type.ezuser.username">
-        <source>Username:</source>
-        <target>Username:</target>
+        <source>Username</source>
+        <target>Username</target>
         <note>key: content.field_type.ezuser.username</note>
-        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/User/UserAccountType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1120fc646c853c462aa4cdf634f476004846fc1b" resname="content.publish_button">
         <source>Publish</source>
         <target>Publish</target>
         <note>key: content.publish_button</note>
-        <jms:reference-file line="43">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/Content/ContentEditType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="49c0762cf87e038e38a06090625eadb4fbbc99ed" resname="content.save_button">
         <source>Save draft</source>
         <target>Save draft</target>
         <note>key: content.save_button</note>
-        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/Content/ContentEditType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df2f594c4b24eb1a49a45e95a5e7ed5cdef802bd" resname="ezrepoforms.content.fields">
         <source>ezrepoforms.content.fields</source>
         <target>ezrepoforms.content.fields</target>
         <note>key: ezrepoforms.content.fields</note>
-        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/repository-forms/lib/Form/Type/Content/ContentEditType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-06-19T08:52:02Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,553 +10,461 @@
         <source>Add field definition</source>
         <target>Add field definition</target>
         <note>key: content_type.add_field_definition</note>
-        <jms:reference-file line="129">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="529a1012c7fe5ca6fafdb5d070ac8ececfe94af6" resname="content_type.create">
         <source>Create a content type</source>
         <target>Create a content type</target>
         <note>key: content_type.create</note>
-        <jms:reference-file line="67">lib/Form/Type/ContentType/ContentTypeCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7b64ebcf792d888de957eaee1c3734c97c80db98" resname="content_type.default_always_available">
         <source>Default content availability</source>
         <target>Default content availability</target>
         <note>key: content_type.default_always_available</note>
-        <jms:reference-file line="116">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b29f5d9c32e10776ec9fd36c35c4aefc96732cb2" resname="content_type.default_sort_field">
         <source>Default field for sorting children</source>
         <target>Default field for sorting children</target>
         <note>key: content_type.default_sort_field</note>
-        <jms:reference-file line="104">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7a67ffefca1339a9e4c5224d773378c2e5f6f378" resname="content_type.default_sort_order">
         <source>Default sort order</source>
         <target>Default sort order</target>
         <note>key: content_type.default_sort_order</note>
-        <jms:reference-file line="112">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="be2f64eb4557a3af16a2f32f5e0185c591d3ca8f" resname="content_type.delete">
         <source>Delete</source>
         <target>Delete</target>
         <note>key: content_type.delete</note>
-        <jms:reference-file line="40">lib/Form/Type/ContentType/ContentTypeDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2a3cc77cdadcff8883b0022e006e24918307687" resname="content_type.description">
         <source>Description</source>
         <target>Description</target>
         <note>key: content_type.description</note>
-        <jms:reference-file line="84">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2aecf6f88fd1ee89037907b8743d5873879a0590" resname="content_type.field_definitions_data">
         <source>Content field definitions</source>
         <target>Content field definitions</target>
         <note>key: content_type.field_definitions_data</note>
-        <jms:reference-file line="121">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a43bfd2651eb1f3357e3398286afd5b6e17c101e" resname="content_type.field_type_selection">
         <source>Field type selection</source>
         <target>Field type selection</target>
         <note>key: content_type.field_type_selection</note>
-        <jms:reference-file line="127">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="368a6ffa173a2e9605371392e99e565d9b247382" resname="content_type.group.delete">
         <source>Delete</source>
         <target>Delete</target>
         <note>key: content_type.group.delete</note>
-        <jms:reference-file line="32">lib/Form/Type/ContentType/ContentTypeGroupDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="043e7766417bd9d21fe58de76fcaee35eb7d2fb0" resname="content_type.group.identifier">
         <source>Name</source>
         <target>Name</target>
         <note>key: content_type.group.identifier</note>
-        <jms:reference-file line="21">lib/Form/Type/ContentType/ContentTypeGroupType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c657344d0bf6b6203b1b9eaf4e44f7a6261dfe1d" resname="content_type.group.save">
         <source>Save</source>
         <target>Save</target>
         <note>key: content_type.group.save</note>
-        <jms:reference-file line="22">lib/Form/Type/ContentType/ContentTypeGroupType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="238db0c5dee8ec13199b073f7cc78728f53ffa36" resname="content_type.identifier">
         <source>Identifier</source>
         <target>Identifier</target>
         <note>key: content_type.identifier</note>
-        <jms:reference-file line="78">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="338e462a91906d03e5e6b8c00528a38d482a3c9e" resname="content_type.is_container">
         <source>Container</source>
         <target>Container</target>
         <note>key: content_type.is_container</note>
-        <jms:reference-file line="90">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7fddd251857df821bd536dd680e1edbc921790a2" resname="content_type.name">
         <source>Name</source>
         <target>Name</target>
         <note>key: content_type.name</note>
-        <jms:reference-file line="75">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9e9628fc59643f3167ebe81dfed3e40eecd281c9" resname="content_type.name_schema">
         <source>Content name pattern</source>
         <target>Content name pattern</target>
         <note>key: content_type.name_schema</note>
-        <jms:reference-file line="88">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="49e5f320e6e37cbd53a5d290e3ffd48788226852" resname="content_type.publish">
         <source>OK</source>
         <target>OK</target>
         <note>key: content_type.publish</note>
-        <jms:reference-file line="137">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="701cbaa7ea48016d7b0eb5940e810cacd16c19b3" resname="content_type.remove_draft">
         <source>Cancel</source>
         <target>Cancel</target>
         <note>key: content_type.remove_draft</note>
-        <jms:reference-file line="135">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5fa42f2a0ef1fee12efaa4cdb1c35bbed35e9b7e" resname="content_type.remove_field_definitions">
         <source>Remove selected field definitions</source>
         <target>Remove selected field definitions</target>
         <note>key: content_type.remove_field_definitions</note>
-        <jms:reference-file line="131">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="946ba9e49beabdacd143e10e343f852736c081d8" resname="content_type.save">
         <source>Apply</source>
         <target>Apply</target>
         <note>key: content_type.save</note>
-        <jms:reference-file line="134">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c625b80940dd9f13842e38446a97391248d0f709" resname="content_type.sort_field.1">
         <source>Location path</source>
         <target>Location path</target>
         <note>key: content_type.sort_field.1</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="4cdfd30bdc30f263b30713d22f714ad46beb120b" resname="content_type.sort_field.2">
         <source>Publication date</source>
         <target>Publication date</target>
         <note>key: content_type.sort_field.2</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="3b367aa1610d6332d66b2113a1b1ed287e0310a6" resname="content_type.sort_field.3">
         <source>Modification date</source>
         <target>Modification date</target>
         <note>key: content_type.sort_field.3</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0dba52962ff2fceb7ab0de72427b4deb55ffbbc" resname="content_type.sort_field.4">
         <source>Section</source>
         <target>Section</target>
         <note>key: content_type.sort_field.4</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="08c573b0f90eddd499911819f24a58632ceec79b" resname="content_type.sort_field.5">
         <source>Location depth</source>
         <target>Location depth</target>
         <note>key: content_type.sort_field.5</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="f75919a228809d6de255e3fd535c4eaaf8789241" resname="content_type.sort_field.6">
         <source>ContentType identifier</source>
         <target>ContentType identifier</target>
         <note>key: content_type.sort_field.6</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4bd88a45172f3cf7e268c40cfc27b0c5336bc9b" resname="content_type.sort_field.7">
         <source>ContentType name</source>
         <target>ContentType name</target>
         <note>key: content_type.sort_field.7</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="d605ada5b53c58b7d08df3379cdc8c9ffc619a3f" resname="content_type.sort_field.8">
         <source>Location priority</source>
         <target>Location priority</target>
         <note>key: content_type.sort_field.8</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="d24f4fdc1a193e1526c297e5e30b61bdb396b3bb" resname="content_type.sort_field.9">
         <source>Content name</source>
         <target>Content name</target>
         <note>key: content_type.sort_field.9</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="18f4f0dcdd6a1f1a9f7a5c301cc378167f403836" resname="content_type.sort_order.0">
         <source>Descending</source>
         <target>Descending</target>
         <note>key: content_type.sort_order.0</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="b411f25ded028ccb2ef56a55d69bd2e3f1da4cd5" resname="content_type.sort_order.1">
         <source>Ascending</source>
         <target>Ascending</target>
         <note>key: content_type.sort_order.1</note>
-        <jms:reference-file>eZ\Publish\API\Repository\Values\Content\Location</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ab7362c77b22ff8bc0d14eeaae8514b0a683473" resname="content_type.url_alias_schema">
         <source>URL alias name pattern</source>
         <target>URL alias name pattern</target>
         <note>key: content_type.url_alias_schema</note>
-        <jms:reference-file line="89">lib/Form/Type/ContentType/ContentTypeUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f99cc628dc4d82c5ee69eae79039a2f449eec064" resname="field_definition.description">
         <source>Description</source>
         <target>Description</target>
         <note>key: field_definition.description</note>
-        <jms:reference-file line="84">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="5ae9eea988dc249d137d285ec360214b238efc26" resname="field_definition.ezboolean.default_value">
-        <source>Default value</source>
-        <target>Default value</target>
-        <note>key: field_definition.ezboolean.default_value</note>
-        <jms:reference-file line="43">lib/FieldType/Mapper/CheckboxFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="41f781284e4bae2abbb6cfdf1126cc90b48dd35b" resname="field_definition.ezbinaryfile.max_file_size">
         <source>Maximum file size (MB)</source>
         <target>Maximum file size (MB)</target>
         <note>key: field_definition.ezbinaryfile.max_file_size</note>
-        <jms:reference-file line="24">lib/FieldType/Mapper/BinaryFileFormMapper.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5ae9eea988dc249d137d285ec360214b238efc26" resname="field_definition.ezboolean.default_value">
+        <source>field_definition.ezboolean.default_value</source>
+        <target state="new">field_definition.ezboolean.default_value</target>
+        <note>key: field_definition.ezboolean.default_value</note>
       </trans-unit>
       <trans-unit id="3ef6598f8cd7d60095784845bb24852ac531e47c" resname="field_definition.ezcountry.default_value">
         <source>Select which countries by default</source>
         <target>Select which countries by default</target>
         <note>key: field_definition.ezcountry.default_value</note>
-        <jms:reference-file line="56">lib/FieldType/Mapper/CountryFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="027f35cf66e5ea571cc7b600dad0ab5ceea20cd6" resname="field_definition.ezcountry.is_multiple">
         <source>Multiple choice</source>
         <target>Multiple choice</target>
         <note>key: field_definition.ezcountry.is_multiple</note>
-        <jms:reference-file line="42">lib/FieldType/Mapper/CountryFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="18a5846deb7a3d7dcc9fbd0a2de28d609c2a55c2" resname="field_definition.ezdate.default_type">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezdate.default_type</note>
-        <jms:reference-file line="34">lib/FieldType/Mapper/DateFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb97ae8058956f1babf75555dbdba76c8e409bf1" resname="field_definition.ezdate.default_type_current">
         <source>Current date</source>
         <target>Current date</target>
         <note>key: field_definition.ezdate.default_type_current</note>
-        <jms:reference-file line="28">lib/FieldType/Mapper/DateFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df532a4ad5878fd0bc3f7842fb6907078efe76f9" resname="field_definition.ezdate.default_type_empty">
         <source>Empty</source>
         <target>Empty</target>
         <note>key: field_definition.ezdate.default_type_empty</note>
-        <jms:reference-file line="27">lib/FieldType/Mapper/DateFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="dbbf37dee75d40448b725aea9c893a4ea84c8ab6" resname="field_definition.ezdatetime.date_interval">
         <source>Current date and time adjusted by</source>
         <target>Current date and time adjusted by</target>
         <note>key: field_definition.ezdatetime.date_interval</note>
-        <jms:reference-file line="45">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7b4f4729ec64de6f20356ad40f768c98c27590fb" resname="field_definition.ezdatetime.default_type">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezdatetime.default_type</note>
-        <jms:reference-file line="40">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e37e68ecadab17cf7132cd1d5163a4f13d0f759c" resname="field_definition.ezdatetime.default_type_adjusted">
         <source>Adjusted current datetime</source>
         <target>Adjusted current datetime</target>
         <note>key: field_definition.ezdatetime.default_type_adjusted</note>
-        <jms:reference-file line="34">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="24ac7fa5478172475d86a2d16829ece8a5e5f59f" resname="field_definition.ezdatetime.default_type_current">
         <source>Current datetime</source>
         <target>Current datetime</target>
         <note>key: field_definition.ezdatetime.default_type_current</note>
-        <jms:reference-file line="33">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0119e6a5f0c829a61263c3a8a37dda53b9da8dce" resname="field_definition.ezdatetime.default_type_empty">
         <source>Empty</source>
         <target>Empty</target>
         <note>key: field_definition.ezdatetime.default_type_empty</note>
-        <jms:reference-file line="32">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a2fbf20071bc00616d6c927dadd484ad75fbcd4c" resname="field_definition.ezdatetime.use_seconds">
         <source>Use seconds</source>
         <target>Use seconds</target>
         <note>key: field_definition.ezdatetime.use_seconds</note>
-        <jms:reference-file line="28">lib/FieldType/Mapper/DateTimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ed0d3cb0a19dd96c1708957f17e15204465c69b6" resname="field_definition.ezfloat.default_value">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezfloat.default_value</note>
-        <jms:reference-file line="44">lib/FieldType/Mapper/FloatFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f6ec24986ca862e96867edc18aa490ff6035e56" resname="field_definition.ezfloat.max_value">
         <source>Maximum value</source>
         <target>Maximum value</target>
         <note>key: field_definition.ezfloat.max_value</note>
-        <jms:reference-file line="33">lib/FieldType/Mapper/FloatFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8eb20f50022f5aa6c623f3f870297f2ee034606" resname="field_definition.ezfloat.min_value">
         <source>Minimum value</source>
         <target>Minimum value</target>
         <note>key: field_definition.ezfloat.min_value</note>
-        <jms:reference-file line="26">lib/FieldType/Mapper/FloatFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5b275c762831def3c6ea393e3e0c25762e0844b3" resname="field_definition.ezimage.max_file_size">
         <source>Maximum file size (byte)</source>
         <target>Maximum file size (byte)</target>
         <note>key: field_definition.ezimage.max_file_size</note>
-        <jms:reference-file line="25">lib/FieldType/Mapper/ImageFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a95f664895f9c72e5ca52ea43908ad3d54c8966" resname="field_definition.ezinteger.default_value">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezinteger.default_value</note>
-        <jms:reference-file line="44">lib/FieldType/Mapper/IntegerFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7529d0af266c6893ae1886faf5578cf4d6d768aa" resname="field_definition.ezinteger.max_value">
         <source>Maximum value</source>
         <target>Maximum value</target>
         <note>key: field_definition.ezinteger.max_value</note>
-        <jms:reference-file line="33">lib/FieldType/Mapper/IntegerFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9b1e51f5ebbb28c403c7707252c6ca47e6a0a82c" resname="field_definition.ezinteger.min_value">
         <source>Minimum value</source>
         <target>Minimum value</target>
         <note>key: field_definition.ezinteger.min_value</note>
-        <jms:reference-file line="26">lib/FieldType/Mapper/IntegerFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4afaf19544597331fbc0eb01e75556a312d657ec" resname="field_definition.ezisbn.default_value">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezisbn.default_value</note>
-        <jms:reference-file line="38">lib/FieldType/Mapper/ISBNFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="461c05cd80b29eb37dc4f7e1f9e1d2454b380332" resname="field_definition.ezisbn.is_isbn13">
         <source>ISBN-13 format</source>
         <target>ISBN-13 format</target>
         <note>key: field_definition.ezisbn.is_isbn13</note>
-        <jms:reference-file line="26">lib/FieldType/Mapper/ISBNFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd243acf201f0150bda1c01399850c7ad9fc0c2d" resname="field_definition.ezmedia.max_file_size">
         <source>Maximum file size (MB)</source>
         <target>Maximum file size (MB)</target>
         <note>key: field_definition.ezmedia.max_file_size</note>
-        <jms:reference-file line="27">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ae04670268864a185efbed749015b7ea14f079b" resname="field_definition.ezmedia.media_type">
         <source>Media type</source>
         <target>Media type</target>
         <note>key: field_definition.ezmedia.media_type</note>
-        <jms:reference-file line="42">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="adfb7d8a234a1500c70ea82dac5f6d8bebff4234" resname="field_definition.ezmedia.type_flash">
         <source>Flash</source>
         <target>Flash</target>
         <note>key: field_definition.ezmedia.type_flash</note>
-        <jms:reference-file line="32">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb4e0e47312060617df5c281c7fc5a537929369f" resname="field_definition.ezmedia.type_html5_audio">
         <source>HTML5 audio</source>
         <target>HTML5 audio</target>
         <note>key: field_definition.ezmedia.type_html5_audio</note>
-        <jms:reference-file line="37">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2039c43bb8832c53f19d0a027c64e40e51f22899" resname="field_definition.ezmedia.type_html5_video">
         <source>HTML5 video</source>
         <target>HTML5 video</target>
         <note>key: field_definition.ezmedia.type_html5_video</note>
-        <jms:reference-file line="31">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e78eb62bcd9c8b47ff51f38c4a828cf91749d38b" resname="field_definition.ezmedia.type_quick_time">
         <source>QuickTime</source>
         <target>QuickTime</target>
         <note>key: field_definition.ezmedia.type_quick_time</note>
-        <jms:reference-file line="33">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a44f707a9ede4f970de7833a2ca29e281fe695d8" resname="field_definition.ezmedia.type_real_player">
         <source>RealPlayer</source>
         <target>RealPlayer</target>
         <note>key: field_definition.ezmedia.type_real_player</note>
-        <jms:reference-file line="34">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="efa6e36c8ec4e2d5c258e780cbefeb54d77f6bc9" resname="field_definition.ezmedia.type_silverlight">
         <source>Silverlight</source>
         <target>Silverlight</target>
         <note>key: field_definition.ezmedia.type_silverlight</note>
-        <jms:reference-file line="35">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="57951280ffe27b8afe3f6c65f8cda4696267d64a" resname="field_definition.ezmedia.type_windows_media_player">
         <source>Windows Media Player</source>
         <target>Windows Media Player</target>
         <note>key: field_definition.ezmedia.type_windows_media_player</note>
-        <jms:reference-file line="36">lib/FieldType/Mapper/MediaFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fabc9be57b82439dac2f612b9c2a171eb7ce6e04" resname="field_definition.ezobjectrelation.selection_content_types">
         <source>Allowed content types</source>
         <target>Allowed content types</target>
         <note>key: field_definition.ezobjectrelation.selection_content_types</note>
-        <jms:reference-file line="34">lib/FieldType/Mapper/RelationFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="440d8fe80bb8a07b62f17d843721285b2cf8a4d5" resname="field_definition.ezobjectrelation.selection_root">
         <source>Default selection item</source>
         <target>Default selection item</target>
         <note>key: field_definition.ezobjectrelation.selection_root</note>
-        <jms:reference-file line="25">lib/FieldType/Mapper/RelationFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e03e262fad0802fdee49aac136644b35450e1eab" resname="field_definition.ezobjectrelation.selection_root_udw_button">
         <source>Select item</source>
         <target>Select item</target>
         <note>key: field_definition.ezobjectrelation.selection_root_udw_button</note>
-        <jms:reference-file line="129">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d892163a41d816c03db3c4a04e35550f02169c11" resname="field_definition.ezobjectrelation.selection_root_udw_title">
         <source>Select a start location for browsing for relation</source>
         <target>Select a start location for browsing for relation</target>
         <note>key: field_definition.ezobjectrelation.selection_root_udw_title</note>
-        <jms:reference-file line="125">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e061dc7c88fe38c11714695d4034f935788efb3" resname="field_definition.ezobjectrelationlist.selection_content_types">
         <source>Allowed content types</source>
         <target>Allowed content types</target>
         <note>key: field_definition.ezobjectrelationlist.selection_content_types</note>
-        <jms:reference-file line="34">lib/FieldType/Mapper/RelationListFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b08d97ea9175eef7352c7e9c5c8ee0516798bdfa" resname="field_definition.ezobjectrelationlist.selection_default_location">
         <source>Default location</source>
         <target>Default location</target>
         <note>key: field_definition.ezobjectrelationlist.selection_default_location</note>
-        <jms:reference-file line="25">lib/FieldType/Mapper/RelationListFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1592c36df8d445c3154d1f639027f97a90739856" resname="field_definition.ezobjectrelationlist.selection_root_udw_button">
         <source>Select location</source>
         <target>Select location</target>
         <note>key: field_definition.ezobjectrelationlist.selection_root_udw_button</note>
-        <jms:reference-file line="154">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d8f3e8bbd5b5f0f5b4b02ddaeaf2af82b0d222" resname="field_definition.ezobjectrelationlist.selection_root_udw_title">
         <source>Select a start location for browsing for relations</source>
         <target>Select a start location for browsing for relations</target>
         <note>key: field_definition.ezobjectrelationlist.selection_root_udw_title</note>
-        <jms:reference-file line="150">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c89d231e7f1b33a8e0b84ad81fc964785a59cbd" resname="field_definition.ezpage.default_layout">
         <source>Default layout</source>
         <target>Default layout</target>
         <note>key: field_definition.ezpage.default_layout</note>
-        <jms:reference-file line="45">lib/FieldType/Mapper/PageFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="14a95e986cd6b94301e0f44fd5ef2d5e7cdf90a4" resname="field_definition.ezselection.add_option">
         <source>Add an option</source>
         <target>Add an option</target>
         <note>key: field_definition.ezselection.add_option</note>
-        <jms:reference-file line="204">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e9e5a43d734719bf6ca42940c1cf5bc78b234e2b" resname="field_definition.ezselection.is_multiple">
         <source>Multiple choice</source>
         <target>Multiple choice</target>
         <note>key: field_definition.ezselection.is_multiple</note>
-        <jms:reference-file line="41">lib/FieldType/Mapper/SelectionFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac85420bb89c319433f4d0e8e988b6fa8363e8b9" resname="field_definition.ezselection.options">
         <source>Options</source>
         <target>Options</target>
         <note>key: field_definition.ezselection.options</note>
-        <jms:reference-file line="53">lib/FieldType/Mapper/SelectionFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8017c71074191e0e6ebe4eb1a3a278eecbcc874" resname="field_definition.ezselection.remove_selected_options">
         <source>Remove selected options</source>
         <target>Remove selected options</target>
         <note>key: field_definition.ezselection.remove_selected_options</note>
-        <jms:reference-file line="205">bundle/Resources/views/ContentType/field_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e8ede1605bfed09023397f8662ca28c40e7c460a" resname="field_definition.ezstring.default_value">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.ezstring.default_value</note>
-        <jms:reference-file line="55">lib/FieldType/Mapper/TextLineFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aeb5a467102cac589770bb08efe1ae15c2845cca" resname="field_definition.ezstring.max_length">
         <source>Maximum length</source>
         <target>Maximum length</target>
         <note>key: field_definition.ezstring.max_length</note>
-        <jms:reference-file line="47">lib/FieldType/Mapper/TextLineFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b3ccbbb1d949cd2ce5971857c15d8c972ee82691" resname="field_definition.ezstring.min_length">
         <source>Minimum length</source>
         <target>Minimum length</target>
         <note>key: field_definition.ezstring.min_length</note>
-        <jms:reference-file line="41">lib/FieldType/Mapper/TextLineFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0a5ed21a62aec2cda555012922b97975d97bc95c" resname="field_definition.eztext.text_rows">
         <source>Number of text rows</source>
         <target>Number of text rows</target>
         <note>key: field_definition.eztext.text_rows</note>
-        <jms:reference-file line="41">lib/FieldType/Mapper/TextBlockFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0f8aa615d0ec1b242535348fecb702d9b75ca2eb" resname="field_definition.eztime.default_type">
         <source>Default value</source>
         <target>Default value</target>
         <note>key: field_definition.eztime.default_type</note>
-        <jms:reference-file line="45">lib/FieldType/Mapper/TimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="95dc4af57dce875f9140238d276ed77f0236746f" resname="field_definition.eztime.default_type_current">
         <source>Current time</source>
         <target>Current time</target>
         <note>key: field_definition.eztime.default_type_current</note>
-        <jms:reference-file line="39">lib/FieldType/Mapper/TimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0a0e3e8eb5d13b0e9e8ca8348615a5c00e2e51c1" resname="field_definition.eztime.default_type_empty">
         <source>Empty</source>
         <target>Empty</target>
         <note>key: field_definition.eztime.default_type_empty</note>
-        <jms:reference-file line="38">lib/FieldType/Mapper/TimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3095005d6d92b499602347e3692b69346a35a845" resname="field_definition.eztime.use_seconds">
         <source>Use seconds</source>
         <target>Use seconds</target>
         <note>key: field_definition.eztime.use_seconds</note>
-        <jms:reference-file line="30">lib/FieldType/Mapper/TimeFormMapper.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="92d9243bb9fac540233dc376b41a3bcd41615ccc" resname="field_definition.field_group">
         <source>Category</source>
         <target>Category</target>
         <note>key: field_definition.field_group</note>
-        <jms:reference-file line="96">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b863a9c7cd91565182ad0a3a5e30ca8090f84c7" resname="field_definition.identifier">
         <source>Identifier</source>
         <target>Identifier</target>
         <note>key: field_definition.identifier</note>
-        <jms:reference-file line="79">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e91f443eb0cd4ab99331950f20cdbcc03f0b88c" resname="field_definition.is_required">
         <source>Required</source>
         <target>Required</target>
         <note>key: field_definition.is_required</note>
-        <jms:reference-file line="88">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a0267d640a8276b546263c23a5dfdf8e99cc3468" resname="field_definition.is_searchable">
         <source>Searchable</source>
         <target>Searchable</target>
         <note>key: field_definition.is_searchable</note>
-        <jms:reference-file line="113">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="83aba8c0c4c654d481c4520feb76e789fbc64c22" resname="field_definition.is_translatable">
         <source>Translatable</source>
         <target>Translatable</target>
         <note>key: field_definition.is_translatable</note>
-        <jms:reference-file line="89">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a02e329edf4c1e41c97c8be922137c284c249c4" resname="field_definition.name">
         <source>Name</source>
         <target>Name</target>
         <note>key: field_definition.name</note>
-        <jms:reference-file line="76">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f6d7350ade5162400b0848796720fe586392fa46" resname="field_definition.position">
         <source>Position</source>
         <target>Position</target>
         <note>key: field_definition.position</note>
-        <jms:reference-file line="99">lib/Form/Type/FieldDefinition/FieldDefinitionType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/bundle/Resources/translations/ezrepoforms_user.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_user.en.xlf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="cbafe6fd8d60ab0c2255f5649c9f0b9096a7a850" resname="user.cancel">
+        <source>Cancel</source>
+        <target>Cancel</target>
+        <note>key: user.cancel</note>
+      </trans-unit>
+      <trans-unit id="95639f06e13f36ba07b01ee8cf5753dbe98fe7ba" resname="user.create">
+        <source>Create</source>
+        <target>Create</target>
+        <note>key: user.create</note>
+      </trans-unit>
+      <trans-unit id="eb38155e104e6d4ebc123884d6052104032a34d7" resname="user.enabled">
+        <source>Enabled</source>
+        <target>Enabled</target>
+        <note>key: user.enabled</note>
+      </trans-unit>
+      <trans-unit id="35f124029a019e1546ec5545a6ffa4968f9e4418" resname="user.update">
+        <source>Update</source>
+        <target>Update</target>
+        <note>key: user.update</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/bundle/Resources/translations/ezrepoforms_user_registration.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_user_registration.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-01-26T15:03:32Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,13 +10,11 @@
         <source>ezrepoforms.content.fields</source>
         <target>ezrepoforms.content.fields</target>
         <note>key: ezrepoforms.content.fields</note>
-        <jms:reference-file line="42">lib/Form/Type/User/UserRegisterType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="745ed48e9eaf1a1a896e411a17317ccbda571d35" resname="user.register_button">
         <source>Register</source>
         <target>Register</target>
         <note>key: user.register_button</note>
-        <jms:reference-file line="47">lib/Form/Type/User/UserRegisterType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/bundle/Resources/views/Content/content_edit.html.twig
+++ b/bundle/Resources/views/Content/content_edit.html.twig
@@ -3,7 +3,9 @@
 {% block content %}
     <section class="ez-content-edit">
         {{ form_start(form) }}
-        {{- form_widget(form.fieldsData) -}}
+        {% for child in form.fieldsData %}
+            {{- form_widget(child) -}}
+        {% endfor %}
         {{ form_end(form) }}
     </section>
 {% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "ezsystems/ezpublish-kernel": "^6.7|^7.0",
         "symfony/symfony": "^2.8 | ^3.0",
         "jms/translation-bundle": "^1.3"

--- a/lib/Data/Mapper/UserCreateMapper.php
+++ b/lib/Data/Mapper/UserCreateMapper.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use Symfony\Component\OptionsResolver\Exception\AccessException;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
+use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form data mapper for user creation.
+ */
+class UserCreateMapper
+{
+    /**
+     * @param ContentType $contentType
+     * @param UserGroup[] $parentGroups
+     * @param array $params
+     *
+     * @return UserCreateData
+     *
+     * @throws UndefinedOptionsException
+     * @throws OptionDefinitionException
+     * @throws NoSuchOptionException
+     * @throws MissingOptionsException
+     * @throws InvalidOptionsException
+     * @throws AccessException
+     */
+    public function mapToFormData(ContentType $contentType, array $parentGroups, array $params = []): UserCreateData
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $params = $resolver->resolve($params);
+
+        $data = new UserCreateData(['contentType' => $contentType, 'mainLanguageCode' => $params['mainLanguageCode']]);
+        $data->setParentGroups($parentGroups);
+
+        foreach ($contentType->fieldDefinitions as $fieldDef) {
+            $data->addFieldData(new FieldData([
+                'fieldDefinition' => $fieldDef,
+                'field' => new Field([
+                    'fieldDefIdentifier' => $fieldDef->identifier,
+                    'languageCode' => $params['mainLanguageCode'],
+                ]),
+                'value' => $fieldDef->defaultValue,
+            ]));
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param OptionsResolver $optionsResolver
+     *
+     * @throws AccessException
+     */
+    private function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired('mainLanguageCode');
+    }
+}

--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -10,13 +10,13 @@ namespace EzSystems\RepositoryForms\Data\Mapper;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
-use EzSystems\RepositoryForms\Data\User\UserCreateData;
-use EzSystems\RepositoryForms\UserRegister\RegistrationContentTypeLoader;
-use EzSystems\RepositoryForms\UserRegister\RegistrationGroupLoader;
+use EzSystems\RepositoryForms\Data\User\UserRegisterData;
+use EzSystems\RepositoryForms\User\RegistrationContentTypeLoader;
+use EzSystems\RepositoryForms\User\RegistrationGroupLoader;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Form data mapper for user registration / creation.
+ * Form data mapper for user creation.
  */
 class UserRegisterMapper
 {
@@ -47,7 +47,7 @@ class UserRegisterMapper
     }
 
     /**
-     * @return UserCreateData
+     * @return UserRegisterData
      */
     public function mapToFormData()
     {
@@ -57,7 +57,7 @@ class UserRegisterMapper
 
         $contentType = $this->contentTypeLoader->loadContentType();
 
-        $data = new UserCreateData([
+        $data = new UserRegisterData([
             'contentType' => $contentType,
             'mainLanguageCode' => $this->params['language'],
         ]);

--- a/lib/Data/Mapper/UserUpdateMapper.php
+++ b/lib/Data/Mapper/UserUpdateMapper.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\User;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\User\UserUpdateData;
+use Symfony\Component\OptionsResolver\Exception\AccessException;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
+use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form data mapper for user updating.
+ */
+class UserUpdateMapper
+{
+    /**
+     * Maps a ValueObject from eZ content repository to a data usable as underlying form data (e.g. create/update struct).
+     *
+     * @param User $user
+     * @param ContentType $contentType
+     * @param array $params
+     *
+     * @return UserUpdateData
+     *
+     * @throws UndefinedOptionsException
+     * @throws OptionDefinitionException
+     * @throws NoSuchOptionException
+     * @throws MissingOptionsException
+     * @throws InvalidOptionsException
+     * @throws AccessException
+     */
+    public function mapToFormData(User $user, ContentType $contentType, array $params = []): UserUpdateData
+    {
+        $optionsResolver = new OptionsResolver();
+        $this->configureOptions($optionsResolver);
+        $params = $optionsResolver->resolve($params);
+
+        $data = new UserUpdateData(['user' => $user, 'enabled' => $user->enabled]);
+        $fields = $user->getFieldsByLanguage($params['languageCode']);
+        foreach ($contentType->fieldDefinitions as $fieldDef) {
+            $field = $fields[$fieldDef->identifier];
+            $data->addFieldData(new FieldData([
+                'fieldDefinition' => $fieldDef,
+                'field' => $field,
+                'value' => $field->value,
+            ]));
+        }
+
+        return $data;
+    }
+
+    private function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver
+            ->setRequired(['languageCode']);
+    }
+}

--- a/lib/Data/User/UserCreateData.php
+++ b/lib/Data/User/UserCreateData.php
@@ -11,10 +11,11 @@ namespace EzSystems\RepositoryForms\Data\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\Repository\Values\User\UserCreateStruct;
 use EzSystems\RepositoryForms\Data\Content\ContentData;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
 use EzSystems\RepositoryForms\Data\NewnessCheckable;
 
 /**
- * @property-read \EzSystems\RepositoryForms\Data\Content\FieldData[] $fieldsData
+ * @property-read FieldData[] $fieldsData
  */
 class UserCreateData extends UserCreateStruct implements NewnessCheckable
 {
@@ -46,5 +47,13 @@ class UserCreateData extends UserCreateStruct implements NewnessCheckable
     public function addParentGroup(UserGroup $parentGroup)
     {
         $this->parentGroups[] = $parentGroup;
+    }
+
+    /**
+     * @param UserGroup[] $parentGroups
+     */
+    public function setParentGroups(array $parentGroups)
+    {
+        $this->parentGroups = $parentGroups;
     }
 }

--- a/lib/Data/User/UserRegisterData.php
+++ b/lib/Data/User/UserRegisterData.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\User;
+
+class UserRegisterData extends UserCreateData
+{
+}

--- a/lib/Data/User/UserUpdateData.php
+++ b/lib/Data/User/UserUpdateData.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Data\User;
+
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
+use EzSystems\RepositoryForms\Data\Content\ContentData;
+use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\NewnessCheckable;
+
+/**
+ * @property-read FieldData[] $fieldsData
+ * @property-read User $user
+ */
+class UserUpdateData extends UserUpdateStruct implements NewnessCheckable
+{
+    use ContentData;
+
+    /**
+     * @var User
+     */
+    public $user;
+
+    public function isNew()
+    {
+        return false;
+    }
+}

--- a/lib/Event/RepositoryFormEvents.php
+++ b/lib/Event/RepositoryFormEvents.php
@@ -106,4 +106,29 @@ final class RepositoryFormEvents
      * Triggered when updating a language.
      */
     const LANGUAGE_UPDATE = 'language.update';
+
+    /**
+     * Base name for User edit processing events.
+     */
+    const USER_EDIT = 'user.edit';
+
+    /**
+     * Triggered when saving an user.
+     */
+    const USER_UPDATE = 'user.edit.update';
+
+    /**
+     * Triggered when creating an user.
+     */
+    const USER_CREATE = 'user.edit.create';
+
+    /**
+     * Triggered when registering an user.
+     */
+    const USER_REGISTER = 'user.edit.register';
+
+    /**
+     * Triggered when canceling a user edition.
+     */
+    const USER_CANCEL = 'user.edit.cancel';
 }

--- a/lib/EventListener/UserEditListener.php
+++ b/lib/EventListener/UserEditListener.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\EventListener;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use EzSystems\RepositoryFormsBundle\Controller\UserController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sets proper controller on content edit.
+ */
+class UserEditListener implements EventSubscriberInterface
+{
+    const CONTENT_CREATE_ROUTE = 'ez_content_create_no_draft';
+    const CONTENT_EDIT_ROUTE = 'ez_content_draft_edit';
+    const USER_FIELD_TYPE = 'ezuser';
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var UserController */
+    protected $userController;
+
+    /**
+     * @param ContentTypeService $contentTypeService
+     * @param ContentService $contentService
+     * @param UserController $userController
+     */
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        ContentService $contentService,
+        UserController $userController
+    ) {
+        $this->contentTypeService = $contentTypeService;
+        $this->contentService = $contentService;
+        $this->userController = $userController;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::CONTROLLER => [
+                ['onControllerUserCreate', 20],
+                ['onControllerUserEdit', 30],
+            ],
+        ];
+    }
+
+    public function onControllerUserCreate(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (self::CONTENT_CREATE_ROUTE === $request->attributes->get('_route')) {
+            $routeParams = $request->attributes->get('_route_params', ['contentTypeIdentifier' => null]);
+            $contentTypeIdentifier = $routeParams['contentTypeIdentifier'];
+            if (null !== $contentTypeIdentifier) {
+                try {
+                    $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+                    $isUserBasedContentType = $this->hasUserField($contentType);
+                } catch (NotFoundException $e) {
+                    return;
+                }
+
+                if (!$isUserBasedContentType) {
+                    return;
+                }
+
+                $event->setController([$this->userController, 'createAction']);
+            }
+        }
+    }
+
+    public function onControllerUserEdit(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (self::CONTENT_EDIT_ROUTE === $request->attributes->get('_route')) {
+            $routeParams = $request->attributes->get('_route_params', ['contentId' => null]);
+            $contentId = $routeParams['contentId'];
+            if (null !== $contentId) {
+                try {
+                    $content = $this->contentService->loadContent($contentId);
+                    $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+                    $isUserBasedContentType = $this->hasUserField($contentType);
+                } catch (NotFoundException $e) {
+                    return;
+                }
+
+                if (!$isUserBasedContentType) {
+                    return;
+                }
+
+                $event->setController([$this->userController, 'editAction']);
+            }
+        }
+    }
+
+    /**
+     * @param ContentType $contentType
+     *
+     * @return bool
+     */
+    private function hasUserField(ContentType $contentType): bool
+    {
+        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+            if (self::USER_FIELD_TYPE === $fieldDefinition->fieldTypeIdentifier) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/Form/ActionDispatcher/UserDispatcher.php
+++ b/lib/Form/ActionDispatcher/UserDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
+
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserDispatcher extends AbstractActionDispatcher
+{
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+    }
+
+    protected function getActionEventBaseName()
+    {
+        return RepositoryFormEvents::USER_EDIT;
+    }
+}

--- a/lib/Form/EventSubscriber/SuppressValidationSubscriber.php
+++ b/lib/Form/EventSubscriber/SuppressValidationSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Suppresses validation on cancel button submit.
+ */
+class SuppressValidationSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::POST_SUBMIT => ['suppressValidationOnCancel', 900],
+        ];
+    }
+
+    public function suppressValidationOnCancel(FormEvent $event)
+    {
+        $form = $event->getForm();
+
+        if ($form->get('cancel')->isClicked()) {
+            $event->stopPropagation();
+        }
+    }
+}

--- a/lib/Form/EventSubscriber/UserFieldsSubscriber.php
+++ b/lib/Form/EventSubscriber/UserFieldsSubscriber.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\EventSubscriber;
+
+use eZ\Publish\Core\FieldType\User\Value;
+use EzSystems\RepositoryForms\Data\User\UserAccountFieldData;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use EzSystems\RepositoryForms\Data\User\UserUpdateData;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Maps data between repository user create/update struct and form data object.
+ */
+class UserFieldsSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::SUBMIT => 'handleUserAccountField',
+        ];
+    }
+
+    /**
+     * Handles User Account field in create/update struct.
+     *
+     * Workaround to quirky ezuser field type, it copies user data from field Data class to general User update/create
+     * struct and injects proper Value for ezuser field type in order to pass validation.
+     *
+     * @param FormEvent $event
+     */
+    public function handleUserAccountField(FormEvent $event)
+    {
+        /** @var UserCreateData|UserUpdateData $data */
+        $data = $event->getData();
+        $form = $event->getForm();
+        $languageCode = $form->getConfig()->getOption('languageCode');
+
+        if ($data->isNew()) {
+            $this->handleUserCreateData($data);
+        } else {
+            $this->handleUserUpdateData($data, $languageCode);
+        }
+    }
+
+    /**
+     * @param UserCreateData $data
+     */
+    private function handleUserCreateData(UserCreateData $data)
+    {
+        foreach ($data->fieldsData as $fieldData) {
+            if ('ezuser' !== $fieldData->getFieldTypeIdentifier()) {
+                continue;
+            }
+
+            /** @var UserAccountFieldData $userAccountFieldData */
+            $userAccountFieldData = $fieldData->value;
+            $data->login = $userAccountFieldData->username;
+            $data->email = $userAccountFieldData->email;
+            $data->password = $userAccountFieldData->password;
+
+            /** @var Value $userValue */
+            $userValue = clone $data->contentType
+                ->getFieldDefinition($fieldData->field->fieldDefIdentifier)->defaultValue;
+            $userValue->login = $userAccountFieldData->username;
+            $userValue->email = $userAccountFieldData->email;
+
+            $fieldData->value = $userValue;
+
+            return;
+        }
+    }
+
+    /**
+     * @param UserUpdateData $data
+     * @param $languageCode
+     */
+    private function handleUserUpdateData(UserUpdateData $data, $languageCode)
+    {
+        foreach ($data->fieldsData as $fieldData) {
+            if ('ezuser' !== $fieldData->getFieldTypeIdentifier()) {
+                continue;
+            }
+
+            /** @var UserAccountFieldData $userAccountFieldData */
+            $userAccountFieldData = $fieldData->value;
+            $data->email = $userAccountFieldData->email;
+            $data->password = $userAccountFieldData->password;
+
+            /** @var Value $userValue */
+            $userValue = clone $data->user->getField($fieldData->field->fieldDefIdentifier, $languageCode)->value;
+            $fieldData->value = $userValue;
+
+            return;
+        }
+    }
+}

--- a/lib/Form/Processor/User/UserCancelFormProcessor.php
+++ b/lib/Form/Processor/User/UserCancelFormProcessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Processor\User;
+
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use EzSystems\RepositoryForms\Data\User\UserUpdateData;
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Listens for and processes User cancel events.
+ */
+class UserCancelFormProcessor implements EventSubscriberInterface
+{
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
+    /**
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function __construct(
+        UrlGeneratorInterface $urlGenerator
+    ) {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::USER_CANCEL => ['processCancel', 10],
+        ];
+    }
+
+    public function processCancel(FormActionEvent $event)
+    {
+        /** @var UserUpdateData|UserCreateData $data */
+        $data = $event->getData();
+
+        $locationId = $data->isNew()
+            ? $data->getParentGroups()[0]->contentInfo->mainLocationId
+            : $data->user->contentInfo->mainLocationId;
+
+        $response = new RedirectResponse($this->urlGenerator->generate('_ezpublishLocation', [
+            'locationId' => $locationId,
+        ]));
+        $event->setResponse($response);
+    }
+}

--- a/lib/Form/Processor/User/UserCreateFormProcessor.php
+++ b/lib/Form/Processor/User/UserCreateFormProcessor.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Processor\User;
+
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Listens for and processes User create events.
+ */
+class UserCreateFormProcessor implements EventSubscriberInterface
+{
+    /** @var UserService */
+    private $userService;
+
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
+    /**
+     * @param UserService $userService
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function __construct(
+        UserService $userService,
+        UrlGeneratorInterface $urlGenerator
+    ) {
+        $this->userService = $userService;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::USER_CREATE => ['processCreate', 20],
+        ];
+    }
+
+    public function processCreate(FormActionEvent $event)
+    {
+        $data = $data = $event->getData();
+
+        if (!$data instanceof UserCreateData) {
+            return;
+        }
+
+        $form = $event->getForm();
+        $languageCode = $form->getConfig()->getOption('languageCode');
+
+        $this->setContentFields($data, $languageCode);
+        $user = $this->userService->createUser($data, $data->getParentGroups());
+
+        $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->urlGenerator->generate(
+            '_ezpublishLocation',
+            ['locationId' => $user->contentInfo->mainLocationId],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+        $event->setResponse(new RedirectResponse($redirectUrl));
+    }
+
+    /**
+     * @param UserCreateData $data
+     * @param string $languageCode
+     */
+    private function setContentFields(UserCreateData $data, string $languageCode): void
+    {
+        foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+            if ('ezuser' === $fieldData->getFieldTypeIdentifier()) {
+                continue;
+            }
+
+            $data->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
+        }
+    }
+}

--- a/lib/Form/Processor/User/UserUpdateFormProcessor.php
+++ b/lib/Form/Processor/User/UserUpdateFormProcessor.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\RepositoryForms\Form\Processor\User;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\RepositoryForms\Data\User\UserUpdateData;
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Listens for and processes User update events.
+ */
+class UserUpdateFormProcessor implements EventSubscriberInterface
+{
+    /** @var UserService */
+    private $userService;
+
+    /** @var ContentService */
+    private $contentService;
+
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
+    public function __construct(
+        UserService $userService,
+        ContentService $contentService,
+        UrlGeneratorInterface $urlGenerator
+    ) {
+        $this->userService = $userService;
+        $this->contentService = $contentService;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::USER_UPDATE => ['processUpdate', 20],
+        ];
+    }
+
+    public function processUpdate(FormActionEvent $event)
+    {
+        $data = $data = $event->getData();
+
+        if (!$data instanceof UserUpdateData) {
+            return;
+        }
+
+        $form = $event->getForm();
+        $languageCode = $form->getConfig()->getOption('languageCode');
+
+        $this->setContentFields($data, $languageCode);
+        $user = $this->userService->updateUser($data->user, $data);
+
+        $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->urlGenerator->generate(
+            '_ezpublishLocation',
+            ['locationId' => $user->contentInfo->mainLocationId],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+        $event->setResponse(new RedirectResponse($redirectUrl));
+    }
+
+    /**
+     * @param UserUpdateData $data
+     * @param string $languageCode
+     */
+    private function setContentFields(UserUpdateData $data, string $languageCode): void
+    {
+        $data->contentUpdateStruct = $this->contentService->newContentUpdateStruct();
+
+        foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+            $data->contentUpdateStruct->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
+        }
+    }
+}

--- a/lib/Form/Type/Content/BaseContentType.php
+++ b/lib/Form/Type/Content/BaseContentType.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Form\Type\Content;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Base Type used on User or Content create/edit forms.
+ */
+class BaseContentType extends AbstractType
+{
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ezrepoforms_content';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('fieldsData', CollectionType::class, [
+                'entry_type' => ContentFieldType::class,
+                'label' => 'ezrepoforms.content.fields',
+                'entry_options' => [
+                    'languageCode' => $options['languageCode'],
+                    'mainLanguageCode' => $options['mainLanguageCode'],
+                ],
+            ])
+            ->add('redirectUrlAfterPublish', HiddenType::class, [
+                'required' => false,
+                'mapped' => false,
+            ]);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['languageCode'] = $options['languageCode'];
+        $view->vars['mainLanguageCode'] = $options['mainLanguageCode'];
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired(['languageCode', 'mainLanguageCode']);
+    }
+}

--- a/lib/Form/Type/FieldType/UserAccountFieldType.php
+++ b/lib/Form/Type/FieldType/UserAccountFieldType.php
@@ -5,8 +5,9 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\Form\Type\User;
+namespace EzSystems\RepositoryForms\Form\Type\FieldType;
 
+use EzSystems\RepositoryForms\Data\User\UserAccountFieldData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -15,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserAccountType extends AbstractType
+class UserAccountFieldType extends AbstractType
 {
     public function getName()
     {
@@ -24,25 +25,27 @@ class UserAccountType extends AbstractType
 
     public function getBlockPrefix()
     {
-        return 'ezuser';
+        return 'ezplatform_fieldtype_ezuser';
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $isUpdateForm = 'update' === $options['intent'];
+
         $builder
             ->add('username', TextType::class, [
-                'property_path' => 'username',
                 'label' => 'content.field_type.ezuser.username',
                 'required' => $options['required'],
+                'attr' => $isUpdateForm ? ['disabled' => 'disabled'] : [],
             ])
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'required' => true,
-                'property_path' => 'password',
+                'required' => $options['required'] && !$isUpdateForm,
                 'first_options' => ['label' => 'content.field_type.ezuser.password'],
                 'second_options' => ['label' => 'content.field_type.ezuser.password_confirm'],
             ])
             ->add('email', EmailType::class, [
+                'required' => $options['required'],
                 'label' => 'content.field_type.ezuser.email',
             ]);
     }
@@ -51,8 +54,10 @@ class UserAccountType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'data_class' => '\EzSystems\RepositoryForms\Data\User\UserAccountFieldData',
+                'data_class' => UserAccountFieldData::class,
                 'translation_domain' => 'ezrepoforms_content',
-            ]);
+            ])
+            ->setRequired(['intent'])
+            ->setAllowedValues('intent', ['register', 'create', 'update']);
     }
 }

--- a/lib/Form/Type/FieldType/UserAccountFieldType.php
+++ b/lib/Form/Type/FieldType/UserAccountFieldType.php
@@ -35,17 +35,17 @@ class UserAccountFieldType extends AbstractType
         $builder
             ->add('username', TextType::class, [
                 'label' => 'content.field_type.ezuser.username',
-                'required' => $options['required'],
+                'required' => true,
                 'attr' => $isUpdateForm ? ['disabled' => 'disabled'] : [],
             ])
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'required' => $options['required'] && !$isUpdateForm,
+                'required' => !$isUpdateForm,
                 'first_options' => ['label' => 'content.field_type.ezuser.password'],
                 'second_options' => ['label' => 'content.field_type.ezuser.password_confirm'],
             ])
             ->add('email', EmailType::class, [
-                'required' => $options['required'],
+                'required' => true,
                 'label' => 'content.field_type.ezuser.email',
             ]);
     }

--- a/lib/Form/Type/User/BaseUserType.php
+++ b/lib/Form/Type/User/BaseUserType.php
@@ -5,10 +5,13 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\Form\Type\Content;
+namespace EzSystems\RepositoryForms\Form\Type\User;
 
 use EzSystems\RepositoryForms\Form\EventSubscriber\SuppressValidationSubscriber;
+use EzSystems\RepositoryForms\Form\EventSubscriber\UserFieldsSubscriber;
+use EzSystems\RepositoryForms\Form\Type\Content\BaseContentType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Underlying data will be either \EzSystems\RepositoryForms\Data\Content\ContentCreateData or \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
  * depending on the context (create or update).
  */
-class ContentEditType extends AbstractType
+class BaseUserType extends AbstractType
 {
     public function getName()
     {
@@ -27,7 +30,7 @@ class ContentEditType extends AbstractType
 
     public function getBlockPrefix()
     {
-        return 'ezrepoforms_content_edit';
+        return 'ezrepoforms_user';
     }
 
     public function getParent()
@@ -38,26 +41,25 @@ class ContentEditType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('publish', SubmitType::class, ['label' => 'content.publish_button']);
-
-        if ($options['drafts_enabled']) {
-            $builder
-                ->add('saveDraft', SubmitType::class, ['label' => 'content.save_button'])
-                ->add('cancel', SubmitType::class, [
-                    'label' => 'content.cancel_button',
-                    'attr' => ['formnovalidate' => 'formnovalidate'],
-                ]);
-            $builder->addEventSubscriber(new SuppressValidationSubscriber());
-        }
+            ->add('enabled', CheckboxType::class, ['required' => false, 'label' => /** @Desc("Enabled") */ 'user.enabled'])
+            ->add('cancel', SubmitType::class, [
+                'label' => /** @Desc("Cancel") */ 'user.cancel',
+                'attr' => ['formnovalidate' => 'formnovalidate'],
+            ])
+            ->addEventSubscriber(new UserFieldsSubscriber())
+            ->addEventSubscriber(new SuppressValidationSubscriber());
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([
-                'drafts_enabled' => false,
-                'data_class' => '\eZ\Publish\API\Repository\Values\Content\ContentStruct',
-                'translation_domain' => 'ezrepoforms_content',
-            ]);
+                'translation_domain' => 'ezrepoforms_user',
+            ])
+            ->setRequired([
+                'languageCode',
+                'intent',
+            ])
+            ->setAllowedValues('intent', ['update', 'create', 'register']);
     }
 }

--- a/lib/Form/Type/User/UserCreateType.php
+++ b/lib/Form/Type/User/UserCreateType.php
@@ -5,9 +5,9 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\Form\Type\Content;
+namespace EzSystems\RepositoryForms\Form\Type\User;
 
-use EzSystems\RepositoryForms\Form\EventSubscriber\SuppressValidationSubscriber;
+use EzSystems\RepositoryForms\Data\User\UserCreateData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Underlying data will be either \EzSystems\RepositoryForms\Data\Content\ContentCreateData or \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
  * depending on the context (create or update).
  */
-class ContentEditType extends AbstractType
+class UserCreateType extends AbstractType
 {
     public function getName()
     {
@@ -27,37 +27,27 @@ class ContentEditType extends AbstractType
 
     public function getBlockPrefix()
     {
-        return 'ezrepoforms_content_edit';
+        return 'ezrepoforms_user_create';
     }
 
     public function getParent()
     {
-        return BaseContentType::class;
+        return BaseUserType::class;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('publish', SubmitType::class, ['label' => 'content.publish_button']);
-
-        if ($options['drafts_enabled']) {
-            $builder
-                ->add('saveDraft', SubmitType::class, ['label' => 'content.save_button'])
-                ->add('cancel', SubmitType::class, [
-                    'label' => 'content.cancel_button',
-                    'attr' => ['formnovalidate' => 'formnovalidate'],
-                ]);
-            $builder->addEventSubscriber(new SuppressValidationSubscriber());
-        }
+            ->add('create', SubmitType::class, ['label' => /** @Desc("Create") */ 'user.create']);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([
-                'drafts_enabled' => false,
-                'data_class' => '\eZ\Publish\API\Repository\Values\Content\ContentStruct',
-                'translation_domain' => 'ezrepoforms_content',
+                'data_class' => UserCreateData::class,
+                'intent' => 'create',
+                'translation_domain' => 'ezrepoforms_user',
             ]);
     }
 }

--- a/lib/Form/Type/User/UserUpdateType.php
+++ b/lib/Form/Type/User/UserUpdateType.php
@@ -5,9 +5,9 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\Form\Type\Content;
+namespace EzSystems\RepositoryForms\Form\Type\User;
 
-use EzSystems\RepositoryForms\Form\EventSubscriber\SuppressValidationSubscriber;
+use EzSystems\RepositoryForms\Data\User\UserUpdateData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Underlying data will be either \EzSystems\RepositoryForms\Data\Content\ContentCreateData or \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
  * depending on the context (create or update).
  */
-class ContentEditType extends AbstractType
+class UserUpdateType extends AbstractType
 {
     public function getName()
     {
@@ -27,37 +27,27 @@ class ContentEditType extends AbstractType
 
     public function getBlockPrefix()
     {
-        return 'ezrepoforms_content_edit';
+        return 'ezrepoforms_user_update';
     }
 
     public function getParent()
     {
-        return BaseContentType::class;
+        return BaseUserType::class;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('publish', SubmitType::class, ['label' => 'content.publish_button']);
-
-        if ($options['drafts_enabled']) {
-            $builder
-                ->add('saveDraft', SubmitType::class, ['label' => 'content.save_button'])
-                ->add('cancel', SubmitType::class, [
-                    'label' => 'content.cancel_button',
-                    'attr' => ['formnovalidate' => 'formnovalidate'],
-                ]);
-            $builder->addEventSubscriber(new SuppressValidationSubscriber());
-        }
+            ->add('update', SubmitType::class, ['label' => /** @Desc("Update") */ 'user.update']);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults([
-                'drafts_enabled' => false,
-                'data_class' => '\eZ\Publish\API\Repository\Values\Content\ContentStruct',
-                'translation_domain' => 'ezrepoforms_content',
+                'data_class' => UserUpdateData::class,
+                'intent' => 'update',
+                'translation_domain' => 'ezrepoforms_user',
             ]);
     }
 }

--- a/lib/User/ConfigurableRegistrationContentTypeLoader.php
+++ b/lib/User/ConfigurableRegistrationContentTypeLoader.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\UserRegister;
+namespace EzSystems\RepositoryForms\User;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/lib/User/ConfigurableRegistrationGroupLoader.php
+++ b/lib/User/ConfigurableRegistrationGroupLoader.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\UserRegister;
+namespace EzSystems\RepositoryForms\User;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/lib/User/ConfigurableSudoRepositoryLoader.php
+++ b/lib/User/ConfigurableSudoRepositoryLoader.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\UserRegister;
+namespace EzSystems\RepositoryForms\User;
 
 use Closure;
 use eZ\Publish\API\Repository\Repository;

--- a/lib/User/RegistrationContentTypeLoader.php
+++ b/lib/User/RegistrationContentTypeLoader.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\UserRegister;
+namespace EzSystems\RepositoryForms\User;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 

--- a/lib/User/RegistrationGroupLoader.php
+++ b/lib/User/RegistrationGroupLoader.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-namespace EzSystems\RepositoryForms\UserRegister;
+namespace EzSystems\RepositoryForms\User;
 
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 

--- a/lib/User/View/UserCreateView.php
+++ b/lib/User/View/UserCreateView.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\User\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+
+class UserCreateView extends BaseView
+{
+}

--- a/lib/User/View/UserRegisterConfirmView.php
+++ b/lib/User/View/UserRegisterConfirmView.php
@@ -3,11 +3,10 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\UserRegister\View;
+namespace EzSystems\RepositoryForms\User\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
-use eZ\Publish\Core\MVC\Symfony\View\View;
 
-class UserRegisterFormView extends BaseView implements View
+class UserRegisterConfirmView extends BaseView
 {
 }

--- a/lib/User/View/UserRegisterFormView.php
+++ b/lib/User/View/UserRegisterFormView.php
@@ -3,11 +3,10 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\RepositoryForms\UserRegister\View;
+namespace EzSystems\RepositoryForms\User\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
-use eZ\Publish\Core\MVC\Symfony\View\View;
 
-class UserRegisterConfirmView extends BaseView implements View
+class UserRegisterFormView extends BaseView
 {
 }

--- a/lib/User/View/UserUpdateView.php
+++ b/lib/User/View/UserUpdateView.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\User\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+
+class UserUpdateView extends BaseView
+{
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27646
> JIRA (epic): https://jira.ez.no/browse/EZP-26700

# Description
This PR provides basic editing support for:
* `ezuser` [EZP-27646: Implement editing support for User FieldType](https://jira.ez.no/browse/EZP-27646) 

# Remarks
I had to implement completely different infrastructure for editing Users due to how kernel manages users. My implementation introduces separate action dispatcher with new event names, separated form processors, types, data classes etc.

# TODO
- [ ] document BC breaks
- [ ] check Behat tests
- [ ] check unit tests