### PR TITLE
EZP-29138: Author FieldType isn't prefilled with logged user data

### DIFF
--- a/lib/Form/Type/FieldType/AuthorFieldType.php
+++ b/lib/Form/Type/FieldType/AuthorFieldType.php
@@ -24,26 +24,37 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class AuthorFieldType extends AbstractType
 {
-    /**
-     * @var \eZ\Publish\API\Repository\Repository
-     */
+    /** @var \eZ\Publish\API\Repository\Repository */
     private $repository;
 
+    /**
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     */
     public function __construct(Repository $repository)
     {
         $this->repository = $repository;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return $this->getBlockPrefix();
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'ezplatform_fieldtype_ezauthor';
     }
 
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -52,6 +63,9 @@ class AuthorFieldType extends AbstractType
             ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'filterOutEmptyAuthors']);
     }
 
+    /**
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['data_class' => Value::class]);
@@ -60,7 +74,7 @@ class AuthorFieldType extends AbstractType
     /**
      * Returns a view transformer which handles empty row needed to display add/remove buttons.
      *
-     * @return DataTransformerInterface
+     * @return \Symfony\Component\Form\DataTransformerInterface
      */
     public function getViewTransformer(): DataTransformerInterface
     {
@@ -76,7 +90,7 @@ class AuthorFieldType extends AbstractType
     }
 
     /**
-     * @param FormEvent $event
+     * @param \Symfony\Component\Form\FormEvent $event
      */
     public function filterOutEmptyAuthors(FormEvent $event)
     {
@@ -95,9 +109,9 @@ class AuthorFieldType extends AbstractType
     /**
      * Returns currently logged user data, or empty Author object if none was found.
      *
-     * @return Author
+     * @return \eZ\Publish\Core\FieldType\Author\Author
      */
-    private function fetchLoggedAuthor()
+    private function fetchLoggedAuthor(): Author
     {
         $author = new Author();
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29318](https://jira.ez.no/browse/EZP-29318)
| **Bug/Improvement**| yes
| **Target version** | 2.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Author FieldType is prefilled with the data of the currently logged user (name, e-mail), to be consistent with 5.4 and v1. As a followup, I'll create PR's which will enable an editor to decide whether this FieldType should be prefilled by default at the creation Content Type level. Implementation goes to `repository-forms` as fetching current user data based on repository in `ezpublish-kernel` is quite problematic. Ref: https://github.com/ezsystems/ezpublish-kernel/pull/2392

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
