### PR TITLE
EZP-29448: HTTP protocol shouldn't be automatically added to the ezurl value

### DIFF
--- a/lib/Form/Type/FieldType/UrlFieldType.php
+++ b/lib/Form/Type/FieldType/UrlFieldType.php
@@ -45,6 +45,7 @@ class UrlFieldType extends AbstractType
                 [
                     'label' => /** @Desc("URL") */ 'content.field_type.ezurl.link',
                     'required' => $options['required'],
+                    'default_protocol' => null,
                 ]
             )
             ->add(


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29448
> Depends on: https://github.com/ezsystems/ezpublish-kernel-ee/pull/161

## Description 

This PR fixes bug reported by the community on Slack: https://ezcommunity.slack.com/archives/C3YFR5ZM4/p1532171743000003.  Currently user is not able to use other protocols then http and https as URL field type value.


Ref. http://symfony.com/doc/current/reference/forms/types/url.html#default-protocol