### PR TITLE
EZP-28575: User can't edit content item with ezselection

### DIFF
--- a/lib/FieldType/DataTransformer/SingleSelectionValueTransformer.php
+++ b/lib/FieldType/DataTransformer/SingleSelectionValueTransformer.php
@@ -22,11 +22,11 @@ class SingleSelectionValueTransformer implements DataTransformerInterface
             return null;
         }
 
-        if ($value->selection === []) {
+        if (empty($value->selection)) {
             return null;
         }
 
-        return $value->selection;
+        return $value->selection[0];
     }
 
     public function reverseTransform($value)


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28575

# Description
`SingleSelectionTransformer` was returning incompatible value (array instead of a string). This was causing an "array to string" conversion error. 