### PR TITLE
EZP-28944: ISE 500 when deleting Draft

### DIFF
--- a/bundle/Controller/ContentEditController.php
+++ b/bundle/Controller/ContentEditController.php
@@ -11,7 +11,9 @@ use eZ\Bundle\EzPublishCoreBundle\Controller;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\RepositoryForms\Content\View\ContentCreateDraftView;
+use EzSystems\RepositoryForms\Content\View\ContentCreateSuccessView;
 use EzSystems\RepositoryForms\Content\View\ContentCreateView;
+use EzSystems\RepositoryForms\Content\View\ContentEditSuccessView;
 use EzSystems\RepositoryForms\Content\View\ContentEditView;
 use EzSystems\RepositoryForms\Data\Content\CreateContentDraftData;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
@@ -44,9 +46,21 @@ class ContentEditController extends Controller
      *
      * @param \EzSystems\RepositoryForms\Content\View\ContentCreateView $view
      *
-     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateView|\Symfony\Component\HttpFoundation\Response
+     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateView
      */
-    public function createWithoutDraftAction(ContentCreateView $view)
+    public function createWithoutDraftAction(ContentCreateView $view): ContentCreateView
+    {
+        return $view;
+    }
+
+    /**
+     * @param \EzSystems\RepositoryForms\Content\View\ContentCreateSuccessView $view
+     *
+     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateSuccessView
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function createWithoutDraftSuccessAction(ContentCreateSuccessView $view): ContentCreateSuccessView
     {
         return $view;
     }
@@ -113,11 +127,23 @@ class ContentEditController extends Controller
     /**
      * @param \EzSystems\RepositoryForms\Content\View\ContentEditView $view
      *
-     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView|\Symfony\Component\HttpFoundation\Response
+     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      */
-    public function editVersionDraftAction(ContentEditView $view)
+    public function editVersionDraftAction(ContentEditView $view): ContentEditView
+    {
+        return $view;
+    }
+
+    /**
+     * @param \EzSystems\RepositoryForms\Content\View\ContentEditSuccessView $view
+     *
+     * @return \EzSystems\RepositoryForms\Content\View\ContentEditSuccessView
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function editVersionDraftSuccessAction(ContentEditSuccessView $view): ContentEditSuccessView
     {
         return $view;
     }
@@ -132,7 +158,7 @@ class ContentEditController extends Controller
      * @param string $language Language code to create the version in (eng-GB, ger-DE, ...))
      * @param int|null $locationId
      *
-     * @return \EzSystems\RepositoryForms\Content\View\ContentEditView|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function editContentDraftAction(
         $contentId,

--- a/bundle/Resources/views/http/302_empty_content.html.twig
+++ b/bundle/Resources/views/http/302_empty_content.html.twig
@@ -1,0 +1,1 @@
+{# do not put anything in here #}

--- a/lib/Content/View/Builder/ContentCreateViewBuilder.php
+++ b/lib/Content/View/Builder/ContentCreateViewBuilder.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use EzSystems\RepositoryForms\Content\View\ContentCreateSuccessView;
 use EzSystems\RepositoryForms\Content\View\ContentCreateView;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 
@@ -63,7 +64,7 @@ class ContentCreateViewBuilder implements ViewBuilder
     /**
      * @param array $parameters
      *
-     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateView
+     * @return \EzSystems\RepositoryForms\Content\View\ContentCreateSuccessView|\EzSystems\RepositoryForms\Content\View\ContentCreateView
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
@@ -88,7 +89,7 @@ class ContentCreateViewBuilder implements ViewBuilder
             );
 
             if ($response = $this->contentActionDispatcher->getResponse()) {
-                $view->setResponse($response);
+                return new ContentCreateSuccessView($response);
             }
         }
 

--- a/lib/Content/View/Builder/ContentEditViewBuilder.php
+++ b/lib/Content/View/Builder/ContentEditViewBuilder.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use EzSystems\RepositoryForms\Content\View\ContentEditSuccessView;
 use EzSystems\RepositoryForms\Content\View\ContentEditView;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
 
@@ -66,6 +67,7 @@ class ContentEditViewBuilder implements ViewBuilder
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|\eZ\Publish\Core\MVC\Symfony\View\View
      *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
@@ -103,7 +105,7 @@ class ContentEditViewBuilder implements ViewBuilder
             );
 
             if ($response = $this->contentActionDispatcher->getResponse()) {
-                $view->setResponse($response);
+                return new ContentEditSuccessView($response);
             }
         }
 

--- a/lib/Content/View/ContentCreateSuccessView.php
+++ b/lib/Content/View/ContentCreateSuccessView.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Content\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+class ContentCreateSuccessView extends BaseView
+{
+    /**
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
+    public function __construct(Response $response)
+    {
+        parent::__construct('@EzSystemsRepositoryForms/http/302_empty_content.html.twig');
+
+        $this->setResponse($response);
+        $this->setControllerReference(new ControllerReference('ez_content_edit:createWithoutDraftSuccessAction'));
+    }
+}

--- a/lib/Content/View/ContentEditSuccessView.php
+++ b/lib/Content/View/ContentEditSuccessView.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Content\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+class ContentEditSuccessView extends BaseView
+{
+    /**
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
+    public function __construct(Response $response)
+    {
+        parent::__construct('@EzSystemsRepositoryForms/http/302_empty_content.html.twig');
+
+        $this->setResponse($response);
+        $this->setControllerReference(new ControllerReference('ez_content_edit:editVersionDraftSuccessAction'));
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28944

# Description
Not the solution I'd like to have but I couldn't find any better way to solve the issue. You are expected to return `View` object from the builder where currently we are handling forms. It's not possible to return `RedirectResponse` directly which is the outcome from the `FormProcessors`. I had to hack it a little to encapsulate Response inside `ContentEditSuccessView` and `ContentCreateSuccessView` which is later picked up by `ViewTemplateListener` which is properly handling the Response. Benefit to this resolution is that you can catch the view and render the template if needed.

If anyone has better idea please let me know.

# QA
Test create and edit functionalities.