### PR TITLE
EZP-27884: Create extensibility point for views overriding in content edit and draft create

### DIFF
--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -14,6 +14,8 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use EzSystems\RepositoryForms\Content\View\ContentCreateDraftView;
+use EzSystems\RepositoryForms\Content\View\ContentEditView;
 use EzSystems\RepositoryForms\Data\Content\CreateContentDraftData;
 use EzSystems\RepositoryForms\Data\Mapper\ContentCreateMapper;
 use EzSystems\RepositoryForms\Data\Mapper\ContentUpdateMapper;
@@ -46,6 +48,8 @@ class ContentEditController extends Controller
 
     /**
      * @var string
+     *
+     * @deprecated Deprecated since 1.10 and will be removed in 2.0. See setPagelayout().
      */
     private $pagelayout;
 
@@ -69,7 +73,7 @@ class ContentEditController extends Controller
      * @param int $parentLocationId Location the content should be a child of
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView|\Symfony\Component\HttpFoundation\Response
      */
     public function createWithoutDraftAction($contentTypeIdentifier, $language, $parentLocationId, Request $request)
     {
@@ -88,10 +92,9 @@ class ContentEditController extends Controller
             }
         }
 
-        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
+        return new ContentEditView(null, [
             'form' => $form->createView(),
             'languageCode' => $language,
-            'pagelayout' => $this->pagelayout,
         ]);
     }
 
@@ -104,7 +107,7 @@ class ContentEditController extends Controller
      * @param string $toLanguage
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateDraftView|\Symfony\Component\HttpFoundation\Response
      */
     public function createContentDraftAction($contentId, $fromVersionNo = null, $fromLanguage = null, $toLanguage = null, Request $request)
     {
@@ -135,10 +138,7 @@ class ContentEditController extends Controller
             }
         }
 
-        return $this->render('@EzSystemsRepositoryForms/Content/content_create_draft.html.twig', [
-            'form' => $form->createView(),
-            'pagelayout' => $this->pagelayout,
-        ]);
+        return new ContentCreateDraftView(null, ['form' => $form->createView()]);
     }
 
     /**
@@ -149,7 +149,7 @@ class ContentEditController extends Controller
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $language Language code to create the version in (eng-GB, ger-DE, ...))
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView|\Symfony\Component\HttpFoundation\Response
      * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException If the version isn't editable, or if there is no editable version.
      */
     public function editContentDraftAction($contentId, $versionNo = null, Request $request, $language = null)
@@ -183,16 +183,17 @@ class ContentEditController extends Controller
             }
         }
 
-        return $this->render('EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig', [
+        return new ContentEditView(null, [
             'form' => $form->createView(),
             'languageCode' => $language,
-            'pagelayout' => $this->pagelayout,
         ]);
     }
 
     /**
      * @param string $pagelayout
      * @return ContentEditController
+     *
+     * @deprecated Deprecated since 1.10 and will be removed in 2.0. Pagelayout is injected via ViewTemplatesListener.
      */
     public function setPagelayout($pagelayout)
     {

--- a/bundle/Controller/UserRegisterController.php
+++ b/bundle/Controller/UserRegisterController.php
@@ -9,8 +9,8 @@
 namespace EzSystems\RepositoryFormsBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
-use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
+use EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 use EzSystems\RepositoryForms\Form\Type\User\UserRegisterType;
 use EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView;
@@ -43,9 +43,7 @@ class UserRegisterController extends Controller
      *
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
-     *
-     * @throws \Exception if the current user isn't allowed to register an account
+     * @return \EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView|\Symfony\Component\HttpFoundation\Response * @throws \Exception if the current user isn't allowed to register an account
      */
     public function registerAction(Request $request)
     {
@@ -70,10 +68,7 @@ class UserRegisterController extends Controller
             }
         }
 
-        return new UserRegisterFormView(
-            null,
-            ['form' => $form->createView()]
-        );
+        return new UserRegisterFormView(null, ['form' => $form->createView()]);
     }
 
     public function registerConfirmAction()

--- a/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class ContentEdit extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('content_edit')
+                ->info('Content edit configuration')
+                ->children()
+                    ->arrayNode('templates')
+                        ->info('Content edit templates.')
+                        ->children()
+                            ->scalarNode('edit')
+                                ->info('Template to use for content edit form rendering.')
+                            ->end()
+                            ->scalarNode('create_draft')
+                                ->info('Template to use for content draft creation rendering.')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (empty($scopeSettings['content_edit'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['content_edit'];
+
+        if (!empty($settings['templates']['edit'])) {
+            $contextualizer->setContextualParameter(
+                'content_edit.templates.edit',
+                $currentScope,
+                $settings['templates']['edit']
+            );
+        }
+
+        if (!empty($settings['templates']['create_draft'])) {
+            $contextualizer->setContextualParameter(
+                'content_edit.templates.create_draft',
+                $currentScope,
+                $settings['templates']['create_draft']
+            );
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -14,6 +14,7 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEdit;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -30,6 +31,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
         $eZExtension->addConfigParser(new UserRegistration());
+        $eZExtension->addConfigParser(new ContentEdit());
         $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -2,4 +2,5 @@ parameters:
     ezsettings.default.user_registration.group_id: 11
     ezsettings.default.user_registration.templates.form: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.user_registration.templates.confirmation: "EzSystemsRepositoryFormsBundle:User:register_confirmation.html.twig"
-
+    ezsettings.default.content_edit.templates.edit: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
+    ezsettings.default.content_edit.templates.create_draft: "EzSystemsRepositoryFormsBundle:Content:content_create_draft.html.twig"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -66,7 +66,8 @@ parameters:
 
     ezrepoforms.user_register.registration_group_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationGroupLoader
     ezrepoforms.user_register.registration_content_type_loader.configurable.class: EzSystems\RepositoryForms\UserRegister\ConfigurableRegistrationContentTypeLoader
-    ezrepoforms.user_register.view_templates_listener.class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
+    ezrepoforms.view_templates_listener.class: EzSystems\RepositoryForms\EventListener\ViewTemplatesListener
+    ezrepoforms.user_register.view_templates_listener.class: '%ezrepoforms.view_templates_listener.class%' # Deprecated in 1.10, to be removed in 2.0
 
     ezrepoforms.form_data_mapper.user_register.class: EzSystems\RepositoryForms\Data\Mapper\UserRegisterMapper
 
@@ -440,14 +441,20 @@ services:
         calls:
             - [setParam, ["language", "@=service('ezpublish.config.resolver').getParameter('languages', null, null)[0]"]]
 
-    ezrepoforms.user_register.view_templates_listener:
-        class: "%ezrepoforms.user_register.view_templates_listener.class%"
+    ezrepoforms.view_templates_listener:
+        class: "%ezrepoforms.view_templates_listener.class%"
         tags:
             - { name: kernel.event_subscriber }
         calls:
             - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView', "$user_registration.templates.form$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentEditView', "$content_edit.templates.edit$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateDraftView', "$content_edit.templates.create_draft$"]]
             - [setPagelayout, ["$pagelayout$"]]
+
+    ezrepoforms.user_register.view_templates_listener:
+        alias: ezrepoforms.view_templates_listener
+        deprecated: 'The "%service_id%" service is deprecated since 1.10 and will be removed in 2.0. Use "ezrepoforms.view_templates_listener" instead.'
 
     ezrepoforms.translation.extractor.sorting:
         class: EzSystems\RepositoryForms\Translation\SortingTranslationExtractor

--- a/doc/bc/changes-1.10.md
+++ b/doc/bc/changes-1.10.md
@@ -16,5 +16,6 @@ Changes affecting version compatibility with former or future versions.
   How it might affect your code: Don't rely on `TranslationHelper` as the same functionality is now achieved by calling `getNames()` directly on the object.
 
 ## Deprecations
-
+ - The "ezrepoforms.user_register.view_templates_listener" service is deprecated since 1.10 and will be removed in 2.0. Use "ezrepoforms.view_templates_listener" instead
+   
 ## Removed features

--- a/lib/Content/View/ContentCreateDraftView.php
+++ b/lib/Content/View/ContentCreateDraftView.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Content\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class ContentCreateDraftView extends BaseView implements View
+{
+}

--- a/lib/Content/View/ContentEditView.php
+++ b/lib/Content/View/ContentEditView.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Content\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class ContentEditView extends BaseView implements View
+{
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27884

# Description
Changed return type of the controller's actions. It now returns `View` objects which are rendered by `ViewManager`. Templates are injected from parameters which can be easily configured. It uses the same principle as UserRegister.