### PR TITLE
EZP-28267: Add Save and Cancel buttons to content create page

### DIFF
--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -82,7 +82,10 @@ class ContentEditController extends Controller
             'mainLanguageCode' => $language,
             'parentLocation' => $this->locationService->newLocationCreateStruct($parentLocationId),
         ]);
-        $form = $this->createForm(ContentEditType::class, $data, ['languageCode' => $language]);
+        $form = $this->createForm(ContentEditType::class, $data, [
+            'languageCode' => $language,
+            'drafts_enabled' => true,
+        ]);
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/lib/Form/Processor/ContentFormProcessor.php
+++ b/lib/Form/Processor/ContentFormProcessor.php
@@ -43,7 +43,7 @@ class ContentFormProcessor implements EventSubscriberInterface
     {
         return [
             RepositoryFormEvents::CONTENT_PUBLISH => ['processPublish', 10],
-            RepositoryFormEvents::CONTENT_CANCEL => ['processRemoveDraft', 10],
+            RepositoryFormEvents::CONTENT_CANCEL => ['processCancel', 10],
             RepositoryFormEvents::CONTENT_SAVE_DRAFT => ['processSaveDraft', 10],
             RepositoryFormEvents::CONTENT_CREATE_DRAFT => ['processCreateDraft', 10],
         ];
@@ -85,13 +85,18 @@ class ContentFormProcessor implements EventSubscriberInterface
         $event->setResponse(new RedirectResponse($redirectUrl));
     }
 
-    public function processRemoveDraft(FormActionEvent $event)
+    public function processCancel(FormActionEvent $event)
     {
         /** @var \EzSystems\RepositoryForms\Data\Content\ContentCreateData|\EzSystems\RepositoryForms\Data\Content\ContentUpdateData $data */
         $data = $event->getData();
-        $form = $event->getForm();
 
         if ($data->isNew()) {
+            $response = new RedirectResponse($this->router->generate(
+                '_ezpublishLocation',
+                ['locationId' => $data->getLocationStructs()[0]->parentLocationId]
+            ));
+            $event->setResponse($response);
+
             return;
         }
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28267

# Description
This PR adds save draft and cancel buttons to content create forms as well as changes behavior of cancel button for content create (it just redirects to parent location).