### PR TITLE
EZP-24699: Enrich policy limitations view with human readable names

### DIFF
--- a/bundle/DependencyInjection/Compiler/LimitationValueMapperPass.php
+++ b/bundle/DependencyInjection/Compiler/LimitationValueMapperPass.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+/**
+ * Compiler pass to register Limitation value mappers.
+ */
+class LimitationValueMapperPass implements CompilerPassInterface
+{
+    const LIMITATION_VALUE_MAPPER_REGISTRY = 'ezrepoforms.limitation_value_mapper.registry';
+    const LIMITATION_VALUE_MAPPER_TAG = 'ez.limitation.valueMapper';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::LIMITATION_VALUE_MAPPER_REGISTRY)) {
+            return;
+        }
+
+        $registry = $container->findDefinition(self::LIMITATION_VALUE_MAPPER_REGISTRY);
+
+        foreach ($container->findTaggedServiceIds(self::LIMITATION_VALUE_MAPPER_TAG) as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['limitationType'])) {
+                    throw new LogicException(sprintf(
+                        '%s service tag needs a "limitationType" attribute to identify which LimitationType the mapper is for. None given.',
+                        self::LIMITATION_VALUE_MAPPER_TAG
+                    ));
+                }
+
+                $registry->addMethodCall('addMapper', [new Reference($id), $attribute['limitationType']]);
+            }
+        }
+    }
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -14,6 +14,7 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationValueMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -26,6 +27,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $container->addCompilerPass(new FieldTypeFormMapperPass());
         $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
+        $container->addCompilerPass(new LimitationValueMapperPass());
 
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());

--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -16,6 +16,7 @@ parameters:
 
     # Limitation mappers
     ezrepoforms.limitation_form_mapper.registry.class: EzSystems\RepositoryForms\Limitation\LimitationFormMapperRegistry
+    ezrepoforms.limitation_value_mapper.registry.class: EzSystems\RepositoryForms\Limitation\LimitationValueMapperRegistry
     ezrepoforms.limitation.null.template: "EzSystemsRepositoryFormsBundle:Limitation:null_limitation_values.html.twig"
     ezrepoforms.limitation.form_mapper.null.class: EzSystems\RepositoryForms\Limitation\Mapper\NullLimitationMapper
     ezrepoforms.limitation.multiple_selection.template: "EzSystemsRepositoryFormsBundle:Limitation:base_limitation_values.html.twig"
@@ -77,6 +78,9 @@ services:
     ezrepoforms.limitation_form_mapper.registry:
         class: "%ezrepoforms.limitation_form_mapper.registry.class%"
 
+    ezrepoforms.limitation_value_mapper.registry:
+        class: "%ezrepoforms.limitation_value_mapper.registry.class%"
+
     ezrepoforms.limitation.form_mapper.multiple_selection:
         class: EzSystems\RepositoryForms\Limitation\Mapper\MultipleSelectionBasedMapper
         abstract: true
@@ -89,12 +93,14 @@ services:
         arguments: ["%ezpublish.siteaccess.list%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: SiteAccess }
+            - { name: ez.limitation.valueMapper, limitationType: SiteAccess }
 
     ezrepoforms.limitation.form_mapper.null:
         class: "%ezrepoforms.limitation.form_mapper.null.class%"
         arguments: ["%ezrepoforms.limitation.null.template%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: "Null" }
+            - { name: ez.limitation.valueMapper, limitationType: "Null" }
 
     ezrepoforms.limitation.form_mapper.contenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -102,6 +108,7 @@ services:
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Class }
+            - { name: ez.limitation.valueMapper, limitationType: Class }
 
     ezrepoforms.limitation.form_mapper.parentcontenttype:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -109,6 +116,7 @@ services:
         arguments: ["@ezpublish.api.service.content_type"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentClass }
+            - { name: ez.limitation.valueMapper, limitationType: ParentClass }
 
     ezrepoforms.limitation.form_mapper.section:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -116,6 +124,7 @@ services:
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Section }
+            - { name: ez.limitation.valueMapper, limitationType: Section }
 
     ezrepoforms.limitation.form_mapper.newsection:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -123,6 +132,7 @@ services:
         arguments: ["@ezpublish.api.service.section"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewSection }
+            - { name: ez.limitation.valueMapper, limitationType: NewSection }
 
     ezrepoforms.limitation.form_mapper.objectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -130,6 +140,7 @@ services:
         arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: State }
+            - { name: ez.limitation.valueMapper, limitationType: State }
 
     ezrepoforms.limitation.form_mapper.newobjectstate:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -137,6 +148,7 @@ services:
         arguments: ["@ezpublish.api.service.object_state"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewState }
+            - { name: ez.limitation.valueMapper, limitationType: NewState }
 
     ezrepoforms.limitation.form_mapper.language:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -144,6 +156,7 @@ services:
         arguments: ["@ezpublish.api.service.language"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Language }
+            - { name: ez.limitation.valueMapper, limitationType: Language }
 
     ezrepoforms.limitation.form_mapper.owner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -151,6 +164,7 @@ services:
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Owner }
+            - { name: ez.limitation.valueMapper, limitationType: Owner }
 
     ezrepoforms.limitation.form_mapper.parentowner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -158,6 +172,7 @@ services:
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentOwner }
+            - { name: ez.limitation.valueMapper, limitationType: ParentOwner }
 
     ezrepoforms.limitation.form_mapper.group:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -165,6 +180,7 @@ services:
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Group }
+            - { name: ez.limitation.valueMapper, limitationType: Group }
 
     ezrepoforms.limitation.form_mapper.parentgroup:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -172,6 +188,7 @@ services:
         arguments: ["@translator"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentGroup }
+            - { name: ez.limitation.valueMapper, limitationType: ParentGroup }
 
     ezrepoforms.limitation.form_mapper.parentdepth:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
@@ -179,9 +196,13 @@ services:
         arguments: ["%ezrepoforms.limitation.form_mapper.parentdepth.maxdepth%"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentDepth }
+            - { name: ez.limitation.valueMapper, limitationType: ParentDepth }
 
     ezrepoforms.limitation.form_mapper.udw_based:
         class: EzSystems\RepositoryForms\Limitation\Mapper\UDWBasedMapper
+        arguments:
+            - "@ezpublish.api.service.location"
+            - "@ezpublish.api.service.search"
         calls:
             - [setFormTemplate, ["%ezrepoforms.limitation.udw.template%"]]
 
@@ -189,10 +210,11 @@ services:
         parent: ezrepoforms.limitation.form_mapper.udw_based
         tags:
             - { name: ez.limitation.formMapper, limitationType: Node }
+            - { name: ez.limitation.valueMapper, limitationType: Node }
 
     ezrepoforms.limitation.form_mapper.subtree:
         parent: ezrepoforms.limitation.form_mapper.udw_based
         class: "%ezrepoforms.limitation.form_mapper.subtree.class%"
-        arguments: ["@ezpublish.api.service.location"]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Subtree }
+            - { name: ez.limitation.valueMapper, limitationType: Subtree }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -45,7 +45,12 @@ parameters:
     ezrepoforms.validator.default_field_value.class: EzSystems\RepositoryForms\Validator\Constraints\FieldDefinitionDefaultValueValidator
     ezrepoforms.validator.field_value.class: EzSystems\RepositoryForms\Validator\Constraints\FieldValueValidator
 
+    ezrepoforms.templating.limitation_block_renderer.class: EzSystems\RepositoryForms\Limitation\Templating\LimitationBlockRenderer
+    ezrepoforms.templating.limitation_block_renderer.value_resources:
+        - 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig'
+
     ezrepoforms.twig.field_edit_rendering_extension.class: EzSystems\RepositoryForms\Twig\FieldEditRenderingExtension
+    ezrepoforms.twig.limitation_rendering_extension.class: EzSystems\RepositoryForms\Twig\LimitationValueRenderingExtension
     ezrepoforms.action_dispatcher.base.class: EzSystems\RepositoryForms\Form\ActionDispatcher\AbstractActionDispatcher
     ezrepoforms.action_dispatcher.content_type.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeDispatcher
     ezrepoforms.action_dispatcher.content_type.group.class: EzSystems\RepositoryForms\Form\ActionDispatcher\ContentTypeGroupDispatcher
@@ -311,6 +316,21 @@ services:
     ezrepoforms.twig.field_edit_rendering_extension:
         class: "%ezrepoforms.twig.field_edit_rendering_extension.class%"
         arguments: ["@ezpublish.templating.field_block_renderer"]
+        tags:
+            - { name: twig.extension }
+
+    ezrepoforms.templating.limitation_block_renderer:
+        class: '%ezrepoforms.templating.limitation_block_renderer.class%'
+        arguments:
+            - '@ezrepoforms.limitation_value_mapper.registry'
+            - '@twig'
+        calls:
+            - ['setLimitationValueResources', [ '%ezrepoforms.templating.limitation_block_renderer.value_resources%' ]]
+
+    ezrepoforms.twig.limitation_rendering_extension:
+        class: '%ezrepoforms.twig.limitation_rendering_extension.class%'
+        arguments:
+            - '@ezrepoforms.templating.limitation_block_renderer'
         tags:
             - { name: twig.extension }
 

--- a/bundle/Resources/views/limitation_values.html.twig
+++ b/bundle/Resources/views/limitation_values.html.twig
@@ -1,0 +1,118 @@
+{# fallback block for limitations without defined value mapper #}
+{% block ez_limitation_value_fallback %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_class_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_language_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_node_value %}
+{% spaceless %}
+    {% for path in values %}
+        {% for value in path %}/{{ value.name }}{% endfor %}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_owner_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_parentowner_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_parentclass_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_section_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_newsection_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_siteaccess_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_state_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_newstate_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_subtree_value %}
+{% spaceless %}
+    {% for path in values %}
+        {% for value in path %}/{{ value.name }}{% endfor %}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_group_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_parentdepth_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_parentgroup_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}
+
+{% block ez_limitation_status_value %}
+{% spaceless %}
+    {{ values|join(', ') }}
+{% endspaceless %}
+{% endblock %}

--- a/lib/Limitation/Exception/MissingLimitationBlockException.php
+++ b/lib/Limitation/Exception/MissingLimitationBlockException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation\Exception;
+
+use RuntimeException;
+
+class MissingLimitationBlockException extends RuntimeException
+{
+}

--- a/lib/Limitation/Exception/ValueMapperNotFoundException.php
+++ b/lib/Limitation/Exception/ValueMapperNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation\Exception;
+
+use Exception;
+use InvalidArgumentException;
+
+class ValueMapperNotFoundException extends InvalidArgumentException
+{
+    public function __construct($limitationType, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("No LimitationValueMapper found for '$limitationType'", $code, $previous);
+    }
+}

--- a/lib/Limitation/LimitationValueMapperInterface.php
+++ b/lib/Limitation/LimitationValueMapperInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+/**
+ * Interface for Limitation Value mappers.
+ */
+interface LimitationValueMapperInterface
+{
+    /**
+     * Map the limitation values, in order to pass them as context of limitation value rendering.
+     *
+     * @param Limitation $limitation
+     * @return mixed[]
+     */
+    public function mapLimitationValue(Limitation $limitation);
+}

--- a/lib/Limitation/LimitationValueMapperRegistry.php
+++ b/lib/Limitation/LimitationValueMapperRegistry.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation;
+
+use EzSystems\RepositoryForms\Limitation\Exception\ValueMapperNotFoundException;
+
+/**
+ * Registry for Limitation value mappers.
+ */
+class LimitationValueMapperRegistry implements LimitationValueMapperRegistryInterface
+{
+    /**
+     * @var LimitationValueMapperInterface[]
+     */
+    private $limitationValueMappers;
+
+    /**
+     * LimitationValueMapperRegistry constructor.
+     *
+     * @param LimitationValueMapperInterface[] $limitationValueMappers
+     */
+    public function __construct(array $limitationValueMappers = [])
+    {
+        $this->limitationValueMappers = $limitationValueMappers;
+    }
+
+    public function getMappers()
+    {
+        return $this->limitationValueMappers;
+    }
+
+    public function getMapper($limitationType)
+    {
+        if (!$this->hasMapper($limitationType)) {
+            throw new ValueMapperNotFoundException($limitationType);
+        }
+
+        return $this->limitationValueMappers[$limitationType];
+    }
+
+    public function hasMapper($limitationType)
+    {
+        return isset($this->limitationValueMappers[$limitationType]);
+    }
+
+    public function addMapper(LimitationValueMapperInterface $mapper, $limitationType)
+    {
+        $this->limitationValueMappers[$limitationType] = $mapper;
+    }
+}

--- a/lib/Limitation/LimitationValueMapperRegistryInterface.php
+++ b/lib/Limitation/LimitationValueMapperRegistryInterface.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation;
+
+use EzSystems\RepositoryForms\Limitation\Exception\ValueMapperNotFoundException;
+
+/**
+ * Interface for Limitation value mappers registry.
+ */
+interface LimitationValueMapperRegistryInterface
+{
+    /**
+     * Returns all available mappers.
+     *
+     * @return LimitationValueMapperInterface[]
+     */
+    public function getMappers();
+
+    /**
+     * Returns mapper corresponding to given Limitation Type.
+     *
+     * @throws ValueMapperNotFoundException If no mapper exists for $limitationType.
+     *
+     * @param string $limitationType
+     * @return LimitationValueMapperInterface
+     */
+    public function getMapper($limitationType);
+
+    /**
+     * Checks if a mapper exists for given Limitation Type.
+     *
+     * @param string $limitationType
+     * @return bool
+     */
+    public function hasMapper($limitationType);
+
+    /**
+     * Register mapper.
+     *
+     * @param LimitationValueMapperInterface $mapper
+     * @param string $limitationType Limitation identifier the mapper is meant for.
+     */
+    public function addMapper(LimitationValueMapperInterface $mapper, $limitationType);
+}

--- a/lib/Limitation/Mapper/ContentTypeLimitationMapper.php
+++ b/lib/Limitation/Mapper/ContentTypeLimitationMapper.php
@@ -9,8 +9,10 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 
-class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper
+class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var ContentTypeService
@@ -32,5 +34,15 @@ class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper
         }
 
         return $contentTypeChoices;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $values = [];
+        foreach ($limitation->limitationValues as $contentTypeId) {
+            $values[] = $this->contentTypeService->loadContentType($contentTypeId);
+        }
+
+        return $values;
     }
 }

--- a/lib/Limitation/Mapper/GroupLimitationMapper.php
+++ b/lib/Limitation/Mapper/GroupLimitationMapper.php
@@ -9,9 +9,10 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class GroupLimitationMapper extends MultipleSelectionBasedMapper
+class GroupLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var TranslatorInterface
@@ -27,6 +28,13 @@ class GroupLimitationMapper extends MultipleSelectionBasedMapper
     {
         return [
             1 => $this->translator->trans('policy.limitation.group.self', [], 'ezrepoforms_role'),
+        ];
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        return [
+            $this->translator->trans('policy.limitation.group.self', [], 'ezrepoforms_role'),
         ];
     }
 }

--- a/lib/Limitation/Mapper/LanguageLimitationMapper.php
+++ b/lib/Limitation/Mapper/LanguageLimitationMapper.php
@@ -9,8 +9,10 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 
-class LanguageLimitationMapper extends MultipleSelectionBasedMapper
+class LanguageLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var LanguageService
@@ -30,5 +32,16 @@ class LanguageLimitationMapper extends MultipleSelectionBasedMapper
         }
 
         return $choices;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $values = [];
+
+        foreach ($limitation->limitationValues as $languageCode) {
+            $values[] = $this->languageService->loadLanguage($languageCode);
+        }
+
+        return $values;
     }
 }

--- a/lib/Limitation/Mapper/NullLimitationMapper.php
+++ b/lib/Limitation/Mapper/NullLimitationMapper.php
@@ -10,9 +10,10 @@ namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 use Symfony\Component\Form\FormInterface;
 
-class NullLimitationMapper implements LimitationFormMapperInterface
+class NullLimitationMapper implements LimitationFormMapperInterface, LimitationValueMapperInterface
 {
     /**
      * @var string
@@ -35,5 +36,10 @@ class NullLimitationMapper implements LimitationFormMapperInterface
 
     public function filterLimitationValues(Limitation $limitation)
     {
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        return $limitation->limitationValues;
     }
 }

--- a/lib/Limitation/Mapper/ObjectStateLimitationMapper.php
+++ b/lib/Limitation/Mapper/ObjectStateLimitationMapper.php
@@ -9,8 +9,11 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 
-class ObjectStateLimitationMapper extends MultipleSelectionBasedMapper
+class ObjectStateLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var ObjectStateService
@@ -27,10 +30,34 @@ class ObjectStateLimitationMapper extends MultipleSelectionBasedMapper
         $choices = [];
         foreach ($this->objectStateService->loadObjectStateGroups() as $group) {
             foreach ($this->objectStateService->loadObjectStates($group) as $state) {
-                $choices[$state->id] = $state->getObjectStateGroup()->getName($state->defaultLanguageCode) . ':' . $state->getName($state->defaultLanguageCode);
+                $choices[$state->id] = $this->getObjectStateLabel($state);
             }
         }
 
         return $choices;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $values = [];
+
+        foreach ($limitation->limitationValues as $stateId) {
+            $values[] = $this->getObjectStateLabel(
+                $this->objectStateService->loadObjectState($stateId)
+            );
+        }
+
+        return $values;
+    }
+
+    protected function getObjectStateLabel(ObjectState $state)
+    {
+        $groupName = $state
+            ->getObjectStateGroup()
+            ->getName($state->defaultLanguageCode);
+
+        $stateName = $state->getName($state->defaultLanguageCode);
+
+        return $groupName . ':' . $stateName;
     }
 }

--- a/lib/Limitation/Mapper/OwnerLimitationMapper.php
+++ b/lib/Limitation/Mapper/OwnerLimitationMapper.php
@@ -9,9 +9,10 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class OwnerLimitationMapper extends MultipleSelectionBasedMapper
+class OwnerLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var TranslatorInterface
@@ -28,6 +29,13 @@ class OwnerLimitationMapper extends MultipleSelectionBasedMapper
         // 2: "Session" is not supported yet, see OwnerLimitationType
         return [
             1 => $this->translator->trans('policy.limitation.owner.self', [], 'ezrepoforms_role'),
+        ];
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        return [
+            $this->translator->trans('policy.limitation.owner.self', [], 'ezrepoforms_role'),
         ];
     }
 }

--- a/lib/Limitation/Mapper/ParentDepthLimitationMapper.php
+++ b/lib/Limitation/Mapper/ParentDepthLimitationMapper.php
@@ -8,7 +8,10 @@
  */
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
-class ParentDepthLimitationMapper extends MultipleSelectionBasedMapper
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+
+class ParentDepthLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var int The maximum possible depth to use in a limitation
@@ -28,5 +31,10 @@ class ParentDepthLimitationMapper extends MultipleSelectionBasedMapper
         }
 
         return $choices;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        return $limitation->limitationValues;
     }
 }

--- a/lib/Limitation/Mapper/SectionLimitationMapper.php
+++ b/lib/Limitation/Mapper/SectionLimitationMapper.php
@@ -9,8 +9,10 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 
-class SectionLimitationMapper extends MultipleSelectionBasedMapper
+class SectionLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var SectionService
@@ -30,5 +32,15 @@ class SectionLimitationMapper extends MultipleSelectionBasedMapper
         }
 
         return $choices;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $values = [];
+        foreach ($limitation->limitationValues as $sectionId) {
+            $values[] = $this->sectionService->loadSection($sectionId);
+        }
+
+        return $values;
     }
 }

--- a/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
+++ b/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
@@ -8,7 +8,10 @@
  */
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
-class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+
+class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
      * @var array
@@ -24,9 +27,26 @@ class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper
     {
         $siteAccesses = [];
         foreach ($this->siteAccessList as $sa) {
-            $siteAccesses[sprintf('%u', crc32($sa))] = $sa;
+            $siteAccesses[$this->getSiteAccessKey($sa)] = $sa;
         }
 
         return $siteAccesses;
+    }
+
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $values = [];
+        foreach ($this->siteAccessList as $sa) {
+            if (in_array($this->getSiteAccessKey($sa), $limitation->limitationValues)) {
+                $values[] = $sa;
+            }
+        }
+
+        return $values;
+    }
+
+    private function getSiteAccessKey($sa)
+    {
+        return sprintf('%u', crc32($sa));
     }
 }

--- a/lib/Limitation/Templating/LimitationBlockRenderer.php
+++ b/lib/Limitation/Templating/LimitationBlockRenderer.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation\Templating;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\Exception\MissingLimitationBlockException;
+use EzSystems\RepositoryForms\Limitation\Exception\ValueMapperNotFoundException;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperRegistryInterface;
+use Twig_Environment;
+use Twig_Template;
+
+class LimitationBlockRenderer implements LimitationBlockRendererInterface
+{
+    const LIMITATION_VALUE_BLOCK_NAME = 'ez_limitation_%s_value';
+    const LIMITATION_VALUE_BLOCK_NAME_FALLBACK = 'ez_limitation_value_fallback';
+
+    /**
+     * @var LimitationValueMapperRegistryInterface
+     */
+    private $valueMapperRegistry;
+
+    /**
+     * @var Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * @var array
+     */
+    private $limitationValueResources = [];
+
+    /**
+     * LimitationRenderer constructor.
+     *
+     * @param LimitationValueMapperRegistryInterface $valueMapperRegistry
+     * @param Twig_Environment $twig
+     */
+    public function __construct(LimitationValueMapperRegistryInterface $valueMapperRegistry, Twig_Environment $twig)
+    {
+        $this->valueMapperRegistry = $valueMapperRegistry;
+        $this->twig = $twig;
+    }
+
+    public function renderLimitationValue(Limitation $limitation, array $parameters = [])
+    {
+        try {
+            $blockName = $this->getValueBlockName($limitation);
+            $parameters = $this->getValueBlockParameters($limitation, $parameters);
+        } catch (ValueMapperNotFoundException $exception) {
+            $blockName = self::LIMITATION_VALUE_BLOCK_NAME_FALLBACK;
+            $parameters = $this->getValueFallbackBlockParameters($limitation, $parameters);
+        }
+
+        $localTemplate = null;
+        if (isset($parameters['template'])) {
+            $localTemplate = $parameters['template'];
+            unset($parameters['template']);
+        }
+
+        $template = $this->findTemplateWithBlock($blockName, $localTemplate);
+        if ($template === null) {
+            throw new MissingLimitationBlockException("Could not find block for {$limitation->getIdentifier()}: $blockName!");
+        }
+
+        return $template->renderBlock($blockName, $parameters);
+    }
+
+    public function setLimitationValueResources(array $limitationValueResources)
+    {
+        $this->limitationValueResources = $limitationValueResources;
+    }
+
+    /**
+     * Generates value block name based on Limitation.
+     *
+     * @param Limitation $limitation
+     * @return string
+     */
+    protected function getValueBlockName(Limitation $limitation)
+    {
+        return sprintf(self::LIMITATION_VALUE_BLOCK_NAME, strtolower($limitation->getIdentifier()));
+    }
+
+    /**
+     * Find the first template containing block definition $blockName.
+     *
+     * @param string $blockName
+     * @param string|Twig_Template $localTemplate
+     * @return null|\Twig_TemplateWrapper
+     */
+    protected function findTemplateWithBlock($blockName, $localTemplate = null)
+    {
+        if ($localTemplate !== null) {
+            if (is_string($localTemplate)) {
+                $localTemplate = $this->twig->load($localTemplate);
+            }
+
+            if ($localTemplate->hasBlock($blockName)) {
+                return $localTemplate;
+            }
+        }
+
+        foreach ($this->limitationValueResources as &$template) {
+            if (is_string($template)) {
+                // Load the template if it is necessary
+                $template = $this->twig->load($template);
+            }
+
+            if ($template->hasBlock($blockName)) {
+                return $template;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get parameters passed as context of value block render.
+     *
+     * @param Limitation $limitation
+     * @param array $parameters
+     * @return array
+     */
+    protected function getValueBlockParameters(Limitation $limitation, array $parameters)
+    {
+        $values = $this->valueMapperRegistry
+            ->getMapper($limitation->getIdentifier())
+            ->mapLimitationValue($limitation);
+
+        $parameters += [
+            'limitation' => $limitation,
+            'values' => $values,
+        ];
+
+        return $parameters;
+    }
+
+    /**
+     * Get parameters passed as context of value fallback block.
+     *
+     * @param Limitation $limitation
+     * @param array $parameters
+     * @return array
+     */
+    protected function getValueFallbackBlockParameters(Limitation $limitation, array $parameters)
+    {
+        $parameters += [
+            'limitation' => $limitation,
+            'values' => $limitation->limitationValues,
+        ];
+
+        return $parameters;
+    }
+}

--- a/lib/Limitation/Templating/LimitationBlockRendererInterface.php
+++ b/lib/Limitation/Templating/LimitationBlockRendererInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Limitation\Templating;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+interface LimitationBlockRendererInterface
+{
+    /**
+     * Returns limitation value in human readable format.
+     *
+     * @param Limitation $limitation
+     * @param array $parameters
+     * @return string
+     */
+    public function renderLimitationValue(Limitation $limitation, array $parameters = []);
+}

--- a/lib/Twig/LimitationValueRenderingExtension.php
+++ b/lib/Twig/LimitationValueRenderingExtension.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Twig;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\Templating\LimitationBlockRenderer;
+use EzSystems\RepositoryForms\Limitation\Templating\LimitationBlockRendererInterface;
+use Twig_Environment;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+class LimitationValueRenderingExtension extends Twig_Extension
+{
+    /** @var LimitationBlockRenderer */
+    private $limitationRenderer;
+
+    /**
+     * LimitationValueRenderingExtension constructor.
+     *
+     * @param LimitationBlockRendererInterface $limitationRenderer
+     */
+    public function __construct(LimitationBlockRendererInterface $limitationRenderer)
+    {
+        $this->limitationRenderer = $limitationRenderer;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new Twig_SimpleFunction(
+                'ez_render_limitation_value',
+                function (Twig_Environment $twig, Limitation $limitation, array $params = []) {
+                    return $this->limitationRenderer->renderLimitationValue($limitation, $params);
+                },
+                ['is_safe' => ['html'], 'needs_environment' => true]
+            ),
+        ];
+    }
+
+    public function getName()
+    {
+        return 'ezrepoforms.limitation_value_rendering';
+    }
+}

--- a/tests/RepositoryForms/Limitation/LimitationValueMapperRegistryTest.php
+++ b/tests/RepositoryForms/Limitation/LimitationValueMapperRegistryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation;
+
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperRegistry;
+use PHPUnit\Framework\TestCase;
+
+class LimitationValueMapperRegistryTest extends TestCase
+{
+    public function testGetMappers()
+    {
+        $foo = $this->createMock(LimitationValueMapperInterface::class);
+        $bar = $this->createMock(LimitationValueMapperInterface::class);
+
+        $registry = new LimitationValueMapperRegistry([
+            'foo' => $foo,
+            'bar' => $bar,
+        ]);
+
+        $result = $registry->getMappers();
+
+        $this->assertCount(2, $result);
+        $this->assertContains($foo, $result);
+        $this->assertContains($bar, $result);
+    }
+
+    public function testGetMapper()
+    {
+        $foo = $this->createMock(LimitationValueMapperInterface::class);
+
+        $registry = new LimitationValueMapperRegistry([
+            'foo' => $foo,
+        ]);
+
+        $this->assertEquals($foo, $registry->getMapper('foo'));
+    }
+
+    /**
+     * @expectedException \EzSystems\RepositoryForms\Limitation\Exception\ValueMapperNotFoundException
+     */
+    public function testGetNonExistingMapper()
+    {
+        $registry = new LimitationValueMapperRegistry([
+            'foo' => $this->createMock(LimitationValueMapperInterface::class),
+        ]);
+
+        $registry->getMapper('bar');
+    }
+
+    public function testAddMapper()
+    {
+        $foo = $this->createMock(LimitationValueMapperInterface::class);
+
+        $registry = new LimitationValueMapperRegistry();
+        $registry->addMapper($foo, 'foo');
+
+        $this->assertTrue($registry->hasMapper('foo'));
+    }
+
+    public function testHasMapper()
+    {
+        $registry = new LimitationValueMapperRegistry([
+            'foo' => $this->createMock(LimitationValueMapperInterface::class),
+        ]);
+
+        $this->assertTrue($registry->hasMapper('foo'));
+        $this->assertFalse($registry->hasMapper('bar'));
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/ContentTypeLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/ContentTypeLimitationMapperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\ContentTypeLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class ContentTypeLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['foo', 'bar', 'baz'];
+
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
+        foreach ($values as $i => $value) {
+            $contentTypeServiceMock
+                ->expects($this->at($i))
+                ->method('loadContentType')
+                ->with($value)
+                ->willReturn($value);
+        }
+
+        $mapper = new ContentTypeLimitationMapper($contentTypeServiceMock);
+        $result = $mapper->mapLimitationValue(new ContentTypeLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals($values, $result);
+        $this->assertCount(3, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/GroupLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/GroupLimitationMapperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\UserGroupLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\GroupLimitationMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class GroupLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $expected = ['policy.limitation.group.self'];
+
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->willReturnArgument(0);
+
+        $mapper = new GroupLimitationMapper($translatorMock);
+        $result = $mapper->mapLimitationValue(new UserGroupLimitation([
+            'limitationValues' => [1],
+        ]));
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/LanguageTypeLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/LanguageTypeLimitationMapperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\LanguageLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class LanguageTypeLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['en_GB', 'en_US', 'pl_PL'];
+
+        $languageServiceMock = $this->createMock(LanguageService::class);
+        foreach ($values as $i => $value) {
+            $languageServiceMock
+                ->expects($this->at($i))
+                ->method('loadLanguage')
+                ->with($value)
+                ->willReturnArgument(0);
+        }
+
+        $mapper = new LanguageLimitationMapper($languageServiceMock);
+        $result = $mapper->mapLimitationValue(new LanguageLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals($values, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/NullLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/NullLimitationMapperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\NullLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class NullLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['foo', 'bar', 'baz'];
+
+        // NullLimitationMapper accepts all types of limitations
+        $limitation = new ContentTypeLimitation([
+            'limitationValues' => $values,
+        ]);
+
+        $mapper = new NullLimitationMapper(null);
+        $result = $mapper->mapLimitationValue($limitation);
+
+        $this->assertEquals($values, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/ObjectStateLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/ObjectStateLimitationMapperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
+use EzSystems\RepositoryForms\Limitation\Mapper\ObjectStateLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class ObjectStateLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['foo', 'bar', 'baz'];
+
+        $objectStateServiceMock = $this->createMock(ObjectStateService::class);
+        foreach ($values as $i => $value) {
+            $stateMock = $this->createStateMock($value);
+
+            $objectStateServiceMock
+                ->expects($this->at($i))
+                ->method('loadObjectState')
+                ->with($value)
+                ->willReturn($stateMock);
+        }
+
+        $mapper = new ObjectStateLimitationMapper($objectStateServiceMock);
+        $result = $mapper->mapLimitationValue(new ObjectStateLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals([
+            'foo:foo', 'bar:bar', 'baz:baz',
+        ], $result);
+    }
+
+    private function createStateMock($value)
+    {
+        $stateGroupMock = $this->createMock(ObjectStateGroup::class);
+        $stateGroupMock
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn($value);
+
+        $stateMock = $this->createMock(ObjectState::class);
+        $stateMock
+            ->expects($this->any())
+            ->method('getObjectStateGroup')
+            ->willReturn($stateGroupMock);
+
+        $stateMock
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn($value);
+
+        return $stateMock;
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/OwnerLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/OwnerLimitationMapperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\OwnerLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\OwnerLimitationMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class OwnerLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $expected = ['policy.limitation.owner.self'];
+
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->willReturnArgument(0);
+
+        $mapper = new OwnerLimitationMapper($translatorMock);
+        $result = $mapper->mapLimitationValue(new OwnerLimitation([
+            'limitationValues' => [1],
+        ]));
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/ParentDepthLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/ParentDepthLimitationMapperTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\ParentDepthLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class ParentDepthLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $mapper = new ParentDepthLimitationMapper(1024);
+        $result = $mapper->mapLimitationValue(new ParentDepthLimitation([
+            'limitationValues' => [256],
+        ]));
+
+        $this->assertEquals([256], $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/SectionLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/SectionLimitationMapperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\Content\Section;
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\SectionLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class SectionLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['3', '5', '7'];
+
+        $sectionServiceMock = $this->createMock(SectionService::class);
+
+        $expected = [];
+        foreach ($values as $i => $value) {
+            $expected[$i] = new Section([
+                'id' => $value,
+            ]);
+
+            $sectionServiceMock
+                ->expects($this->at($i))
+                ->method('loadSection')
+                ->with($value)
+                ->willReturn($expected[$i]);
+        }
+
+        $mapper = new SectionLimitationMapper($sectionServiceMock);
+        $result = $mapper->mapLimitationValue(new SectionLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\SiteAccessLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class SiteAccessLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $siteAccessList = [
+            '2356372769' => 'foo',
+            '1996459178' => 'bar',
+            '2015626392' => 'baz',
+        ];
+
+        $limitation = new SiteAccessLimitation([
+            'limitationValues' => array_keys($siteAccessList),
+        ]);
+
+        $mapper = new SiteAccessLimitationMapper($siteAccessList);
+        $result = $mapper->mapLimitationValue($limitation);
+
+        $this->assertEquals(array_values($siteAccessList), $result);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/SubtreeLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/SubtreeLimitationMapperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use EzSystems\RepositoryForms\Limitation\Mapper\SubtreeLimitationMapper;
+use PHPUnit\Framework\TestCase;
+
+class SubtreeLimitationMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = ['/1/2/5/', '/1/2/7/', '/1/2/11/'];
+        $expected = [
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 5]),
+            ],
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 7]),
+            ],
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 11]),
+            ],
+        ];
+
+        $locationServiceMock = $this->createMock(LocationService::class);
+        $searchServiceMock = $this->createMock(SearchService::class);
+
+        foreach ($values as $i => $pathString) {
+            $query = new LocationQuery([
+                'filter' => new Ancestor($pathString),
+            ]);
+
+            $searchServiceMock
+                ->expects($this->at($i))
+                ->method('findLocations')
+                ->with($query)
+                ->willReturn($this->createSearchResultsMock($expected[$i]));
+        }
+
+        $mapper = new SubtreeLimitationMapper($locationServiceMock, $searchServiceMock);
+        $result = $mapper->mapLimitationValue(new SubtreeLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals($expected, $result);
+    }
+
+    private function createSearchResultsMock($expected)
+    {
+        $hits = [];
+        foreach ($expected as $contentInfo) {
+            $locationMock = $this->createMock(Location::class);
+            $locationMock
+                ->expects($this->atLeastOnce())
+                ->method('getContentInfo')
+                ->willReturn($contentInfo);
+
+            $hits[] = new SearchHit(['valueObject' => $locationMock]);
+        }
+
+        return new SearchResult(['searchHits' => $hits]);
+    }
+}

--- a/tests/RepositoryForms/Limitation/Mapper/UDWBasedMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/UDWBasedMapperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\RepositoryForms\Limitation\Mapper\UDWBasedMapper;
+use PHPUnit\Framework\TestCase;
+
+class UDWBasedMapperTest extends TestCase
+{
+    public function testMapLimitationValue()
+    {
+        $values = [5, 7, 11];
+        $expected = [
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 5]),
+            ],
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 7]),
+            ],
+            [
+                new ContentInfo(['id' => 1]),
+                new ContentInfo(['id' => 2]),
+                new ContentInfo(['id' => 11]),
+            ],
+        ];
+
+        $locationServiceMock = $this->createMock(LocationService::class);
+        $searchServiceMock = $this->createMock(SearchService::class);
+
+        foreach ($values as $i => $id) {
+            $location = new Location([
+                'pathString' => '/1/2/' . $id . '/',
+            ]);
+
+            $locationServiceMock
+                ->expects($this->at($i))
+                ->method('loadLocation')
+                ->with($id)
+                ->willReturn($location);
+
+            $query = new LocationQuery([
+                'filter' => new Ancestor($location->pathString),
+            ]);
+
+            $searchServiceMock
+                ->expects($this->at($i))
+                ->method('findLocations')
+                ->with($query)
+                ->willReturn($this->createSearchResultsMock($expected[$i]));
+        }
+
+        $mapper = new UDWBasedMapper($locationServiceMock, $searchServiceMock);
+        $result = $mapper->mapLimitationValue(new SubtreeLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEquals($expected, $result);
+    }
+
+    private function createSearchResultsMock($expected)
+    {
+        $hits = [];
+        foreach ($expected as $contentInfo) {
+            $locationMock = $this->createMock(Location::class);
+            $locationMock
+                ->expects($this->atLeastOnce())
+                ->method('getContentInfo')
+                ->willReturn($contentInfo);
+
+            $hits[] = new SearchHit(['valueObject' => $locationMock]);
+        }
+
+        return new SearchResult(['searchHits' => $hits]);
+    }
+}

--- a/tests/RepositoryForms/Twig/LimitationMock.php
+++ b/tests/RepositoryForms/Twig/LimitationMock.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Tests\Twig;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+class LimitationMock extends Limitation
+{
+    /** @var string */
+    private $identifier;
+
+    public function __construct($identifier, array $limitationValues)
+    {
+        parent::__construct([
+            'limitationValues' => $limitationValues,
+        ]);
+
+        $this->identifier = $identifier;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+}

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/ez_render_limitation_value.test
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/ez_render_limitation_value.test
@@ -1,0 +1,18 @@
+--TEST--
+"ez_render_limitation_value" function
+--TEMPLATE--
+{{ ez_render_limitation_value(foo) }}
+{{ ez_render_limitation_value(bar) }}
+{{ ez_render_limitation_value(foo, { 'template': 'templates/limitation_value_overriden.html.twig'}) }}
+{{ ez_render_limitation_value(custom_param, { 'param_a': 'A', 'param_b': 'B'}) }}
+--DATA--
+return [
+    'foo' => $this->getLimitation('foo', [1,2,3]),
+    'bar' => $this->getLimitation('bar', ['A','B','C']),
+    'custom_param' => $this->getLimitation('custom_param', ['A','B','C'])
+];
+--EXPECT--
+foo: 1,2,3
+bar: A,B,C
+FOO: 1|2|3
+custom_param: A,B,C PARAM A:A PARAM B:B

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_1.html.twig
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_1.html.twig
@@ -1,0 +1,5 @@
+{% block ez_limitation_foo_value %}foo: {{ values|join(',') }}{% endblock %}
+
+{% block ez_limitation_bar_value %}bar: {{ values|join(',') }}{% endblock %}
+
+{% block ez_limitation_custom_param_value %}custom_param: {{ values|join(',') }} PARAM A:{{ param_a }} PARAM B:{{ param_b }}{% endblock %}

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_2.html.twig
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_2.html.twig
@@ -1,0 +1,2 @@
+{% block ez_limitation_baz_value %}baz: {{ values|join(',') }}{% endblock %}
+

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_overriden.html.twig
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_overriden.html.twig
@@ -1,0 +1,2 @@
+{% block ez_limitation_foo_value %}FOO: {{ values|join('|') }}{% endblock %}
+

--- a/tests/RepositoryFormsBundle/DependencyInjection/Compiler/LimitationValueMapperPassTest.php
+++ b/tests/RepositoryFormsBundle/DependencyInjection/Compiler/LimitationValueMapperPassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\Tests\DependencyInjection\Compiler;
+
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationValueMapperPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class LimitationValueMapperPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setDefinition(LimitationValueMapperPass::LIMITATION_VALUE_MAPPER_REGISTRY, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new LimitationValueMapperPass());
+    }
+
+    public function testRegisterMappers()
+    {
+        $limitationValueMapperServiceId = 'limitationvalue_mapper';
+
+        $def = new Definition();
+        $def->addTag(LimitationValueMapperPass::LIMITATION_VALUE_MAPPER_TAG, [
+            'limitationType' => 'limitation',
+        ]);
+        $def->setClass(get_class($this->createMock(LimitationValueMapperInterface::class)));
+        $this->setDefinition($limitationValueMapperServiceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            LimitationValueMapperPass::LIMITATION_VALUE_MAPPER_REGISTRY,
+            'addMapper',
+            [new Reference($limitationValueMapperServiceId), 'limitation']
+        );
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-24699

## Description

_Disclaimer: There wasn't significant activity in original JIRA ticket since 2016, so I decided to create this  PR as my own open-source contribution_ :wink:

This PR contains implementation of mapping the policy limitation values to human readable versions. 

![zrzut ekranu z 2017-09-25 22-43-47](https://user-images.githubusercontent.com/211967/30830084-0adaea66-a243-11e7-8914-6fda9faa7c6c.png)

## Architecture

Limitation values are rendered via `ez_render_limitation_value` Twig function, which takes two arguments: 

1. `eZ\Publish\API\Repository\Values\User\Limitation` 
2. Optional hash of parameters

and delegates execution to `EzSystems\RepositoryForms\Templating\LimitationBlockRenderer`. 

Limitation values are mapped by services implementing the following interface: 

```php
/**
 * Interface for Limitation Value mappers.
 */
interface LimitationValueMapperInterface
{
    /**
     * Map the limitation values, in order to pass them as context of limitation value rendering.
     *
     * @param Limitation $limitation
     * @return mixed[]
     */
    public function mapLimitationValue(Limitation $limitation);
}
```
and registered in DIC with `ez.limitation.valueMapper` tag with `limitationType` attribute e.g.

```yml
ezrepoforms.limitation.form_mapper.newsection:
    parent: ezrepoforms.limitation.form_mapper.multiple_selection
    class: "%ezrepoforms.limitation.form_mapper.section.class%"
    arguments: ["@ezpublish.api.service.section"]
    tags:
        - { name: ez.limitation.formMapper, limitationType: NewSection }
        - { name: ez.limitation.valueMapper, limitationType: NewSection }
```

Responsibility of `EzSystems\RepositoryForms\Templating\LimitationRenderer` is similar to `\eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer`: render propery twig block and supply all required parameters: 

* limitation instance
* mapped values 
* parameters (second argument of `ez_render_limitation_value`) 

Block name is resolved as `ez_limitation_%LIMITATION_IDENTIFIER%_value`
, where `%LIMITATION_IDENTIFIER%` is identifier of limitation (converted to lower case characters). 

If the value mapper for limitation type is not provided, the "fallback block" is rendered (`ez_limitation_value_fallback`).

## TODO:

- [X] Implementation
- [x] Tests
- [ ] Documentation for `ez_render_limitation_value` and `eZ\Publish\API\Repository\Values\User\Limitation\LimitationValueMapperInterface` 