### PR TITLE
EZP-28224: Use PHP5.6 compatible function

### DIFF
--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -12,9 +12,9 @@ namespace EzSystems\RepositoryForms\Form\Processor;
 
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
-use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -170,7 +170,9 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
         $startIndex,
         $fieldTypeIdentifier
     ) {
-        $fieldDefinitionIdentifiers = array_column($contentTypeDraft->getFieldDefinitions(), 'identifier');
+        $fieldDefinitionIdentifiers = array_map(function ($fieldDefinition) {
+            return $fieldDefinition->identifier;
+        }, $contentTypeDraft->getFieldDefinitions());
 
         do {
             $fieldDefinitionIdentifier = sprintf('new_%s_%d', $fieldTypeIdentifier, ++$startIndex);

--- a/lib/Form/Processor/ContentTypeFormProcessor.php
+++ b/lib/Form/Processor/ContentTypeFormProcessor.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -170,7 +171,7 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
         $startIndex,
         $fieldTypeIdentifier
     ) {
-        $fieldDefinitionIdentifiers = array_map(function ($fieldDefinition) {
+        $fieldDefinitionIdentifiers = array_map(function (FieldDefinition $fieldDefinition) {
             return $fieldDefinition->identifier;
         }, $contentTypeDraft->getFieldDefinitions());
 


### PR DESCRIPTION
Done as part of https://jira.ez.no/browse/EZP-28224

This is a follow-up to https://github.com/ezsystems/repository-forms/pull/190, where the tests weren't passing on PHP5.6 (and probably a bug fix to https://github.com/ezsystems/repository-forms/pull/187)

Function `array_column` works on objects only since PHP7 [(Ref),](http://www.php.net/manual/en/function.array-column.php) `$contentTypeDraft->getFieldDefinitions()` returns an array of `FieldDefinition` objects. Changing it to `array_map` should do the trick.