### PR TITLE
EZP-28871: Return value of BinaryBaseFieldType::getMaxUploadSize should be cached

### DIFF
--- a/lib/Form/Type/FieldType/BinaryBaseFieldType.php
+++ b/lib/Form/Type/FieldType/BinaryBaseFieldType.php
@@ -58,7 +58,7 @@ class BinaryBaseFieldType extends AbstractType
     {
         static $value = null;
         if ($value === null) {
-            return $this->str2bytes(ini_get('upload_max_filesize'));
+            $value = $this->str2bytes(ini_get('upload_max_filesize'));
         }
 
         return $value;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28871

## Description 

`\EzSystems\RepositoryForms\Form\Type\FieldType\BinaryBaseFieldType::getMaxUploadSize` is called multipe times, so it return value should be cached.  