### PR TITLE
EZP-28224: Fix Behat tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     # For functional tests
     - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - SYMFONY_ENV=behat
+    - SYMFONY_DEBUG=1
 
 matrix:
   # mark as finished before allow_failures are run

--- a/features/Context/PagelayoutContext.php
+++ b/features/Context/PagelayoutContext.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\Assert as Assertion;
 
 class PagelayoutContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {
+    /** @var string Regex matching the way the Twig template name is inserted in debug mode */
+    const TWIG_DEBUG_STOP_REGEX = '<!-- STOP .*%s.* -->';
+
     /**
      * @var ConfigResolverInterface
      */
@@ -30,7 +33,7 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
      */
     public function aPagelayoutIsConfigured()
     {
-        $this->configResolver->hasParameter('pagelayout');
+        Assertion::assertTrue($this->configResolver->hasParameter('pagelayout'));
     }
 
     /**
@@ -38,9 +41,8 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
      */
     public function itIsRenderedUsingTheConfiguredPagelayout()
     {
-        Assertion::assertContains(
-            sprintf('<!-- STOP %s -->', $this->configResolver->getParameter('pagelayout')),
-            $this->getSession()->getPage()->getOuterHtml()
-        );
+        $pageLayout = $this->configResolver->getParameter('pagelayout');
+        $searchedPattern = sprintf(self::TWIG_DEBUG_STOP_REGEX, preg_quote($pageLayout, null));
+        Assertion::assertRegExp($searchedPattern, $this->getSession()->getPage()->getOuterHtml());
     }
 }

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -27,6 +27,9 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
 {
     use RepositoryContext;
 
+    /** @var string Regex matching the way the Twig template name is inserted in debug mode */
+    const TWIG_DEBUG_STOP_REGEX = '<!-- STOP .*%s.* -->';
+
     private static $password = 'publish';
 
     private static $language = 'eng-GB';
@@ -336,7 +339,8 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     public function thePageIsRenderedUsingTheTemplateConfiguredIn($template)
     {
         $html = $this->getSession()->getPage()->getOuterHtml();
-        $found = (strpos($html, sprintf('<!-- STOP %s -->', $template)) !== false);
+        $searchedPattern = sprintf(self::TWIG_DEBUG_STOP_REGEX, preg_quote($template, null));
+        $found = preg_match($searchedPattern, $html) === 1;
 
         if (!$found && strpos($template, ':') === false) {
             $alternativeTemplate = sprintf(
@@ -344,7 +348,8 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
                 dirname($template),
                 basename($template)
             );
-            $found = (strpos($html, sprintf('<!-- STOP %s -->', $alternativeTemplate)) !== false);
+            $searchedPattern = sprintf(self::TWIG_DEBUG_STOP_REGEX, preg_quote($alternativeTemplate, null));
+            $found = preg_match($searchedPattern, $html) === 1;
         }
 
         Assert::assertTrue(

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -42,10 +42,10 @@ Scenario: The user registration templates can be customized
           default:
             user_registration:
               templates:
-                form: 'user/registration_form.html.twig'
-                confirmation: 'user/registration_confirmation.html.twig'
+                form: 'AppBundle:user:registration_form.html.twig'
+                confirmation: 'AppBundle:user:registration_confirmation.html.twig'
       """
-      And the following template in "app/Resources/views/user/registration_form.html.twig":
+      And the following template in "src/AppBundle/Resources/views/user/registration_form.html.twig":
       """
       {% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
 
@@ -57,7 +57,7 @@ Scenario: The user registration templates can be customized
           </section>
       {% endblock %}
       """
-      And the following template in "app/Resources/views/user/registration_confirmation.html.twig":
+      And the following template in "src/AppBundle/Resources/views/user/registration_confirmation.html.twig":
       """
       {% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-28224

Three things had to be changed in order to make the tests pass:
1. Enabling Debug mode - the tests are searching for strings like 
```
<!-- START src/AppBundle/Resources/views/user/registration_form.html.twig (AppBundle:user:registration_form.html.twig) -->
```
in the page source, which AFAIK are only displayed when Debug is enabled.

2. Changing the way these strings are searched for: recently the format changed a bit (https://github.com/ezsystems/ezpublish-kernel/pull/2285), I've switched to Regex to account for that.

3. Permissions: tests were trying to create a directory in `app/Resources`, but by default the www-data is owner of the `app/config` and `src` (https://github.com/ezsystems/ezplatform/blob/1.7/bin/.travis/trusty/setup_from_external_repo.sh#L68). I've switched the tests so that they are creating it in `src/AppBundle` now.
