### PR TITLE
EZP-28939: Internal Server Error when saving unpublished Draft

### DIFF
--- a/lib/Content/View/ContentEditView.php
+++ b/lib/Content/View/ContentEditView.php
@@ -20,7 +20,7 @@ class ContentEditView extends BaseView implements ContentValueView, LocationValu
     /** @var \eZ\Publish\API\Repository\Values\Content\Content */
     private $content;
 
-    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location|null */
     private $location;
 
     /** @var \eZ\Publish\API\Repository\Values\Content\Language */
@@ -48,17 +48,17 @@ class ContentEditView extends BaseView implements ContentValueView, LocationValu
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @param \eZ\Publish\API\Repository\Values\Content\Location|null $location
      */
-    public function setLocation(Location $location)
+    public function setLocation(?Location $location)
     {
         $this->location = $location;
     }
 
     /**
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
      */
-    public function getLocation(): Location
+    public function getLocation(): ?Location
     {
         return $this->location;
     }

--- a/lib/Form/ActionDispatcher/ContentDispatcher.php
+++ b/lib/Form/ActionDispatcher/ContentDispatcher.php
@@ -16,7 +16,8 @@ class ContentDispatcher extends AbstractActionDispatcher
     protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefined(['referrerLocation']);
-        $resolver->setAllowedTypes('referrerLocation', [Location::class, null]);
+        $resolver->setDefault('referrerLocation', null);
+        $resolver->setAllowedTypes('referrerLocation', [Location::class, 'null']);
     }
 
     protected function getActionEventBaseName()


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28939

# Description
This PR fixes the issue with unpublished drafts. It was relying on `Location` a lot but unpublished content has no location until published. My PR introduces another property to the `ContentEditView` which tells about `ParentLocation`, it allows `ContentEditView::$location` to be `null`.