### PR TITLE
Added `friendsofphp/php-cs-fixer` requirement to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             "dev-master": "1.5.x-dev"
         }
     },
+    "scripts": {
+        "fix": "@php bin/php-cs-fixer fix"
+    },
     "config": {
         "bin-dir": "bin"
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "~1.0",
-        "behat/behat": "^3.0"
+        "behat/behat": "^3.0",
+        "friendsofphp/php-cs-fixer": "^2.7"
     },
     "conflict": {
         "symfony/symfony": "2.7.11"


### PR DESCRIPTION
# Description
#161 introduced minimal requirement on `php-cs-fixer` 2.7 but it wasn't specified in the `composer.json`. To keep things clear I added this so that developers can fix their code using bundled (`bin/php-cs-fixer`) fixer.