### PR TITLE
Update Travis config for 1.10 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 branches:
   only:
     - master
-    - "1.9"
+    - "1.10"
     - "/^feature-/"
 
 before_install:


### PR DESCRIPTION
I've noticed that Travis does not list 1.10 as active branch:
https://travis-ci.org/ezsystems/repository-forms/branches
and I think it should (and unless I'm wrong this should help?).

I've used GitHub online editor - please let me know if I should create a JIRA ticket (and have a properly named branch), I'll adjust.