### PR TITLE
Fix EZP-27873: Added translations for role.policy.all_modules/role.policy.all_modules_all_functions

### DIFF
--- a/bundle/Resources/translations/ezrepoforms_role.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_role.en.xlf
@@ -48,6 +48,18 @@
         <note>key: role.identifier</note>
         <jms:reference-file line="44">/../../../../.././lib/Form/Type/Role/RoleUpdateType.php</jms:reference-file>
       </trans-unit>
+      <trans-unit id="6345474b02b9503fc624bf2e4c781130f58d9d41" resname="role.policy.all_modules">
+        <source>All modules</source>
+        <target>All modules</target>
+        <note>key: role.policy.all_modules</note>
+        <jms:reference-file line="54">/../../../../.././lib/Form/Type/Role/PolicyType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="d4690e1d0c7d2cf0468ab5aa04caa891e1b5efbd" resname="role.policy.all_modules_all_functions">
+        <source>All modules / All functions</source>
+        <target>All modules / All functions</target>
+        <note>key: role.policy.all_modules_all_functions</note>
+        <jms:reference-file line="54">/../../../../.././lib/Form/Type/Role/PolicyType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="deab5c91a76488732d0405e72c36702ed2aea3d6" resname="role.policy.all_functions">
         <source>All functions</source>
         <target>All functions</target>

--- a/lib/Form/Type/Role/PolicyType.php
+++ b/lib/Form/Type/Role/PolicyType.php
@@ -51,7 +51,12 @@ class PolicyType extends AbstractType
      */
     private function buildPolicyChoicesFromMap($policyMap)
     {
-        $policyChoices = ['role.policy.all_modules' => ['role.policy.all_modules_all_functions' => '*|*']];
+        $policyChoices = [
+            $this->translator->trans('role.policy.all_modules', [], 'ezrepoforms_role') => [
+                $this->translator->trans('role.policy.all_modules_all_functions', [], 'ezrepoforms_role') => '*|*',
+            ],
+        ];
+
         foreach ($policyMap as $module => $functionList) {
             $humanizedModule = $this->humanize($module);
             // For each module, add possibility to grant access to all functions.


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27873

# Description

 This PR adds two missing translations for the following keys: 

* `role.policy.all_modules`
* `role.policy.all_modules_all_functions`

in "Policy type" choice field in "New policy" form 


