### PR TITLE
EZP-28077: As a bundle developer, I want to easily provide template for custom limitation value

### DIFF
--- a/bundle/DependencyInjection/Configuration/Parser/LimitationValueTemplates.php
+++ b/bundle/DependencyInjection/Configuration/Parser/LimitationValueTemplates.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Templates;
+
+class LimitationValueTemplates extends Templates
+{
+    const NODE_KEY = 'limitation_value_templates';
+    const INFO = 'Settings for limitation value templates';
+    const INFO_TEMPLATE_KEY = 'Template file where to find block definition to display limitation values';
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -15,6 +15,7 @@ use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMa
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationValueMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\LimitationValueTemplates;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -32,6 +33,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
         $eZExtension->addConfigParser(new UserRegistration());
+        $eZExtension->addConfigParser(new LimitationValueTemplates());
         $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -3,3 +3,5 @@ parameters:
     ezsettings.default.user_registration.templates.form: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.user_registration.templates.confirmation: "EzSystemsRepositoryFormsBundle:User:register_confirmation.html.twig"
 
+    ezsettings.default.limitation_value_templates:
+        - { template: 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig', priority: 0 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -46,8 +46,6 @@ parameters:
     ezrepoforms.validator.field_value.class: EzSystems\RepositoryForms\Validator\Constraints\FieldValueValidator
 
     ezrepoforms.templating.limitation_block_renderer.class: EzSystems\RepositoryForms\Limitation\Templating\LimitationBlockRenderer
-    ezrepoforms.templating.limitation_block_renderer.value_resources:
-        - 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig'
 
     ezrepoforms.twig.field_edit_rendering_extension.class: EzSystems\RepositoryForms\Twig\FieldEditRenderingExtension
     ezrepoforms.twig.limitation_rendering_extension.class: EzSystems\RepositoryForms\Twig\LimitationValueRenderingExtension
@@ -325,7 +323,7 @@ services:
             - '@ezrepoforms.limitation_value_mapper.registry'
             - '@twig'
         calls:
-            - ['setLimitationValueResources', [ '%ezrepoforms.templating.limitation_block_renderer.value_resources%' ]]
+            - ['setLimitationValueResources', [ '$limitation_value_templates$' ]]
 
     ezrepoforms.twig.limitation_rendering_extension:
         class: '%ezrepoforms.twig.limitation_rendering_extension.class%'

--- a/lib/Limitation/Templating/LimitationBlockRenderer.php
+++ b/lib/Limitation/Templating/LimitationBlockRenderer.php
@@ -70,9 +70,13 @@ class LimitationBlockRenderer implements LimitationBlockRendererInterface
         return $template->renderBlock($blockName, $parameters);
     }
 
-    public function setLimitationValueResources(array $limitationValueResources)
+    public function setLimitationValueResources(array $resources)
     {
-        $this->limitationValueResources = $limitationValueResources;
+        usort($resources, function ($a, $b) {
+            return $b['priority'] - $a['priority'];
+        });
+
+        $this->limitationValueResources = array_column($resources, 'template');
     }
 
     /**

--- a/tests/RepositoryForms/Twig/LimitationValueRenderingExtensionTest.php
+++ b/tests/RepositoryForms/Twig/LimitationValueRenderingExtensionTest.php
@@ -32,8 +32,18 @@ class LimitationValueRenderingExtensionTest extends FileSystemTwigIntegrationTes
         );
 
         $limitationBlockRenderer->setLimitationValueResources([
-            'templates/limitation_value_1.html.twig',
-            'templates/limitation_value_2.html.twig',
+            [
+                'template' => 'templates/limitation_value_1.html.twig',
+                'priority' => 10,
+            ],
+            [
+                'template' => 'templates/limitation_value_2.html.twig',
+                'priority' => 0,
+            ],
+            [
+                'template' => 'templates/limitation_value_3.html.twig',
+                'priority' => 20,
+            ],
         ]);
 
         return [

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/ez_render_limitation_value.test
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/ez_render_limitation_value.test
@@ -13,6 +13,6 @@ return [
 ];
 --EXPECT--
 foo: 1,2,3
-bar: A,B,C
+bar: A|B|C
 FOO: 1|2|3
 custom_param: A,B,C PARAM A:A PARAM B:B

--- a/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_3.html.twig
+++ b/tests/RepositoryForms/Twig/_fixtures/ez_render_limitation_value/templates/limitation_value_3.html.twig
@@ -1,0 +1,1 @@
+{% block ez_limitation_bar_value %}bar: {{ values|join('|') }}{% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28077

# Description

Improvement for https://github.com/ezsystems/repository-forms/pull/159: Overriding parameters defined by 3rd party bundle is not easy for bundle developer. This PR adds an ability to configure the list of resources containing definitions of limitation value blocks, in similar to fields view/edit/definition view/definition edit blocks. Configuration example: 

```yaml
system:
    default:
        limitation_value_templates:
            - { template: 'AppBundle:Limitation:custom_limitation_value.html.twig', priority: 0 }
```


