### PR TITLE
EZP-28544: Added NotFoundException handling in limitation value mappers

### DIFF
--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -106,6 +106,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.contenttype.class%"
         arguments: ["@ezpublish.api.service.content_type"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Class }
             - { name: ez.limitation.valueMapper, limitationType: Class }
@@ -114,6 +116,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.contenttype.class%"
         arguments: ["@ezpublish.api.service.content_type"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: ParentClass }
             - { name: ez.limitation.valueMapper, limitationType: ParentClass }
@@ -122,6 +126,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.section.class%"
         arguments: ["@ezpublish.api.service.section"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Section }
             - { name: ez.limitation.valueMapper, limitationType: Section }
@@ -130,6 +136,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.section.class%"
         arguments: ["@ezpublish.api.service.section"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewSection }
             - { name: ez.limitation.valueMapper, limitationType: NewSection }
@@ -138,6 +146,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.objectstate.class%"
         arguments: ["@ezpublish.api.service.object_state"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: State }
             - { name: ez.limitation.valueMapper, limitationType: State }
@@ -146,6 +156,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.objectstate.class%"
         arguments: ["@ezpublish.api.service.object_state"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: NewState }
             - { name: ez.limitation.valueMapper, limitationType: NewState }
@@ -154,6 +166,8 @@ services:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.language.class%"
         arguments: ["@ezpublish.api.service.language"]
+        calls:
+            - [setLogger, ['@?logger']]
         tags:
             - { name: ez.limitation.formMapper, limitationType: Language }
             - { name: ez.limitation.valueMapper, limitationType: Language }

--- a/lib/Limitation/Mapper/ContentTypeLimitationMapper.php
+++ b/lib/Limitation/Mapper/ContentTypeLimitationMapper.php
@@ -9,11 +9,16 @@
 namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var ContentTypeService
      */
@@ -22,6 +27,7 @@ class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper implement
     public function __construct(ContentTypeService $contentTypeService)
     {
         $this->contentTypeService = $contentTypeService;
+        $this->logger = new NullLogger();
     }
 
     protected function getSelectionChoices()
@@ -40,7 +46,11 @@ class ContentTypeLimitationMapper extends MultipleSelectionBasedMapper implement
     {
         $values = [];
         foreach ($limitation->limitationValues as $contentTypeId) {
-            $values[] = $this->contentTypeService->loadContentType($contentTypeId);
+            try {
+                $values[] = $this->contentTypeService->loadContentType($contentTypeId);
+            } catch (NotFoundException $e) {
+                $this->logger->error(sprintf('Could not map limitation value: Content Type with id = %s not found', $contentTypeId));
+            }
         }
 
         return $values;

--- a/tests/RepositoryForms/Limitation/Mapper/SectionLimitationMapperTest.php
+++ b/tests/RepositoryForms/Limitation/Mapper/SectionLimitationMapperTest.php
@@ -8,19 +8,37 @@
  */
 namespace EzSystems\RepositoryForms\Tests\Limitation\Mapper;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use EzSystems\RepositoryForms\Limitation\Mapper\SectionLimitationMapper;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class SectionLimitationMapperTest extends TestCase
 {
+    /** @var SectionService|\PHPUnit_Framework_MockObject_MockObject */
+    private $sectionServiceMock;
+
+    /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $logger;
+
+    /** @var SectionLimitationMapper */
+    private $mapper;
+
+    protected function setUp()
+    {
+        $this->sectionServiceMock = $this->createMock(SectionService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->mapper = new SectionLimitationMapper($this->sectionServiceMock);
+        $this->mapper->setLogger($this->logger);
+    }
+
     public function testMapLimitationValue()
     {
         $values = ['3', '5', '7'];
-
-        $sectionServiceMock = $this->createMock(SectionService::class);
 
         $expected = [];
         foreach ($values as $i => $value) {
@@ -28,18 +46,39 @@ class SectionLimitationMapperTest extends TestCase
                 'id' => $value,
             ]);
 
-            $sectionServiceMock
+            $this->sectionServiceMock
                 ->expects($this->at($i))
                 ->method('loadSection')
                 ->with($value)
                 ->willReturn($expected[$i]);
         }
 
-        $mapper = new SectionLimitationMapper($sectionServiceMock);
-        $result = $mapper->mapLimitationValue(new SectionLimitation([
+        $result = $this->mapper->mapLimitationValue(new SectionLimitation([
             'limitationValues' => $values,
         ]));
 
         $this->assertEquals($expected, $result);
+    }
+
+    public function testMapLimitationValueWithNotExistingContentType()
+    {
+        $values = ['foo'];
+
+        $this->sectionServiceMock
+            ->expects($this->once())
+            ->method('loadSection')
+            ->with($values[0])
+            ->willThrowException($this->createMock(NotFoundException::class));
+
+        $this->logger
+            ->expects($this->once())
+            ->method('error')
+            ->with('Could not map limitation value: Section with id = foo not found');
+
+        $actual = $this->mapper->mapLimitationValue(new SectionLimitation([
+            'limitationValues' => $values,
+        ]));
+
+        $this->assertEmpty($actual);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28544

## Description

This PR adds `\eZ\Publish\API\Repository\Exceptions\NotFoundException` handling in limitation value mappers, which are the cause of problem described in JIRA ticket.

## Steps to reproduce

> 1. Create a new eZ Platform installation.
> 2. Create a new Content Type.
> 3. Create a new Role.
> 4. Create a new Content/Read Policy in the Role created in the previous step. Add Content Type created in the second step as Limitations->Class for this Policy.
> 5. Remove Content Type created in the second step.
> 6. Try to navigate to the Role created in the third step (in the Platform UI: "Admin Panel"->"Roles"->Name of the Role).
> 7. Confirm the error described above.

