### PR TITLE
EZP-28265: Expose ContentCreateView to allow setting different theme for content creation

### DIFF
--- a/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
@@ -30,6 +30,9 @@ class ContentEdit extends AbstractParser
                             ->scalarNode('edit')
                                 ->info('Template to use for content edit form rendering.')
                             ->end()
+                            ->scalarNode('create')
+                                ->info('Template to use for content create form rendering.')
+                            ->end()
                             ->scalarNode('create_draft')
                                 ->info('Template to use for content draft creation rendering.')
                             ->end()
@@ -52,6 +55,14 @@ class ContentEdit extends AbstractParser
                 'content_edit.templates.edit',
                 $currentScope,
                 $settings['templates']['edit']
+            );
+        }
+
+        if (!empty($settings['templates']['create'])) {
+            $contextualizer->setContextualParameter(
+                'content_edit.templates.create',
+                $currentScope,
+                $settings['templates']['create']
             );
         }
 

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -3,6 +3,7 @@ parameters:
     ezsettings.default.user_registration.templates.form: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.user_registration.templates.confirmation: "EzSystemsRepositoryFormsBundle:User:register_confirmation.html.twig"
     ezsettings.default.content_edit.templates.edit: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
+    ezsettings.default.content_edit.templates.create: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.content_edit.templates.create_draft: "EzSystemsRepositoryFormsBundle:Content:content_create_draft.html.twig"
     ezsettings.default.limitation_value_templates:
         - { template: 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig', priority: 0 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -265,6 +265,7 @@ services:
             - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterFormView', "$user_registration.templates.form$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\UserRegister\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentEditView', "$content_edit.templates.edit$"]]
+            - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateView', "$content_edit.templates.create$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateDraftView', "$content_edit.templates.create_draft$"]]
             - [setPagelayout, ["$pagelayout$"]]
 

--- a/lib/Content/View/ContentCreateView.php
+++ b/lib/Content/View/ContentCreateView.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryForms\Content\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+
+class ContentCreateView extends BaseView
+{
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28265

# Description:
This PR brings:
* content create now returns `ContentCreateView` instead of `ContentEditView` which helps theming it separately from content draft edit action
* new configuration key `content_edit.templates.create` to assign template