### PR TITLE
EZP-28072: Translate limitation identifiers

### DIFF
--- a/bin/extract-translations.sh
+++ b/bin/extract-translations.sh
@@ -9,6 +9,7 @@ echo '# Extract RepositoryForms';
   --exclude-dir=vendor \
   --output-dir=./vendor/ezsystems/repository-forms/bundle/Resources/translations \
   --enable-extractor=ez_location_sorting \
+  --enable-extractor=ez_policy_limitation \
   --keep
   "$@"
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -446,3 +446,10 @@ services:
         class: EzSystems\RepositoryForms\Translation\SortingTranslationExtractor
         tags:
             - { name: jms_translation.extractor, alias: ez_location_sorting }
+
+    ezrepoforms.translation.extractor.limitation:
+        class: EzSystems\RepositoryForms\Translation\LimitationTranslationExtractor
+        arguments:
+            - '%ezpublish.api.role.policy_map%'
+        tags:
+            - { name: jms_translation.extractor, alias: ez_policy_limitation }

--- a/bundle/Resources/translations/ezrepoforms_policies.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_policies.en.xlf
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file date="2017-10-16T18:26:20Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="3742f2cc514848bd4a5eb03430e412d44f5d9ec2" resname="policy.limitation.identifier.class">
+        <source>Content Type</source>
+        <target>Content Type</target>
+        <note>key: policy.limitation.identifier.class</note>
+      </trans-unit>
+      <trans-unit id="76adf2a27f1ae0ab14b623729cd3f281a6e2c285" resname="policy.limitation.identifier.group">
+        <source>Content Type Group</source>
+        <target>Content Type Group</target>
+        <note>key: policy.limitation.identifier.group</note>
+      </trans-unit>
+      <trans-unit id="cee78b25ec2de77cf09109e6a2ac175a515a8350" resname="policy.limitation.identifier.language">
+        <source>Language</source>
+        <target>Language</target>
+        <note>key: policy.limitation.identifier.language</note>
+      </trans-unit>
+      <trans-unit id="ab9163a435d32610a7a1af8df07ab38eebc4c7c6" resname="policy.limitation.identifier.newsection">
+        <source>New Section</source>
+        <target>New Section</target>
+        <note>key: policy.limitation.identifier.newsection</note>
+      </trans-unit>
+      <trans-unit id="a9958f1d76f4685bf5fc32eee7514046db942160" resname="policy.limitation.identifier.newstate">
+        <source>New State</source>
+        <target>New State</target>
+        <note>key: policy.limitation.identifier.newstate</note>
+      </trans-unit>
+      <trans-unit id="be2b0449251f53db814dc4fbbb27e534419add2b" resname="policy.limitation.identifier.node">
+        <source>Location</source>
+        <target>Location</target>
+        <note>key: policy.limitation.identifier.node</note>
+      </trans-unit>
+      <trans-unit id="9daf8e1a94a6409f9b9b102e042c2858e4307ea8" resname="policy.limitation.identifier.owner">
+        <source>Owner</source>
+        <target>Owner</target>
+        <note>key: policy.limitation.identifier.owner</note>
+      </trans-unit>
+      <trans-unit id="e3773b71c8e7fda97f221ab25a6c25164d179d84" resname="policy.limitation.identifier.parentclass">
+        <source>Content Type of Parent</source>
+        <target>Content Type of Parent</target>
+        <note>key: policy.limitation.identifier.parentclass</note>
+      </trans-unit>
+      <trans-unit id="39bf0d9c1e0e8b64193bf09d83fbd89c2dac3421" resname="policy.limitation.identifier.parentdepth">
+        <source>Parent Depth</source>
+        <target>Parent Depth</target>
+        <note>key: policy.limitation.identifier.parentdepth</note>
+      </trans-unit>
+      <trans-unit id="cb52ff8582459d1bc981e9f98cf1c79876f83a1e" resname="policy.limitation.identifier.parentgroup">
+        <source>Content Type Group of Parent</source>
+        <target>Content Type Group of Parent</target>
+        <note>key: policy.limitation.identifier.parentgroup</note>
+      </trans-unit>
+      <trans-unit id="6208b97847450b255559e4a56c51ff06b76a08dd" resname="policy.limitation.identifier.parentowner">
+        <source>Owner of Parent</source>
+        <target>Owner of Parent</target>
+        <note>key: policy.limitation.identifier.parentowner</note>
+      </trans-unit>
+      <trans-unit id="bb77b27363dad566197a200290f0f0b18baa4705" resname="policy.limitation.identifier.section">
+        <source>Section</source>
+        <target>Section</target>
+        <note>key: policy.limitation.identifier.section</note>
+      </trans-unit>
+      <trans-unit id="548bc922c693c8259cbfd3354451a3035e2fa6f6" resname="policy.limitation.identifier.siteaccess">
+        <source>SiteAccess</source>
+        <target>SiteAccess</target>
+        <note>key: policy.limitation.identifier.siteaccess</note>
+      </trans-unit>
+      <trans-unit id="30cc18895dfb23b14d3f9b8249e90baf678c8180" resname="policy.limitation.identifier.state">
+        <source>State</source>
+        <target>State</target>
+        <note>key: policy.limitation.identifier.state</note>
+      </trans-unit>
+      <trans-unit id="2291e238752ad3c4d20ef08253f5d5736f6382d2" resname="policy.limitation.identifier.subtree">
+        <source>Subtree of Location</source>
+        <target>Subtree of Location</target>
+        <note>key: policy.limitation.identifier.subtree</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/lib/Translation/LimitationTranslationExtractor.php
+++ b/lib/Translation/LimitationTranslationExtractor.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Translation;
+
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\ExtractorInterface;
+
+/**
+ * Generates translation strings for limitation types.
+ */
+class LimitationTranslationExtractor implements ExtractorInterface
+{
+    const MESSAGE_DOMAIN = 'ezrepoforms_policies';
+    const MESSAGE_ID_PREFIX = 'policy.limitation.identifier.';
+
+    /**
+     * @var array
+     */
+    private $policyMap;
+
+    /**
+     * LimitationTranslationExtractor constructor.
+     *
+     * @param array $policyMap
+     */
+    public function __construct(array $policyMap)
+    {
+        $this->policyMap = $policyMap;
+    }
+
+    public function extract()
+    {
+        $catalogue = new MessageCatalogue();
+
+        foreach ($this->getLimitationTypes() as $limitationType) {
+            $id = self::MESSAGE_ID_PREFIX . strtolower($limitationType);
+
+            $message = new Message\XliffMessage($id, self::MESSAGE_DOMAIN);
+            $message->setNew(false);
+            $message->setMeaning($limitationType);
+            $message->setDesc($limitationType);
+            $message->setLocaleString($limitationType);
+            $message->addNote('key: ' . $id);
+
+            $catalogue->add($message);
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * Returns all known limitation types.
+     *
+     * @return array
+     */
+    private function getLimitationTypes()
+    {
+        $limitationTypes = [];
+        foreach ($this->policyMap as $module) {
+            foreach ($module as $policy) {
+                foreach (array_keys($policy) as $limitationType) {
+                    if (!in_array($limitationType, $limitationTypes)) {
+                        $limitationTypes[] = $limitationType;
+                    }
+                }
+            }
+        }
+
+        return $limitationTypes;
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28072

# Description 

This PR adds translations for limitation identifiers which are same for 1.X and 2.X versions of the administration panel.  

As has been noted by @Nattfarinn on Slack, we can't use dynamic translation keys, because JMS Translation Bundle can't extract them. This PR omits this limitation by providing custom `\JMS\TranslationBundle\Translation\ExtractorInterface` impl. for limitation identifiers. 

Translated limitation identifiers are display on view is that same way as currently: 
```twig
{{ ('policy.limitation.identifier.' ~ (limitation.identifier | lower)) | trans({}, 'ezrepoforms_policies') }}:
```
To display translated identifier of custom limitation provided in 3rd party bundle, as Developer you need create `/Resources/translations/repoforms_policies.en.xlf` file containing translation unit which id follows this convention.  

It requires related PR in https://github.com/ezsystems/PlatformUIBundle and https://github.com/ezsystems/ezplatform-admin-ui.