### PR TITLE
Install ezpublish-kernel with @dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "ezsystems/ezpublish-kernel": "^7.0",
+        "ezsystems/ezpublish-kernel": "^7.0@dev",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3"
     },


### PR DESCRIPTION
Checking if installing kernel with @dev helps with failing unit tests:
https://travis-ci.org/ezsystems/repository-forms/builds/467887329

AdminUI, which also runs Unit Tests, has kernel set that way already (https://github.com/ezsystems/ezplatform-admin-ui/blob/master/composer.json#L19).