### PR TITLE
Symfony 4.x: aliased service to avoid autowiring notice

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -346,5 +346,7 @@ services:
         tags:
             - { name: 'form.type', alias: 'ezrepoforms_url_edit' }
 
+    EzSystems\RepositoryForms\ConfigResolver\MaxUploadSize: ~
+
     ezrepoforms.config_resolver.max_upload_size:
-        class: EzSystems\RepositoryForms\ConfigResolver\MaxUploadSize
+        alias: EzSystems\RepositoryForms\ConfigResolver\MaxUploadSize


### PR DESCRIPTION
> [EZP-29409](https://jira.ez.no/browse/EZP-29409)

The `MaxUploadSize` class was wired as a dependency of `BinaryBaseFieldType` while it wasn't named after its type. It generated a warning:

```
Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "ezrepoforms.config_resolver.max_upload_size" service to "EzSystems\RepositoryForms\ConfigResolver\MaxUploadSize" instead.
```

This fixes it by making the FQN the service name, and aliasing the previous name to it.