### PR TITLE
[WIP] EZP-27860: Set Travis dist to "precise"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: required
+dist: precise
 
 matrix:
   # mark as finished before allow_failures are run


### PR DESCRIPTION
> JIRA: [EZP-27860](https://jira.ez.no/browse/EZP-27860)

# Description

In this repository we've been using the default dist on Travis , which used to be "precise". It has been changed recently [source](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status) (so that it default to "trusty" and it looks our behat tests are not working correctly there.

This PR changes the distribution back to the one we've been using to make sure the tests are passing. It should unblock some tickets, such as:
https://github.com/ezsystems/repository-forms/pull/140
https://github.com/ezsystems/repository-forms/pull/149

I'd treat this change as a quick fix so that the development is unblocked, I guess a deeper investigation is needed to find out why aren't the tests working on Trusty.

I'm marking it as WIP until the Travis build passes.
