### PR TITLE
EZP-28342: Invalid input type for latitude and logitude in MapLocation fieldtype

### DIFF
--- a/bundle/Resources/translations/ezrepoforms_fieldtype.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_fieldtype.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-16T11:30:14Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,49 +10,56 @@
         <source>File</source>
         <target>File</target>
         <note>key: content.field_type.binary_base.file</note>
-        <jms:reference-file line="33">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/BinaryBaseFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1bd4c3b865897e29623c2b4d3a42d4fc1df85c9f" resname="content.field_type.binary_base.remove">
         <source>Remove</source>
         <target>Remove</target>
         <note>key: content.field_type.binary_base.remove</note>
-        <jms:reference-file line="26">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/BinaryBaseFieldType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="79843ce578133501bb420c52cd410a113dcfaefb" resname="content.field_type.ezgmaplocation.address">
+        <source>Address</source>
+        <target>Address</target>
+        <note>key: content.field_type.ezgmaplocation.address</note>
+      </trans-unit>
+      <trans-unit id="2fcb1cae76dae0c5ddda6446822bf2d656e84601" resname="content.field_type.ezgmaplocation.latitude">
+        <source>Latitude</source>
+        <target>Latitude</target>
+        <note>key: content.field_type.ezgmaplocation.latitude</note>
+      </trans-unit>
+      <trans-unit id="f598e2bedb749c004e232b9c3f0cffbc08f9c491" resname="content.field_type.ezgmaplocation.longitude">
+        <source>Longitude</source>
+        <target>Longitude</target>
+        <note>key: content.field_type.ezgmaplocation.longitude</note>
       </trans-unit>
       <trans-unit id="aa904d94a0f6df2084d669e82dac178189509aab" resname="content.field_type.ezimage.alternative_text">
         <source>Alternative text</source>
-        <target state="new">Alternative text</target>
+        <target>Alternative text</target>
         <note>key: content.field_type.ezimage.alternative_text</note>
-        <jms:reference-file line="40">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/ImageFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7162d22b1be8aaa634e57fa94cc2664026be4390" resname="content.field_type.ezmedia.autoplay">
         <source>Auto play</source>
-        <target state="new">Auto play</target>
+        <target>Auto play</target>
         <note>key: content.field_type.ezmedia.autoplay</note>
-        <jms:reference-file line="48">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/MediaFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0176a5e197c6c207e09affb1a027db2ab48a506" resname="content.field_type.ezmedia.display_controls">
         <source>Display controls</source>
-        <target state="new">Display controls</target>
+        <target>Display controls</target>
         <note>key: content.field_type.ezmedia.display_controls</note>
-        <jms:reference-file line="41">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/MediaFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb3b924b6a2d94344ea5e1e51636ef5b92a7a57a" resname="content.field_type.ezmedia.height">
         <source>Height</source>
-        <target state="new">Height</target>
+        <target>Height</target>
         <note>key: content.field_type.ezmedia.height</note>
-        <jms:reference-file line="73">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/MediaFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="48e4eb02443e58b9ff501ca03bdc4008e842eba4" resname="content.field_type.ezmedia.loop">
         <source>Loop</source>
-        <target state="new">Loop</target>
+        <target>Loop</target>
         <note>key: content.field_type.ezmedia.loop</note>
-        <jms:reference-file line="55">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/MediaFieldType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e5940ee516f3edb1d09e7ac4eed4fe7a28d3cacd" resname="content.field_type.ezmedia.width">
         <source>Width</source>
-        <target state="new">Width</target>
+        <target>Width</target>
         <note>key: content.field_type.ezmedia.width</note>
-        <jms:reference-file line="62">/../../../../../.././vendor/ezsystems/repository-forms/lib/Form/Type/FieldType/MediaFieldType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/lib/Form/Type/FieldType/MapLocationFieldType.php
+++ b/lib/Form/Type/FieldType/MapLocationFieldType.php
@@ -11,6 +11,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Form Type representing ezgmaplocation field type.
@@ -42,12 +45,13 @@ class MapLocationFieldType extends AbstractType
                 'latitude',
                 NumberType::class,
                 [
-                    'label' => 'content.field_type.ezgmaplocation.latitude',
+                    'label' => /** @Desc("Latitude") */ 'content.field_type.ezgmaplocation.latitude',
                     'required' => $options['required'],
+                    'scale' => 6,
                     'attr' => [
                         'min' => -90,
                         'max' => 90,
-                        'step' => 'any',
+                        'step' => 0.000001,
                     ],
                 ]
             )
@@ -55,12 +59,13 @@ class MapLocationFieldType extends AbstractType
                 'longitude',
                 NumberType::class,
                 [
-                    'label' => 'content.field_type.ezgmaplocation.longitude',
+                    'label' => /** @Desc("Longitude") */ 'content.field_type.ezgmaplocation.longitude',
                     'required' => $options['required'],
+                    'scale' => 6,
                     'attr' => [
                         'min' => -90,
                         'max' => 90,
-                        'step' => 'any',
+                        'step' => 0.000001,
                     ],
                 ]
             )
@@ -68,10 +73,24 @@ class MapLocationFieldType extends AbstractType
                 'address',
                 TextType::class,
                 [
-                    'label' => 'content.field_type.ezgmaplocation.address',
+                    'label' => /* @Desc("Address") */ 'content.field_type.ezgmaplocation.address',
                     'required' => false,
+                    'empty_data' => '',
                 ]
             )
-            ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezgmaplocation')));
+            ->addModelTransformer(
+                new FieldValueTransformer($this->fieldTypeService->getFieldType('ezgmaplocation'))
+            );
+    }
+
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->children['latitude']->vars['type'] = 'number';
+        $view->children['longitude']->vars['type'] = 'number';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(['translation_domain' => 'ezrepoforms_fieldtype']);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28342

# Description
MapLocation's children types had invalid input type (text instead of number) which made validation fail and also it was incorrect from HTML5 standpoint as text input should not have `min` and `max` attributes. 