### PR TITLE
EZP-28315: Cannot delete draft in case of nonpublished content

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -193,8 +193,11 @@ services:
             - { name: kernel.event_subscriber }
 
     ezrepoforms.form_processor.content:
-        class: "%ezrepoforms.form_processor.content.class%"
-        arguments: ["@ezpublish.api.service.content", "@router"]
+        class: '%ezrepoforms.form_processor.content.class%'
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.location'
+            - '@router'
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28315
> Requires: https://github.com/ezsystems/ezpublish-kernel/pull/2163

# Description
This PR fixes the problem of deleting a draft when there is only one version in edited content. Kernel doesn't allow to remove version if that's the only one in the content. In order to fix that it's required to detect single version content and remove content completely instead. The fix relies on kernel improvement: https://github.com/ezsystems/ezpublish-kernel/pull/2163

**TODO**:
- [x] Wait for ezpublish-kernel/#2163 getting merged/rebased into `7.0`