### PR TITLE
EZP-29012: Invalid initial language code set after saving content draft

### DIFF
--- a/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/lib/Data/Mapper/ContentUpdateMapper.php
@@ -7,6 +7,7 @@
  */
 namespace EzSystems\RepositoryForms\Data\Mapper;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use EzSystems\RepositoryForms\Data\Content\ContentUpdateData;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
@@ -17,19 +18,23 @@ class ContentUpdateMapper implements FormDataMapperInterface
     /**
      * Maps a ValueObject from eZ content repository to a data usable as underlying form data (e.g. create/update struct).
      *
-     * @param ValueObject|\eZ\Publish\API\Repository\Values\Content\Content $contentDraft
+     * @param \eZ\Publish\API\Repository\Values\ValueObject|\eZ\Publish\API\Repository\Values\Content\Content $contentDraft
      * @param array $params
      *
-     * @return ContentUpdateData
+     * @return \EzSystems\RepositoryForms\Data\Content\ContentUpdateData
      */
     public function mapToFormData(ValueObject $contentDraft, array $params = [])
     {
         $optionsResolver = new OptionsResolver();
         $this->configureOptions($optionsResolver);
+
         $params = $optionsResolver->resolve($params);
+        $languageCode = $params['languageCode'];
 
         $data = new ContentUpdateData(['contentDraft' => $contentDraft]);
-        $fields = $contentDraft->getFieldsByLanguage($params['languageCode']);
+        $data->initialLanguageCode = $languageCode;
+
+        $fields = $contentDraft->getFieldsByLanguage($languageCode);
         foreach ($params['contentType']->fieldDefinitions as $fieldDef) {
             $field = $fields[$fieldDef->identifier];
             $data->addFieldData(new FieldData([
@@ -46,6 +51,6 @@ class ContentUpdateMapper implements FormDataMapperInterface
     {
         $optionsResolver
             ->setRequired(['languageCode', 'contentType'])
-            ->setAllowedTypes('contentType', '\eZ\Publish\API\Repository\Values\ContentType\ContentType');
+            ->setAllowedTypes('contentType', ContentType::class);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29012

# Description
This PR fixes setting `initialLanguageCode` property on edited drafts. This allows to properly display translation language in AdminUI.