### PR TITLE
[Composer] [Travis] Use 2.3 branch in metarepo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "2.3",
         "branch-alias": {
             "dev-master": "2.3.x-dev",
             "dev-tmp_ci_branch": "2.3.x-dev"


### PR DESCRIPTION
This is required to run Behat tests on 2.3 and not on master.