### PR TITLE
EZP-28871: upload_max_filesize setting should be taken into account in the validation of uploaded files

### DIFF
--- a/lib/Form/Type/FieldType/BinaryBaseFieldType.php
+++ b/lib/Form/Type/FieldType/BinaryBaseFieldType.php
@@ -37,9 +37,9 @@ class BinaryBaseFieldType extends AbstractType
                     'required' => $options['required'],
                     'constraints' => [
                         new Assert\File([
-                            'maxSize' => $this->getMaxUploadSize()
-                        ])
-                    ]
+                            'maxSize' => $this->getMaxUploadSize(),
+                        ]),
+                    ],
                 ]
             );
     }
@@ -69,8 +69,8 @@ class BinaryBaseFieldType extends AbstractType
         $str = strtoupper(trim($str));
 
         $value = substr($str, 0, -1);
-        $unit  = substr($str, -1);
-        switch($unit) {
+        $unit = substr($str, -1);
+        switch ($unit) {
             case 'G':
                 $value *= 1024;
             case 'M':

--- a/lib/Form/Type/FieldType/BinaryBaseFieldType.php
+++ b/lib/Form/Type/FieldType/BinaryBaseFieldType.php
@@ -9,7 +9,10 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Parent Form Type for binary file based field types.
@@ -32,12 +35,50 @@ class BinaryBaseFieldType extends AbstractType
                 [
                     'label' => /** @Desc("File") */ 'content.field_type.binary_base.file',
                     'required' => $options['required'],
+                    'constraints' => [
+                        new Assert\File([
+                            'maxSize' => $this->getMaxUploadSize()
+                        ])
+                    ]
                 ]
             );
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['max_upload_size'] = $this->getMaxUploadSize();
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['translation_domain' => 'ezrepoforms_fieldtype']);
+    }
+
+    private function getMaxUploadSize()
+    {
+        static $value = null;
+        if ($value === null) {
+            return $this->str2bytes(ini_get('upload_max_filesize'));
+        }
+
+        return $value;
+    }
+
+    private function str2bytes($str)
+    {
+        $str = strtoupper(trim($str));
+
+        $value = substr($str, 0, -1);
+        $unit  = substr($str, -1);
+        switch($unit) {
+            case 'G':
+                $value *= 1024;
+            case 'M':
+                $value *= 1024;
+            case 'K':
+                $value *= 1024;
+        }
+
+        return (int) $value;
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28871

## Description 

The `upload_max_filesize` setting from `php.ini` should be taken into account in the validation of uploaded files, as an upper limit of upload size. 

## Steps to reproduce 

1. Configure `upload_max_filesize` to e.g 5M
1. Create new Media -> File
2. Select large binary file larger then `upload_max_filesize`
3. Try to save content. The application will return "Internal server error" because of  `Argument 'localFile' is invalid: file does not exist or is unreadable: /var/www/...` exception 

