### PR TITLE
EZP-27539: Translation support in content edit

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -223,6 +223,7 @@ services:
             - "@ezpublish.api.service.content_type"
             - "@ezpublish.api.service.content"
             - "@ezpublish.api.service.location"
+            - "@ezpublish.api.service.language"
             - "@ezrepoforms.action_dispatcher.content"
         parent: ezpublish.controller.base
         calls:

--- a/lib/Data/Content/ContentUpdateData.php
+++ b/lib/Data/Content/ContentUpdateData.php
@@ -13,7 +13,7 @@ use EzSystems\RepositoryForms\Data\NewnessCheckable;
 
 /**
  * @property-read \EzSystems\RepositoryForms\Data\Content\FieldData[] $fieldsData
- * @property-read \eZ\Publish\API\Repository\Values\Content\Content[] $contentDraft
+ * @property-read \eZ\Publish\API\Repository\Values\Content\Content $contentDraft
  */
 class ContentUpdateData extends ContentUpdateStruct implements NewnessCheckable
 {

--- a/lib/FieldType/Mapper/AuthorFormMapper.php
+++ b/lib/FieldType/Mapper/AuthorFormMapper.php
@@ -33,7 +33,7 @@ class AuthorFormMapper implements FieldValueFormMapperInterface
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', AuthorFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/lib/FieldType/Mapper/BinaryFileFormMapper.php
@@ -52,7 +52,7 @@ class BinaryFileFormMapper implements FieldDefinitionFormMapperInterface, FieldV
                         BinaryFileFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->addModelTransformer(new BinaryFileValueTransformer($fieldType, $data->value, Value::class))

--- a/lib/FieldType/Mapper/CheckboxFormMapper.php
+++ b/lib/FieldType/Mapper/CheckboxFormMapper.php
@@ -50,7 +50,7 @@ class CheckboxFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                         CheckboxFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -60,7 +60,7 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface, FieldValu
                     ->create('value', CountryFieldType::class, [
                         'multiple' => $fieldSettings['isMultiple'],
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -57,7 +57,7 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         DateFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -67,7 +67,7 @@ class DateTimeFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                         [
                             'with_seconds' => $fieldSettings['useSeconds'],
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/FloatFormMapper.php
+++ b/lib/FieldType/Mapper/FloatFormMapper.php
@@ -67,7 +67,7 @@ class FloatFormMapper implements FieldDefinitionFormMapperInterface, FieldValueF
                         FloatFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                             'min' => $validatorConfiguration['FloatValueValidator']['minFloatValue'],
                             'max' => $validatorConfiguration['FloatValueValidator']['maxFloatValue'],
                         ]

--- a/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
+++ b/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
@@ -63,8 +63,6 @@ final class FormTypeBasedFieldValueFormMapper implements FieldValueFormMapperInt
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
@@ -72,7 +70,7 @@ final class FormTypeBasedFieldValueFormMapper implements FieldValueFormMapperInt
                     ->create(
                         'value',
                         $this->formType,
-                        ['required' => $fieldDefinition->isRequired, 'label' => $label]
+                        ['required' => $fieldDefinition->isRequired, 'label' => $fieldDefinition->getName()]
                     )
                     ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier)))
                     // Deactivate auto-initialize as we're not on the root form.

--- a/lib/FieldType/Mapper/ISBNFormMapper.php
+++ b/lib/FieldType/Mapper/ISBNFormMapper.php
@@ -56,7 +56,7 @@ class ISBNFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         ISBNFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/lib/FieldType/Mapper/ImageFormMapper.php
@@ -53,7 +53,7 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface, FieldValueF
                         ImageFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->addModelTransformer(new ImageValueTransformer($fieldType, $data->value, Value::class))

--- a/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -67,7 +67,7 @@ class IntegerFormMapper implements FieldDefinitionFormMapperInterface, FieldValu
                         IntegerFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                             'min' => $validatorConfiguration['IntegerValueValidator']['minIntegerValue'],
                             'max' => $validatorConfiguration['IntegerValueValidator']['maxIntegerValue'],
                         ]

--- a/lib/FieldType/Mapper/KeywordFormMapper.php
+++ b/lib/FieldType/Mapper/KeywordFormMapper.php
@@ -32,7 +32,7 @@ class KeywordFormMapper implements FieldValueFormMapperInterface
                         KeywordFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/MapLocationFormMapper.php
+++ b/lib/FieldType/Mapper/MapLocationFormMapper.php
@@ -32,7 +32,7 @@ class MapLocationFormMapper implements FieldValueFormMapperInterface
                         MapLocationFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -69,7 +69,7 @@ class MediaFormMapper implements FieldDefinitionFormMapperInterface, FieldValueF
                         MediaFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->addModelTransformer(new MediaValueTransformer($fieldType, $data->value, Value::class))

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -47,7 +47,7 @@ class RelationFormMapper extends AbstractRelationFormMapper
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', RelationFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -50,7 +50,7 @@ class RelationListFormMapper extends AbstractRelationFormMapper
                         RelationListFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/RichTextFormMapper.php
+++ b/lib/FieldType/Mapper/RichTextFormMapper.php
@@ -26,7 +26,7 @@ class RichTextFormMapper implements FieldValueFormMapperInterface
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', RichTextFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -56,8 +56,6 @@ class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
@@ -67,7 +65,7 @@ class SelectionFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
                         SelectionFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $label,
+                            'label' => $fieldDefinition->getName(),
                             'multiple' => $fieldDefinition->fieldSettings['isMultiple'],
                             'choices' => array_flip($fieldDefinition->fieldSettings['options']),
                         ]

--- a/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -47,7 +47,7 @@ class TextBlockFormMapper implements FieldDefinitionFormMapperInterface, FieldVa
                         TextBlockFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                             'rows' => $data->fieldDefinition->fieldSettings['textRows'],
                         ]
                     )

--- a/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -63,7 +63,7 @@ class TextLineFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                         TextLineFieldType::class,
                         [
                             'required' => $fieldDefinition->isRequired,
-                            'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                            'label' => $fieldDefinition->getName(),
                             'min' => $validatorConfiguration['StringLengthValidator']['minStringLength'],
                             'max' => $validatorConfiguration['StringLengthValidator']['maxStringLength'],
                         ]

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -65,7 +65,7 @@ class TimeFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                     ->create('value', TimeFieldType::class, [
                         'with_seconds' => $fieldSettings['useSeconds'],
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/UrlFormMapper.php
+++ b/lib/FieldType/Mapper/UrlFormMapper.php
@@ -32,7 +32,7 @@ class UrlFormMapper implements FieldValueFormMapperInterface
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', UrlFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $fieldDefinition->getName($formConfig->getOption('languageCode')),
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
+++ b/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
@@ -43,13 +43,11 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('languageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
                 $formConfig->getFormFactory()->createBuilder()
-                    ->create('value', UserAccountType::class, ['required' => $fieldDefinition->isRequired, 'label' => $label])
+                    ->create('value', UserAccountType::class, ['required' => $fieldDefinition->isRequired, 'label' => $fieldDefinition->getName()])
                     ->addModelTransformer(
                         new CallbackTransformer(
                             function (ApiUserValue $data) {

--- a/lib/Form/Type/Content/ContentEditType.php
+++ b/lib/Form/Type/Content/ContentEditType.php
@@ -14,6 +14,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -39,7 +41,10 @@ class ContentEditType extends AbstractType
             ->add('fieldsData', CollectionType::class, [
                 'entry_type' => ContentFieldType::class,
                 'label' => 'ezrepoforms.content.fields',
-                'entry_options' => ['languageCode' => $options['languageCode']],
+                'entry_options' => [
+                    'languageCode' => $options['languageCode'],
+                    'mainLanguageCode' => $options['mainLanguageCode'],
+                ],
             ])
             ->add('redirectUrlAfterPublish', HiddenType::class, ['required' => false, 'mapped' => false])
             ->add('publish', SubmitType::class, ['label' => 'content.publish_button']);
@@ -53,6 +58,12 @@ class ContentEditType extends AbstractType
                 ]);
             $builder->addEventListener(FormEvents::POST_SUBMIT, [$this, 'suppressValidationOnCancel'], 900);
         }
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['languageCode'] = $options['languageCode'];
+        $view->vars['mainLanguageCode'] = $options['mainLanguageCode'];
     }
 
     public function suppressValidationOnCancel(FormEvent $event)
@@ -72,6 +83,6 @@ class ContentEditType extends AbstractType
                 'data_class' => '\eZ\Publish\API\Repository\Values\Content\ContentStruct',
                 'translation_domain' => 'ezrepoforms_content',
             ])
-            ->setRequired(['languageCode']);
+            ->setRequired(['languageCode', 'mainLanguageCode']);
     }
 }

--- a/lib/Form/Type/Content/ContentFieldType.php
+++ b/lib/Form/Type/Content/ContentFieldType.php
@@ -12,6 +12,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentFieldType extends AbstractType
@@ -43,7 +45,13 @@ class ContentFieldType extends AbstractType
                 'data_class' => '\EzSystems\RepositoryForms\Data\Content\FieldData',
                 'translation_domain' => 'ezrepoforms_content',
             ])
-            ->setRequired(['languageCode']);
+            ->setRequired(['languageCode', 'mainLanguageCode']);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['languageCode'] = $options['languageCode'];
+        $view->vars['mainLanguageCode'] = $options['mainLanguageCode'];
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/lib/Form/Type/FieldType/MapLocationFieldType.php
+++ b/lib/Form/Type/FieldType/MapLocationFieldType.php
@@ -74,7 +74,7 @@ class MapLocationFieldType extends AbstractType
                 TextType::class,
                 [
                     'label' => /* @Desc("Address") */ 'content.field_type.ezgmaplocation.address',
-                    'required' => false,
+                    'required' => $options['required'],
                     'empty_data' => '',
                 ]
             )


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27539

# Description

Translation support was never implemented in repository-forms. Now there is a need for that in new AdminUI. This PR makes fieldtypes "language" aware which is helpful for developers theming content edit page. It also fixes the issue of nontranslated labels of fieldtypes as this feature is there but never implemented in Admin UI or Platform UI.