### PR TITLE
EZP-28287: Inconsistent eztime value across timezones

### DIFF
--- a/lib/FieldType/DataTransformer/TimeValueTransformer.php
+++ b/lib/FieldType/DataTransformer/TimeValueTransformer.php
@@ -60,6 +60,6 @@ class TimeValueTransformer implements DataTransformerInterface
             );
         }
 
-        return Value::fromTimestamp($value);
+        return new Value($value);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28287

# Description
This PR fixes data transformation for `eztime` fieldtype. Previously it was using timestamps which wasn't really working - set time should be timezone independent. Right now value represents seconds which follow business logic behind `eztime`. 