### PR TITLE
EZP-29508: As an editor I want to manage ALT field with an image asset field type

### DIFF
--- a/bundle/Resources/translations/ezrepoforms_fieldtype.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_fieldtype.en.xlf
@@ -61,6 +61,11 @@
         <target>Width</target>
         <note>key: content.field_type.ezmedia.width</note>
       </trans-unit>
+      <trans-unit id="56f2bad53d241371a48f88accc3ef08a9bc643b6" resname="content.field_type.ezimageasset.alternative_text">
+        <source>Alternative text</source>
+        <target>Alternative text</target>
+        <note>key: content.field_type.ezimageasset.alternative_text</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/lib/FieldType/DataTransformer/ImageAssetValueTransformer.php
+++ b/lib/FieldType/DataTransformer/ImageAssetValueTransformer.php
@@ -35,7 +35,10 @@ class ImageAssetValueTransformer extends AbstractBinaryBaseTransformer implement
 
         return array_merge(
             $this->getDefaultProperties(),
-            ['destinationContentId' => $value->destinationContentId]
+            [
+                'destinationContentId' => $value->destinationContentId,
+                'alternativeText' => $value->alternativeText,
+            ]
         );
     }
 
@@ -58,6 +61,6 @@ class ImageAssetValueTransformer extends AbstractBinaryBaseTransformer implement
             );
         }
 
-        return new Value($value['destinationContentId']);
+        return new Value($value['destinationContentId'], $value['alternativeText']);
     }
 }

--- a/lib/Form/Type/FieldType/ImageAssetFieldType.php
+++ b/lib/Form/Type/FieldType/ImageAssetFieldType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -79,6 +80,13 @@ class ImageAssetFieldType extends AbstractType
                         ]),
                     ],
                     'mapped' => false,
+                ]
+            )
+            ->add(
+                'alternativeText',
+                TextType::class,
+                [
+                    'label' => /** @Desc("Alternative text") */ 'content.field_type.ezimageasset.alternative_text',
                 ]
             );
     }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29508
> Depends on: https://github.com/ezsystems/ezpublish-kernel/pull/2451

## Description

Impl. possibility to define Alternative Text for Image Asset. 

<img width="1016" alt="zrzut ekranu 2018-09-18 o 13 03 44" src="https://user-images.githubusercontent.com/211967/45683251-49ca5580-bb43-11e8-8709-7ae707155106.png">


