### PR TITLE
EZP-29518: ContentType option "Default field for sorting children" has no effect on new created objects

### DIFF
--- a/lib/Content/View/Filter/ContentCreateViewFilter.php
+++ b/lib/Content/View/Filter/ContentCreateViewFilter.php
@@ -96,7 +96,7 @@ class ContentCreateViewFilter implements EventSubscriberInterface
             $contentType,
             [
                 'mainLanguageCode' => $languageCode,
-                'parentLocation' => $this->locationService->newLocationCreateStruct($location->id),
+                'parentLocation' => $this->locationService->newLocationCreateStruct($location->id, $contentType),
             ]
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29518](https://jira.ez.no/browse/EZP-29518)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `2.3+`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is the required modification for https://github.com/ezsystems/ezpublish-kernel/pull/2428 to have full effect in v2.