### PR TITLE
EZP-28299: Enforces empty value to be int(0) for ezmedia's width and height

### DIFF
--- a/lib/Form/Type/FieldType/MediaFieldType.php
+++ b/lib/Form/Type/FieldType/MediaFieldType.php
@@ -63,7 +63,8 @@ class MediaFieldType extends AbstractType
                 IntegerType::class,
                 [
                     'label' => /** @Desc("Width") */ 'content.field_type.ezmedia.width',
-                    'required' => false,
+                    'required' => true,
+                    'empty_data' => 0,
                     'attr' => [
                         'step' => 1,
                         'min' => 1,
@@ -75,7 +76,8 @@ class MediaFieldType extends AbstractType
                 IntegerType::class,
                 [
                     'label' => /** @Desc("Height") */ 'content.field_type.ezmedia.height',
-                    'required' => false,
+                    'required' => true,
+                    'empty_data' => 0,
                     'attr' => [
                         'step' => 1,
                         'min' => 1,


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28299

# Description
Width and height were set to `null` if no value was passed. This passed validation (once field was not required) but was failing during content create as kernel was rejecting the values.