### PR TITLE
EZP-28850: Add optional location parameter to draft edit for more appropriate redirection

### DIFF
--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -6,10 +6,11 @@ ez_content_create_no_draft:
         expose: true
 
 ez_content_draft_edit:
-    path: /content/edit/draft/{contentId}/{versionNo}/{language}
+    path: /content/edit/draft/{contentId}/{versionNo}/{language}/{locationId}
     defaults:
         _controller: ez_content_edit:editContentDraftAction
-        language: null
+        language: ~
+        locationId: ~
     options:
         expose: true
 

--- a/lib/Form/ActionDispatcher/ContentDispatcher.php
+++ b/lib/Form/ActionDispatcher/ContentDispatcher.php
@@ -7,6 +7,7 @@
  */
 namespace EzSystems\RepositoryForms\Form\ActionDispatcher;
 
+use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -14,6 +15,8 @@ class ContentDispatcher extends AbstractActionDispatcher
 {
     protected function configureOptions(OptionsResolver $resolver)
     {
+        $resolver->setDefined(['referrerLocation']);
+        $resolver->setAllowedTypes('referrerLocation', [Location::class, null]);
     }
 
     protected function getActionEventBaseName()

--- a/lib/Form/Processor/ContentFormProcessor.php
+++ b/lib/Form/Processor/ContentFormProcessor.php
@@ -64,11 +64,13 @@ class ContentFormProcessor implements EventSubscriberInterface
         $formConfig = $form->getConfig();
         $languageCode = $formConfig->getOption('languageCode');
         $draft = $this->saveDraft($data, $languageCode);
+        $referrerLocation = $event->getOption('referrerLocation');
 
         $defaultUrl = $this->router->generate('ez_content_draft_edit', [
             'contentId' => $draft->id,
             'versionNo' => $draft->getVersionInfo()->versionNo,
             'language' => $languageCode,
+            'locationId' => null !== $referrerLocation ? $referrerLocation->id : null,
         ]);
         $event->setResponse(new RedirectResponse($formConfig->getAction() ?: $defaultUrl));
     }
@@ -136,11 +138,13 @@ class ContentFormProcessor implements EventSubscriberInterface
         $contentInfo = $this->contentService->loadContentInfo($createContentDraft->contentId);
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $createContentDraft->fromVersionNo);
         $contentDraft = $this->contentService->createContentDraft($contentInfo, $versionInfo);
+        $referrerLocation = $event->getOption('referrerLocation');
 
         $contentEditUrl = $this->router->generate('ez_content_draft_edit', [
             'contentId' => $contentDraft->id,
             'versionNo' => $contentDraft->getVersionInfo()->versionNo,
             'language' => $contentDraft->contentInfo->mainLanguageCode,
+            'locationId' => null !== $referrerLocation ? $referrerLocation->id : null,
         ]);
         $event->setResponse(new RedirectResponse($contentEditUrl));
     }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28850
> Requires: https://github.com/ezsystems/ezplatform-admin-ui/pull/374

# Description
Right now it's not possible to return to the proper location in AdminUI as repository-forms is not passing any information about the location draft was edited from. It's also crucial for Page Builder. 

The parameter is optional and should not introduce any BC breaks.

# QA Testing
I'm not sure how are you supposed to test it, the best thing that comes to my mind is to just test content edit in Admin UI as this is directly affected.