### PR TITLE
EZP-28224: Fix Behat in 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "2.0",
+        "_ezplatform_branch_for_behat_tests": "2.1",
         "branch-alias": {
             "dev-master": "2.1.x-dev",
             "dev-tmp_ci_branch": "2.1.x-dev"

--- a/features/Context/ContentEdit.php
+++ b/features/Context/ContentEdit.php
@@ -140,7 +140,7 @@ final class ContentEdit extends MinkContext implements Context, SnippetAccepting
     public function thereIsARelevantErrorMessageLinkedToTheInvalidField()
     {
         $selector = sprintf(
-            '#ezrepoforms_content_edit_fieldsData_%s div.has-error ul li',
+            '#ezrepoforms_content_edit_fieldsData_%s div ul li',
             self::$constrainedFieldIdentifier
         );
 

--- a/features/Context/UserRegistrationContext.php
+++ b/features/Context/UserRegistrationContext.php
@@ -223,7 +223,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      */
     public function iClickOnTheRegisterButton()
     {
-        $this->getSession()->getPage()->pressButton('ezrepoforms_user_register[publish]');
+        $this->getSession()->getPage()->pressButton('ezrepoforms_user_register[register]');
         $this->assertSession()->statusCodeEquals(200);
     }
 

--- a/features/FieldTypeForm/checkbox_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/checkbox_fieldtype_edit_form.feature
@@ -8,10 +8,10 @@ Background:
 
 Scenario: The attributes of the field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain an identifiable widget for that field definition
+    Then the edit form should contain an identifiable widget for ezboolean field definition
      And it should contain a checkbox input field
 
 Scenario: The input fields are flagged as required when the field definition is required
     Given the field definition is required
      When I view the edit form for this field
-     Then the value input fields should be flagged as required
+     Then the value input fields for ezboolean field should be flagged as required

--- a/features/FieldTypeForm/selection_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/selection_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of the field have a form representation
     Given I view the edit form for this field
-     Then the edit form should contain an identifiable widget for that field definition
+     Then the edit form should contain an identifiable widget for ezselection field definition
       And it should contain a select field
 
 Scenario: The options added to a field definition have a form representation

--- a/features/FieldTypeForm/textline_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/textline_fieldtype_edit_form.feature
@@ -8,10 +8,10 @@ Background:
 
 Scenario: The attributes of a textline field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain an identifiable widget for that field definition
+    Then the edit form should contain an identifiable widget for textline field definition
      And it should contain a text input field
 
 Scenario: The input fields are flagged as required when the field definition is required
     Given the field definition is required
      When I view the edit form for this field
-     Then the value input fields should be flagged as required
+     Then the value input fields for textline field should be flagged as required

--- a/features/FieldTypeForm/user_fieldtype_edit_form.feature
+++ b/features/FieldTypeForm/user_fieldtype_edit_form.feature
@@ -8,7 +8,7 @@ Background:
 
 Scenario: The attributes of a user field have a form representation
     When I view the edit form for this field
-    Then the edit form should contain an identifiable widget for that field definition
+    Then the edit form should contain an identifiable widget for user field definition
      And it should contain the following set of labels, and input fields of the following types:
          | label | type |
          | Username | text |
@@ -19,4 +19,4 @@ Scenario: The attributes of a user field have a form representation
 Scenario: The input fields are flagged as required when the field definition is required
     Given the field definition is marked as required
      When I view the edit form for this field
-     Then the value input fields should be flagged as required
+     Then the value input fields for user field should be flagged as required

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -50,11 +50,11 @@ Scenario: The user registration templates can be customized
       {% extends noLayout is defined and noLayout == true ? viewbaseLayout : pagelayout %}
 
       {% block content %}
-          {% import "EzSystemsRepositoryFormsBundle:Content:content_form.html.twig" as contentForms %}
-
           <section class="ez-content-edit">
-              {{ contentForms.display_form(form) }}
-          </section>
+            {{ form_start(form) }}
+            {{- form_widget(form.fieldsData) -}}
+            {{ form_end(form) }}
+           </section>
       {% endblock %}
       """
       And the following template in "src/AppBundle/Resources/views/user/registration_confirmation.html.twig":


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28224](https://jira.ez.no/browse/EZP-28224)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | 1 failure - see description for details
| **Doc needed**     | no

**Description**
Things done:
1) User fieldType has a different selector than other fields, tests are not taking it into account
2) The `has-error` class is no longer used when validating fields
3) Previously the tests were checking whether all the fields are set as required when fieldType is set as required. It had to be changed, because required User field does not have the "Enabled" field as required (allowing the user to change it). Added a way to handle exceptions like this

**Note**
One test is still failing because it detects an issue: https://jira.ez.no/browse/EZP-29091
I've decided not to disable it (because there is *probably* nothing wrong with the test).