### PR TITLE
EZP-29119: Display proper validation error message when non-image file uploaded in image FieldType

### DIFF
--- a/lib/Form/Type/FieldType/ImageFieldType.php
+++ b/lib/Form/Type/FieldType/ImageFieldType.php
@@ -44,6 +44,9 @@ class ImageFieldType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['translation_domain' => 'ezrepoforms_fieldtype']);
+        $resolver->setDefaults([
+            'translation_domain' => 'ezrepoforms_fieldtype',
+            'error_bubbling' => false,
+        ]);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29119
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR is also fixing doubled error messages (backend). See also https://github.com/ezsystems/ezplatform-admin-ui/pull/507

<img width="1127" alt="screen shot 2018-06-13 at 3 32 22 pm" src="https://user-images.githubusercontent.com/1654712/41354642-c8e9fa3e-6f1f-11e8-8fd2-a42b9b731c52.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review