### PR TITLE
Revert "EZP-28930: Labels are one line below checkbox/radiobutton"

### DIFF
--- a/bundle/Resources/views/ContentType/field_types.html.twig
+++ b/bundle/Resources/views/ContentType/field_types.html.twig
@@ -18,7 +18,6 @@
 
 {% block ezboolean_field_definition_edit %}
     <div class="ezboolean-default-value{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.defaultValue, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.defaultValue) -}}
         {{- form_errors(form.defaultValue) -}}
         {{- form_widget(form.defaultValue) -}}
@@ -27,7 +26,6 @@
 
 {% block ezcountry_field_definition_edit %}
     <div class="ezcountry-settings is-multiple{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.isMultiple, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.isMultiple) -}}
         {{- form_errors(form.isMultiple) -}}
         {{- form_widget(form.isMultiple) -}}
@@ -42,7 +40,6 @@
 
 {% block ezdate_field_definition_edit %}
     <div class="ezdate-settings default-type{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.defaultType, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.defaultType) -}}
         {{- form_errors(form.defaultType) -}}
         {{- form_widget(form.defaultType) -}}
@@ -51,14 +48,12 @@
 
 {% block ezdatetime_field_definition_edit %}
     <div class="ezdatetime-settings use-seconds{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.useSeconds, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.useSeconds) -}}
         {{- form_errors(form.useSeconds) -}}
         {{- form_widget(form.useSeconds) -}}
     </div>
 
     <div class="ezdatetime-settings default-type{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.defaultType, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.defaultType) -}}
         {{- form_errors(form.defaultType) -}}
         {{- form_widget(form.defaultType) -}}
@@ -219,7 +214,6 @@
 
 {% block ezselection_field_definition_edit %}
     <div class="ezselection-settings is-multiple{% if group_class is not empty %} {{ group_class }}{% endif %}">
-        {{- form_row(form.isMultiple, {'label_attr': {'class': 'checkbox-inline'}}) -}}
         {{- form_label(form.isMultiple) -}}
         {{- form_errors(form.isMultiple) -}}
         {{- form_widget(form.isMultiple) -}}


### PR DESCRIPTION
Reverts ezsystems/repository-forms#219. 

That PR was causing some labels to appear twice because first it was rendering `form_row` and later `form_label`, `form_errors` and `form_widget`. 

I've moved field definition templates: https://github.com/ezsystems/ezplatform-admin-ui/pull/400 to prevent people from making AdminUI related changes in this repository.