### PR TITLE
EZP-29748: Replacing the outdated verbiage of eZ Publish from eZ Platform when adding a Policy

### DIFF
--- a/lib/Form/Type/Role/LimitationType.php
+++ b/lib/Form/Type/Role/LimitationType.php
@@ -77,7 +77,7 @@ class LimitationType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => '\eZ\Publish\API\Repository\Values\User\Limitation',
-            'translation_domain' => 'ezrepoforms_role',
+            'translation_domain' => 'ezrepoforms_policies',
         ]);
     }
 

--- a/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
+++ b/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
@@ -9,6 +9,7 @@ namespace EzSystems\RepositoryForms\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
+use EzSystems\RepositoryForms\Translation\LimitationTranslationExtractor;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 
@@ -28,7 +29,7 @@ abstract class MultipleSelectionBasedMapper implements LimitationFormMapperInter
     {
         $options = $this->getChoiceFieldOptions() + [
             'multiple' => true,
-            'label' => $data->getIdentifier(),
+            'label' => LimitationTranslationExtractor::identifierToLabel($data->getIdentifier()),
             'required' => false,
         ];
         $choices = $this->getSelectionChoices();

--- a/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueTransformer;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
 use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+use EzSystems\RepositoryForms\Translation\LimitationTranslationExtractor;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormInterface;
 
@@ -69,7 +70,7 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
             $form->getConfig()->getFormFactory()->createBuilder()
                 ->create('limitationValues', HiddenType::class, [
                     'required' => false,
-                    'label' => $data->getIdentifier(),
+                    'label' => LimitationTranslationExtractor::identifierToLabel($data->getIdentifier()),
                 ])
                 ->addModelTransformer(new UDWBasedValueTransformer())
                 // Deactivate auto-initialize as we're not on the root form.

--- a/lib/Translation/LimitationTranslationExtractor.php
+++ b/lib/Translation/LimitationTranslationExtractor.php
@@ -23,8 +23,6 @@ class LimitationTranslationExtractor implements ExtractorInterface
     private $policyMap;
 
     /**
-     * LimitationTranslationExtractor constructor.
-     *
      * @param array $policyMap
      */
     public function __construct(array $policyMap)
@@ -50,6 +48,16 @@ class LimitationTranslationExtractor implements ExtractorInterface
         }
 
         return $catalogue;
+    }
+
+    /**
+     * @param string $limitationIdentifier
+     *
+     * @return string
+     */
+    public static function identifierToLabel(string $limitationIdentifier): string
+    {
+        return self::MESSAGE_ID_PREFIX . strtolower($limitationIdentifier);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29748
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2018-10-24 at 11 18 56 am](https://user-images.githubusercontent.com/1654712/47420727-692a5300-d77f-11e8-90be-33d46d79dcb6.png)


![screen shot 2018-10-24 at 11 21 02 am](https://user-images.githubusercontent.com/1654712/47420729-692a5300-d77f-11e8-83b6-0f74755b9e96.png)

See [https://github.com/ezsystems/ezplatform-admin-ui/pull/701](https://github.com/ezsystems/ezplatform-admin-ui/pull/701) [https://github.com/ezsystems/ezplatform/pull/336](https://github.com/ezsystems/ezplatform/pull/336)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
