### PR TITLE
EZP-28849: Allow repository forms to use View Manager for handling draft edit controller and template dispatching

### DIFF
--- a/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
+++ b/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler;
+
+use EzSystems\RepositoryForms\Content\View\Builder\ContentEditViewBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to add View Builders to ViewBuilderRegistry.
+ */
+class ViewBuilderRegistryPass implements CompilerPassInterface
+{
+    const VIEW_BUILDER_REGISTRY = 'ezpublish.view_builder.registry';
+    const VIEW_BUILDER_CONTENT_EDIT = ContentEditViewBuilder::class;
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::VIEW_BUILDER_REGISTRY) || !$container->hasDefinition(ContentEditViewBuilder::class)) {
+            return;
+        }
+
+        $registry = $container->findDefinition(self::VIEW_BUILDER_REGISTRY);
+
+        $viewBuilders = [
+            $container->getDefinition(self::VIEW_BUILDER_CONTENT_EDIT),
+        ];
+
+        $registry->addMethodCall('addToRegistry', [$viewBuilders]);
+    }
+}

--- a/bundle/DependencyInjection/Configuration/Parser/ContentEditView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentEditView.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\View;
+
+class ContentEditView extends View
+{
+    const NODE_KEY = 'content_edit_view';
+    const INFO = 'Template selection settings when displaying a content edit form';
+}

--- a/bundle/EzSystemsRepositoryFormsBundle.php
+++ b/bundle/EzSystemsRepositoryFormsBundle.php
@@ -12,7 +12,9 @@ use EzSystems\RepositoryForms\Security\UserRegisterPolicyProvider;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationFormMapperPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\LimitationValueMapperPass;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\ViewBuilderRegistryPass;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEdit;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\ContentEditView;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\LimitationValueTemplates;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserEdit;
 use EzSystems\RepositoryFormsBundle\DependencyInjection\Configuration\Parser\UserRegistration;
@@ -27,6 +29,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
         $container->addCompilerPass(new LimitationFormMapperPass());
         $container->addCompilerPass(new LimitationValueMapperPass());
+        $container->addCompilerPass(new ViewBuilderRegistryPass());
 
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addPolicyProvider(new UserRegisterPolicyProvider());
@@ -34,6 +37,7 @@ class EzSystemsRepositoryFormsBundle extends Bundle
         $eZExtension->addConfigParser(new ContentEdit());
         $eZExtension->addConfigParser(new UserEdit());
         $eZExtension->addConfigParser(new LimitationValueTemplates());
+        $eZExtension->addConfigParser(new ContentEditView());
         $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['ezpublish_default_settings.yml']);
     }
 }

--- a/bundle/Resources/config/ezpublish_default_settings.yml
+++ b/bundle/Resources/config/ezpublish_default_settings.yml
@@ -9,3 +9,5 @@ parameters:
     ezsettings.default.user_edit.templates.create: "EzSystemsRepositoryFormsBundle:Content:content_edit.html.twig"
     ezsettings.default.limitation_value_templates:
         - { template: 'EzSystemsRepositoryFormsBundle::limitation_values.html.twig', priority: 0 }
+
+    ezsettings.default.content_edit_view: {}

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -8,8 +8,8 @@ ez_content_create_no_draft:
 ez_content_draft_edit:
     path: /content/edit/draft/{contentId}/{versionNo}/{language}/{locationId}
     defaults:
-        _controller: ez_content_edit:editContentDraftAction
-        language: ~
+        _controller: ez_content_edit:editVersionDraftAction
+        language: ~ # @todo rename to languageCode in 3.0
         locationId: ~
     options:
         expose: true

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -4,6 +4,7 @@ imports:
     - {resource: role.yml}
     - {resource: fieldtypes.yml}
     - {resource: form_types.yml}
+    - {resource: views.yml}
 
 parameters:
     ezrepoforms.field_type_form_mapper.dispatcher.class: EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperDispatcher
@@ -259,8 +260,6 @@ services:
             - "@ezpublish.api.service.language"
             - "@ezrepoforms.action_dispatcher.content"
         parent: ezpublish.controller.base
-        calls:
-            - [setPageLayout, [$pagelayout$]]
 
     ezrepoforms.controller.user:
         class: "%ezrepoforms.controller.user.class%"
@@ -313,7 +312,6 @@ services:
             - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserUpdateView', "$user_edit.templates.update$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserRegisterFormView', "$user_registration.templates.form$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\User\View\UserRegisterConfirmView', "$user_registration.templates.confirmation$"]]
-            - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentEditView', "$content_edit.templates.edit$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateView', "$content_edit.templates.create$"]]
             - [setViewTemplate, ['EzSystems\RepositoryForms\Content\View\ContentCreateDraftView', "$content_edit.templates.create_draft$"]]
             - [setPagelayout, ["$pagelayout$"]]

--- a/bundle/Resources/config/views.yml
+++ b/bundle/Resources/config/views.yml
@@ -1,0 +1,35 @@
+services:
+    _defaults:
+        public: false
+        autowire: true
+        autoconfigure: true
+
+    EzSystems\RepositoryForms\Content\View\Builder\ContentEditViewBuilder:
+        arguments:
+            - '@ezpublish.api.repository'
+            - '@ezpublish.view.configurator'
+            - '@ezpublish.view.view_parameters.injector.dispatcher'
+            - '$content_edit.templates.edit$'
+            - '@ezrepoforms.action_dispatcher.content'
+
+    EzSystems\RepositoryForms\Content\View\Provider\Configured:
+        arguments:
+            - '@ezplatform.repository_forms.content_edit_view.matcher_factory'
+        tags:
+            - { name: ezpublish.view_provider, type: EzSystems\RepositoryForms\Content\View\ContentEditView, priority: 10 }
+
+    ezplatform.repository_forms.content_edit_view.matcher_factory:
+        class: '%ezpublish.view.matcher_factory.class%'
+        arguments:
+            - '@ezpublish.api.repository'
+            - 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased'
+        calls:
+            - [setContainer, ['@service_container']]
+            - [setMatchConfig, ['$content_edit_view$']]
+
+    EzSystems\RepositoryForms\Content\View\Filter\ContentEditViewFilter:
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.content_type'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/lib/Content/View/Builder/ContentEditViewBuilder.php
+++ b/lib/Content/View/Builder/ContentEditViewBuilder.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Content\View\Builder;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use EzSystems\RepositoryForms\Content\View\ContentEditView;
+use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
+
+/**
+ * Builds ContentEditView objects.
+ *
+ * @internal
+ */
+class ContentEditViewBuilder implements ViewBuilder
+{
+    /** @var \eZ\Publish\API\Repository\Repository */
+    private $repository;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
+    private $viewConfigurator;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
+    private $viewParametersInjector;
+
+    /** @var string */
+    private $defaultTemplate;
+
+    /** @var ActionDispatcherInterface */
+    private $contentActionDispatcher;
+
+    public function __construct(
+        Repository $repository,
+        Configurator $viewConfigurator,
+        ParametersInjector $viewParametersInjector,
+        string $defaultTemplate,
+        ActionDispatcherInterface $contentActionDispatcher
+    ) {
+        $this->repository = $repository;
+        $this->viewConfigurator = $viewConfigurator;
+        $this->viewParametersInjector = $viewParametersInjector;
+        $this->defaultTemplate = $defaultTemplate;
+        $this->contentActionDispatcher = $contentActionDispatcher;
+    }
+
+    public function matches($argument)
+    {
+        return 'ez_content_edit:editVersionDraftAction' === $argument;
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|\eZ\Publish\Core\MVC\Symfony\View\View
+     *
+     * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function buildView(array $parameters)
+    {
+        // @todo improve default templates injection
+        $view = new ContentEditView($this->defaultTemplate);
+
+        $language = $this->resolveLanguage($parameters);
+        $location = $this->resolveLocation($parameters);
+        $content = $this->resolveContent($parameters, $location, $language);
+        $contentType = $this->loadContentType((int) $content->contentInfo->contentTypeId);
+        $form = $parameters['form'];
+
+        if (!$content->getVersionInfo()->isDraft()) {
+            throw new InvalidArgumentException('Version', 'status is not draft');
+        }
+
+        if (null === $location) { // assume main location if no location was provided
+            $location = $this->loadLocation((int) $content->contentInfo->mainLocationId);
+        }
+
+        if ($location->contentId !== $content->id) {
+            throw new InvalidArgumentException('Location', 'Provided location does not belong to selected content');
+        }
+
+        if ($form->isValid() && null !== $form->getClickedButton()) {
+            $this->contentActionDispatcher->dispatchFormAction(
+                $form,
+                $form->getData(),
+                $form->getClickedButton()->getName(),
+                ['referrerLocation' => $location]
+            );
+
+            if ($response = $this->contentActionDispatcher->getResponse()) {
+                $view->setResponse($response);
+            }
+        }
+
+        $view->setContent($content);
+        $view->setLanguage($language);
+        $view->setLocation($location);
+        $view->setForm($parameters['form']);
+
+        $view->addParameters([
+            'content' => $content,
+            'location' => $location,
+            'language' => $language,
+            'contentType' => $contentType,
+            'form' => $form->createView(),
+        ]);
+
+        $this->viewParametersInjector->injectViewParameters($view, $parameters);
+        $this->viewConfigurator->configure($view);
+
+        return $view;
+    }
+
+    /**
+     * Loads Content with id $contentId.
+     *
+     * @param int $contentId
+     * @param array $languages
+     * @param int|null $versionNo
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadContent(int $contentId, array $languages = [], int $versionNo = null): Content
+    {
+        return $this->repository->getContentService()->loadContent($contentId, $languages, $versionNo);
+    }
+
+    /**
+     * Loads a visible Location.
+     *
+     * @param int $locationId
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadLocation(int $locationId): Location
+    {
+        return $this->repository->getLocationService()->loadLocation($locationId);
+    }
+
+    /**
+     * Loads Language with code $languageCode.
+     *
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadLanguage(string $languageCode): Language
+    {
+        return $this->repository->getContentLanguageService()->loadLanguage($languageCode);
+    }
+
+    /**
+     * Loads ContentType with id $contentTypeId.
+     *
+     * @param int $contentTypeId
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadContentType(int $contentTypeId): ContentType
+    {
+        return $this->repository->getContentTypeService()->loadContentType($contentTypeId);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function resolveLanguage(array $parameters): Language
+    {
+        if (isset($parameters['languageCode'])) {
+            return $this->loadLanguage($parameters['languageCode']);
+        }
+
+        if (isset($parameters['language'])) {
+            if (is_string($parameters['language'])) {
+                // @todo BC: route parameter should be called languageCode but it won't happen until 3.0
+                return $this->loadLanguage($parameters['language']);
+            }
+
+            return $parameters['language'];
+        }
+
+        throw new InvalidArgumentException('Language',
+            'No language information provided. Are you missing language or languageCode parameters');
+    }
+
+    /**
+     * @param array $parameters
+     * @param \eZ\Publish\API\Repository\Values\Content\Location|null $location
+     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function resolveContent(array $parameters, ?Location $location, Language $language): Content
+    {
+        if (isset($parameters['content'])) {
+            return $parameters['content'];
+        }
+
+        if (isset($parameters['contentId'])) {
+            $contentId = $parameters['contentId'];
+        } elseif (null !== $location) {
+            $contentId = $location->contentId;
+        } else {
+            throw new InvalidArgumentException(
+                'Content',
+                'No content could be loaded from parameters'
+            );
+        }
+
+        return $this->loadContent(
+            (int) $contentId,
+            null !== $language ? [$language->languageCode] : [],
+            (int) $parameters['versionNo'] ?: null
+        );
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
+     */
+    private function resolveLocation(array $parameters): ?Location
+    {
+        if (isset($parameters['locationId'])) {
+            return $this->loadLocation((int) $parameters['locationId']);
+        }
+
+        if (isset($parameters['location'])) {
+            return $parameters['location'];
+        }
+
+        return null;
+    }
+}

--- a/lib/Content/View/ContentEditView.php
+++ b/lib/Content/View/ContentEditView.php
@@ -3,11 +3,95 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\RepositoryForms\Content\View;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
-use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView;
+use Symfony\Component\Form\FormInterface;
 
-class ContentEditView extends BaseView implements View
+class ContentEditView extends BaseView implements ContentValueView, LocationValueView
 {
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $content;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    private $location;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Language */
+    private $language;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    private $form;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     */
+    public function setContent(Content $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Returns the Content.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    public function getContent(): Content
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     */
+    public function setLocation(Location $location)
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function getLocation(): Location
+    {
+        return $this->location;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Language
+     */
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
+     */
+    public function setLanguage(Language $language)
+    {
+        $this->language = $language;
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    public function getForm(): FormInterface
+    {
+        return $this->form;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormInterface $form
+     */
+    public function setForm(FormInterface $form)
+    {
+        $this->form = $form;
+    }
 }

--- a/lib/Content/View/Filter/ContentEditViewFilter.php
+++ b/lib/Content/View/Filter/ContentEditViewFilter.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Content\View\Filter;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
+use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use EzSystems\RepositoryForms\Data\Content\ContentUpdateData;
+use EzSystems\RepositoryForms\Data\Mapper\ContentUpdateMapper;
+use EzSystems\RepositoryForms\Form\Type\Content\ContentEditType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class ContentEditViewFilter implements EventSubscriberInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \Symfony\Component\Form\FormFactoryInterface */
+    private $formFactory;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
+     */
+    public function __construct(
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        FormFactoryInterface $formFactory
+    ) {
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->formFactory = $formFactory;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [ViewEvents::FILTER_BUILDER_PARAMETERS => 'handleContentEditForm'];
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent $event
+     *
+     * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function handleContentEditForm(FilterViewBuilderParametersEvent $event)
+    {
+        if ('ez_content_edit:editVersionDraftAction' !== $event->getParameters()->get('_controller')) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $languageCode = $request->attributes->get('language');
+        $contentDraft = $this->contentService->loadContent(
+            $request->attributes->get('contentId'),
+            [$languageCode], // @todo: rename to languageCode in 3.0
+            $request->attributes->get('versionNo')
+        );
+        $contentType = $this->contentTypeService->loadContentType($contentDraft->contentInfo->contentTypeId);
+
+        $contentUpdate = $this->resolveContentEditData($contentDraft, $languageCode, $contentType);
+        $form = $this->resolveContentEditForm($contentUpdate, $languageCode, $contentDraft);
+
+        $event->getParameters()->add(['form' => $form->handleRequest($request)]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $languageCode
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
+     */
+    private function resolveContentEditData(
+        Content $content,
+        string $languageCode,
+        ContentType $contentType
+    ): ContentUpdateData {
+        $contentUpdateMapper = new ContentUpdateMapper();
+
+        return $contentUpdateMapper->mapToFormData($content, [
+            'languageCode' => $languageCode,
+            'contentType' => $contentType,
+        ]);
+    }
+
+    /**
+     * @param \EzSystems\RepositoryForms\Data\Content\ContentUpdateData $contentUpdate
+     * @param string $languageCode
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \Symfony\Component\Form\FormInterface
+     *
+     * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    private function resolveContentEditForm(
+        ContentUpdateData $contentUpdate,
+        string $languageCode,
+        Content $content
+    ): FormInterface {
+        return $this->formFactory->create(
+            ContentEditType::class,
+            $contentUpdate,
+            [
+                'languageCode' => $languageCode,
+                'mainLanguageCode' => $content->contentInfo->mainLanguageCode,
+                'drafts_enabled' => true,
+            ]
+        );
+    }
+}

--- a/lib/Content/View/Provider/Configured.php
+++ b/lib/Content/View/Provider/Configured.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Content\View\Provider;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
+use EzSystems\RepositoryForms\Content\View\ContentEditView;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * View provider based on configuration.
+ */
+class Configured implements ViewProvider
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface
+     */
+    protected $matcherFactory;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface $matcherFactory
+     */
+    public function __construct(MatcherFactoryInterface $matcherFactory)
+    {
+        $this->matcherFactory = $matcherFactory;
+    }
+
+    public function getView(View $view)
+    {
+        if (($configHash = $this->matcherFactory->match($view)) === null) {
+            return null;
+        }
+
+        return $this->buildContentEditView($configHash);
+    }
+
+    /**
+     * Builds a ContentEditView object from $viewConfig.
+     *
+     * @param array $viewConfig
+     *
+     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView
+     */
+    protected function buildContentEditView(array $viewConfig): ContentEditView
+    {
+        $view = new ContentEditView();
+        $view->setConfigHash($viewConfig);
+        if (isset($viewConfig['template'])) {
+            $view->setTemplateIdentifier($viewConfig['template']);
+        }
+        if (isset($viewConfig['controller'])) {
+            $view->setControllerReference(new ControllerReference($viewConfig['controller']));
+        }
+        if (isset($viewConfig['params']) && is_array($viewConfig['params'])) {
+            $view->addParameters($viewConfig['params']);
+        }
+
+        return $view;
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28849
> Requires: https://github.com/ezsystems/ezplatform-admin-ui/pull/375 (to work with AdminUI)

# Description
I heard from @bdunogier it was always the initial idea but no one had time to finish it. As Page Builder is meant to replace edit interface for Landing Pages we need this feature. This PR only affects draft edit action, next one will be dedicated to content create.

I'd like a solid code review as this PR might potentially introduce some BC breaks.

# QA Testing
Might be hard to test by QA as this is mostly related to developer experience but I'd advise to get through content editing briefly. If the content editing screen is displayed correctly and the actions are performed as expected it should be alright.