### PR TITLE
EZP-27819: Template exception when editing policies with no node and subtree limitation

### DIFF
--- a/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
+++ b/bundle/Resources/views/Limitation/udw_limitation_value.html.twig
@@ -10,9 +10,11 @@
 <div>
     <ul id="{{form.limitationValues.vars.id}}-selected-location">
         {% for limitationValue in form.limitationValues.vars.value|split(',') %}
-        <li>
-            {{ render( controller( "ez_content:viewAction", {'locationId': limitationValue, 'viewType': '_platformui_content_name'} ) ) }}
-        </li>
+            {% if limitationValue is not empty %}
+                <li>
+                    {{ render( controller( "ez_content:viewAction", {'locationId': limitationValue, 'viewType': '_platformui_content_name'} ) ) }}
+                </li>
+            {% endif %}
         {% endfor %}
     </ul>
 </div>


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-27819
> Pending QA

When editing limitations for a policy that can have Node and Subtree limitations, but doesn't, Twig throws an exception because it is trying to render a Location with an empty string as ID.

Fixing this by verifying we have an ID to render. Thanks to @Plopix!