### PR TITLE
[CS] Aligned php-cs-fixer config with changes introduced by v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
This PR updates php-cs-fixer config to align with changes introduced by `v2.7.1`.

**Backporting this** to `1.5` as this is the oldest branch supported by `1.7 LTS`.

**TODO**:
- [x] Add `'yoda_style' => false` setting
- [x] Add `'no_break_comment' => false` setting