### PR TITLE
EZP-28949: switched sort of field type selection to use human readable name

### DIFF
--- a/lib/Form/Type/ContentType/FieldTypeChoiceType.php
+++ b/lib/Form/Type/ContentType/FieldTypeChoiceType.php
@@ -69,7 +69,7 @@ class FieldTypeChoiceType extends AbstractType
             $choices[$this->getFieldTypeLabel($fieldTypeIdentifier)] = $fieldTypeIdentifier;
         }
 
-        asort($choices, SORT_NATURAL);
+        ksort($choices, SORT_NATURAL);
 
         return $choices;
     }


### PR DESCRIPTION
Field types are currently sorted by their respectable identifiers (e.g. ezstring, eztext, etc.)

This works fine with the default build in field types but degrades UX once custom field types are introduced.