### PR TITLE
EZP-28299: Fixes default settings value initialization for binary based fieldtypes

### DIFF
--- a/lib/FieldType/DataTransformer/AbstractBinaryBaseTransformer.php
+++ b/lib/FieldType/DataTransformer/AbstractBinaryBaseTransformer.php
@@ -39,16 +39,10 @@ abstract class AbstractBinaryBaseTransformer
     }
 
     /**
-     * @param Value $value
-     *
      * @return array|null
      */
-    public function getTransformedValue($value)
+    public function getDefaultProperties()
     {
-        if ($this->fieldType->isEmptyValue($value)) {
-            return null;
-        }
-
         return [
             'file' => null,
             'remove' => false,
@@ -67,6 +61,7 @@ abstract class AbstractBinaryBaseTransformer
         if (!is_array($value)) {
             throw new TransformationFailedException(sprintf('Expected a array got %s', gettype($value)));
         }
+
         if ($value['remove']) {
             return $this->fieldType->getEmptyValue();
         }

--- a/lib/FieldType/DataTransformer/BinaryFileValueTransformer.php
+++ b/lib/FieldType/DataTransformer/BinaryFileValueTransformer.php
@@ -24,15 +24,14 @@ class BinaryFileValueTransformer extends AbstractBinaryBaseTransformer implement
      */
     public function transform($value)
     {
-        $transformedValue = $this->getTransformedValue($value);
-
-        if (null === $transformedValue) {
-            return null;
+        if (null === $value) {
+            $value = $this->fieldType->getEmptyValue();
         }
 
-        return array_merge($transformedValue, [
-            'downloadCount' => $value->downloadCount,
-        ]);
+        return array_merge(
+            $this->getDefaultProperties(),
+            ['downloadCount' => $value->downloadCount]
+        );
     }
 
     /**

--- a/lib/FieldType/DataTransformer/ImageValueTransformer.php
+++ b/lib/FieldType/DataTransformer/ImageValueTransformer.php
@@ -24,15 +24,14 @@ class ImageValueTransformer extends AbstractBinaryBaseTransformer implements Dat
      */
     public function transform($value)
     {
-        $transformedValue = $this->getTransformedValue($value);
-
-        if (null === $transformedValue) {
-            return null;
+        if (null === $value) {
+            $value = $this->fieldType->getEmptyValue();
         }
 
-        return array_merge($transformedValue, [
-            'alternativeText' => $value->alternativeText,
-        ]);
+        return array_merge(
+            $this->getDefaultProperties(),
+            ['alternativeText' => $value->alternativeText]
+        );
     }
 
     /**

--- a/lib/FieldType/DataTransformer/MediaValueTransformer.php
+++ b/lib/FieldType/DataTransformer/MediaValueTransformer.php
@@ -24,19 +24,20 @@ class MediaValueTransformer extends AbstractBinaryBaseTransformer implements Dat
      */
     public function transform($value)
     {
-        $transformedValue = $this->getTransformedValue($value);
-
-        if (null === $transformedValue) {
-            return null;
+        if (null === $value) {
+            $value = $this->fieldType->getEmptyValue();
         }
 
-        return array_merge($transformedValue, [
-            'hasController' => $value->hasController,
-            'loop' => $value->loop,
-            'autoplay' => $value->autoplay,
-            'width' => $value->width,
-            'height' => $value->height,
-        ]);
+        return array_merge(
+            $this->getDefaultProperties(),
+            [
+                'hasController' => $value->hasController,
+                'loop' => $value->loop,
+                'autoplay' => $value->autoplay,
+                'width' => $value->width,
+                'height' => $value->height,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28299

# Description
This PR fixes the problem with empty settings like width and height (in case of `ezmedia` field type). Type expects an integer for those thus it was causing an error. Data Transformers are now using default values from an empty field value.
