### PR TITLE
EZP-28703: Error 400 after trying to register new user

### DIFF
--- a/lib/Data/Mapper/UserRegisterMapper.php
+++ b/lib/Data/Mapper/UserRegisterMapper.php
@@ -59,6 +59,7 @@ class UserRegisterMapper
         $data = new UserRegisterData([
             'contentType' => $contentType,
             'mainLanguageCode' => $this->params['language'],
+            'enabled' => true,
         ]);
         $data->addParentGroup($this->parentGroupLoader->loadGroup());
 

--- a/lib/Form/EventSubscriber/UserFieldsSubscriber.php
+++ b/lib/Form/EventSubscriber/UserFieldsSubscriber.php
@@ -62,7 +62,7 @@ class UserFieldsSubscriber implements EventSubscriberInterface
             $data->login = $userAccountFieldData->username;
             $data->email = $userAccountFieldData->email;
             $data->password = $userAccountFieldData->password;
-            $data->enabled = $userAccountFieldData->enabled;
+            $data->enabled = $data->enabled ?? $userAccountFieldData->enabled;
 
             /** @var Value $userValue */
             $userValue = clone $data->contentType


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28703

# Description
This PR fixes registration issue which was caused by passing `null` as a value for `UserCreateStruct::$enabled`. This was the result of assigning the value from `User/Value::$enabled` which is in fact `null` for empty fieldtype. My fix is either taking value coming from the fieldtype (in case of user create/edit) or from the `UserCreateStruct::$enabled` in registration. Also I've used `true` as a default value to reflect the behavior used in v1.