### PR TITLE
EZP-29849: Allow user to remove location in subtree limitation

### DIFF
--- a/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
@@ -11,7 +11,6 @@ namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\API\Repository\Values\Content\Location;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 

--- a/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * DataTransformer for UDWBasedMapper.
+ *
+ * Needed to display the form field correctly and transform it back to an appropriate value object.
+ */
+class UDWBasedValueModelTransformer implements DataTransformerInterface
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     */
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        try {
+            return array_map(function (string $path) {
+                return $this->locationService->loadLocation(
+                    $this->extractLocationIdFromPath($path)
+                );
+            }, $value);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        return array_map(function(Location $location) {
+            return $location->id;
+        }, $value);
+    }
+
+    /**
+     * Extracts and returns an item id from a path, e.g. /1/2/58/ => 58.
+     *
+     * @param string $path
+     *
+     * @return string|null
+     */
+    private function extractLocationIdFromPath(string $path): ?string
+    {
+        $pathParts = explode('/', trim($path, '/'));
+
+        return array_pop($pathParts);
+    }
+}

--- a/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
@@ -62,7 +62,7 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
             return null;
         }
 
-        return array_map(function(Location $location) {
+        return array_map(function (Location $location) {
             return $location->id;
         }, $value);
     }

--- a/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueModelTransformer.php
@@ -62,9 +62,7 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
             return null;
         }
 
-        return array_map(function (Location $location) {
-            return $location->id;
-        }, $value);
+        return array_column($value, 'id');
     }
 
     /**

--- a/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueTransformer.php
@@ -8,48 +8,9 @@
  */
 namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
 
-use Symfony\Component\Form\DataTransformerInterface;
-
 /**
- * DataTransformer for UDWBasedMapper.
- * Needed to display the form field correctly and transform it back to an appropriate value object.
+ * @deprecated since v2.5.0. Use \EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueModelTransformer instead.
  */
-class UDWBasedValueTransformer implements DataTransformerInterface
+class UDWBasedValueTransformer extends UDWBasedValueModelTransformer
 {
-    public function transform($value)
-    {
-        if (!is_array($value)) {
-            return null;
-        }
-
-        $locations = [];
-        foreach ($value as $key => $path) {
-            $locations[] = $this->extractLocationIdFromPath($path);
-        }
-
-        return implode(',', $locations);
-    }
-
-    public function reverseTransform($value)
-    {
-        if (!is_string($value)) {
-            return null;
-        }
-
-        return explode(',', $value);
-    }
-
-    /**
-     * Extracts and returns an item id from a path, e.g. /1/2/58 => 58.
-     *
-     * @param string $path
-     *
-     * @return mixed
-     */
-    private function extractLocationIdFromPath($path)
-    {
-        $pathParts = explode('/', trim($path, '/'));
-
-        return array_pop($pathParts);
-    }
 }

--- a/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
@@ -51,9 +51,7 @@ class UDWBasedValueViewTransformer implements DataTransformerInterface
         }
 
         try {
-            return array_map(function ($id) {
-                return $this->locationService->loadLocation($id);
-            }, explode(self::DELIMITER, $value));
+            return array_map([$this->locationService, 'loadLocation'], explode(self::DELIMITER, $value));
         } catch (NotFoundException | UnauthorizedException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
@@ -11,7 +11,6 @@ namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\API\Repository\Values\Content\Location;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 

--- a/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
@@ -39,9 +39,7 @@ class UDWBasedValueViewTransformer implements DataTransformerInterface
             return null;
         }
 
-        return implode(self::DELIMITER, array_map(function (Location $location) {
-            return $location->id;
-        }, $value));
+        return implode(self::DELIMITER, array_column($value, 'id'));
     }
 
     /**

--- a/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
+++ b/lib/Limitation/DataTransformer/UDWBasedValueViewTransformer.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Limitation\DataTransformer;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class UDWBasedValueViewTransformer implements DataTransformerInterface
+{
+    const DELIMITER = ',';
+
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     */
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        return implode(self::DELIMITER, array_map(function (Location $location) {
+            return $location->id;
+        }, $value));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (!is_string($value) || $value === '') {
+            return $value;
+        }
+
+        try {
+            return array_map(function ($id) {
+                return $this->locationService->loadLocation($id);
+            }, explode(self::DELIMITER, $value));
+        } catch (NotFoundException | UnauthorizedException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueTransformer;
+use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueViewTransformer;
 use EzSystems\RepositoryForms\Limitation\LimitationFormMapperInterface;
 use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 use EzSystems\RepositoryForms\Translation\LimitationTranslationExtractor;
@@ -67,12 +68,14 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
     {
         $form->add(
             // Creating from FormBuilder as we need to add a DataTransformer.
-            $form->getConfig()->getFormFactory()->createBuilder()
+            $form->getConfig()->getFormFactory()
+                ->createBuilder()
                 ->create('limitationValues', HiddenType::class, [
                     'required' => false,
                     'label' => LimitationTranslationExtractor::identifierToLabel($data->getIdentifier()),
                 ])
-                ->addModelTransformer(new UDWBasedValueTransformer())
+                ->addViewTransformer(new UDWBasedValueViewTransformer($this->locationService))
+                ->addModelTransformer(new UDWBasedValueTransformer($this->locationService))
                 // Deactivate auto-initialize as we're not on the root form.
                 ->setAutoInitialize(false)->getForm()
         );

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
@@ -39,7 +39,7 @@ class UDWBasedValueModelTransformerTest extends TestCase
     {
         $this->locationService
             ->method('loadLocation')
-            ->willReturnCallback(function($id) {
+            ->willReturnCallback(function ($id) {
                 return $this->createLocation($id);
             });
 
@@ -49,19 +49,19 @@ class UDWBasedValueModelTransformerTest extends TestCase
     public function dataProviderForTransform(): array
     {
         return [
-            [ null, null ],
+            [null, null],
             [
                 [
                     '/1/2/54/',
                     '/1/2/54/56/',
-                    '/1/2/54/58/'
+                    '/1/2/54/58/',
                 ],
                 [
                     $this->createLocation(54),
                     $this->createLocation(56),
                     $this->createLocation(58),
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -101,15 +101,15 @@ class UDWBasedValueModelTransformerTest extends TestCase
     public function dataProviderForReverseTransform(): array
     {
         return [
-            [ null, null ],
+            [null, null],
             [
                 [
                     $this->createLocation(54),
                     $this->createLocation(56),
                     $this->createLocation(58),
                 ],
-                [ 54, 56, 58 ],
-            ]
+                [54, 56, 58],
+            ],
         ];
     }
 

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
@@ -120,6 +120,10 @@ class UDWBasedValueModelTransformerTest extends TestCase
             ->method('__get')
             ->with('id')
             ->willReturn($id);
+        $location
+            ->method('__isset')
+            ->with('id')
+            ->willReturn(true);
 
         return $location;
     }

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueModelTransformerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Tests\Limitation\DataTransformer;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueModelTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class UDWBasedValueModelTransformerTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationService;
+
+    /** @var \EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueModelTransformer */
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->transformer = new UDWBasedValueModelTransformer(
+            $this->locationService
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTransform
+     */
+    public function testTransform(?array $given, ?array $expected)
+    {
+        $this->locationService
+            ->method('loadLocation')
+            ->willReturnCallback(function($id) {
+                return $this->createLocation($id);
+            });
+
+        $this->assertEquals($expected, $this->transformer->transform($given));
+    }
+
+    public function dataProviderForTransform(): array
+    {
+        return [
+            [ null, null ],
+            [
+                [
+                    '/1/2/54/',
+                    '/1/2/54/56/',
+                    '/1/2/54/58/'
+                ],
+                [
+                    $this->createLocation(54),
+                    $this->createLocation(56),
+                    $this->createLocation(58),
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTransformThrowsTransformationFailedException
+     */
+    public function testTransformThrowsTransformationFailedException(string $exceptionClass)
+    {
+        $this->expectException(TransformationFailedException::class);
+
+        $this->locationService
+            ->expects($this->any())
+            ->method('loadLocation')
+            ->willThrowException(
+                $this->createMock($exceptionClass)
+            );
+
+        $this->transformer->transform(['/1/2/54']);
+    }
+
+    public function dataProviderForTransformThrowsTransformationFailedException(): array
+    {
+        return [
+            [NotFoundException::class],
+            [UnauthorizedException::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransform
+     */
+    public function testReverseTransform(?array $given, ?array $expected)
+    {
+        $this->assertEquals($expected, $this->transformer->reverseTransform($given));
+    }
+
+    public function dataProviderForReverseTransform(): array
+    {
+        return [
+            [ null, null ],
+            [
+                [
+                    $this->createLocation(54),
+                    $this->createLocation(56),
+                    $this->createLocation(58),
+                ],
+                [ 54, 56, 58 ],
+            ]
+        ];
+    }
+
+    private function createLocation($id): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->method('__get')
+            ->with('id')
+            ->willReturn($id);
+
+        return $location;
+    }
+}

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
@@ -116,6 +116,10 @@ class UDWBasedValueViewTransformerTest extends TestCase
             ->method('__get')
             ->with('id')
             ->willReturn($id);
+        $location
+            ->method('__isset')
+            ->with('id')
+            ->willReturn(true);
 
         return $location;
     }

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
@@ -43,7 +43,7 @@ class UDWBasedValueViewTransformerTest extends TestCase
     public function dataProviderForTransform(): array
     {
         return [
-            [ null, null ],
+            [null, null],
             [
                 [
                     $this->createLocation(54),
@@ -51,7 +51,7 @@ class UDWBasedValueViewTransformerTest extends TestCase
                     $this->createLocation(58),
                 ],
                 '54,56,58',
-            ]
+            ],
         ];
     }
 
@@ -62,7 +62,7 @@ class UDWBasedValueViewTransformerTest extends TestCase
     {
         $this->locationService
             ->method('loadLocation')
-            ->willReturnCallback(function($id) {
+            ->willReturnCallback(function ($id) {
                 return $this->createLocation($id);
             });
 
@@ -72,7 +72,7 @@ class UDWBasedValueViewTransformerTest extends TestCase
     public function dataProviderForReverseTransform(): array
     {
         return [
-            [ null, null ],
+            [null, null],
             [
                 '54,56,58',
                 [
@@ -80,7 +80,7 @@ class UDWBasedValueViewTransformerTest extends TestCase
                     $this->createLocation(56),
                     $this->createLocation(58),
                 ],
-            ]
+            ],
         ];
     }
 

--- a/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
+++ b/tests/RepositoryForms/Limitation/DataTransformer/UDWBasedValueViewTransformerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Tests\Limitation\DataTransformer;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueViewTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class UDWBasedValueViewTransformerTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationService;
+
+    /** @var \EzSystems\RepositoryForms\Limitation\DataTransformer\UDWBasedValueViewTransformer */
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->transformer = new UDWBasedValueViewTransformer(
+            $this->locationService
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTransform
+     */
+    public function testTransform(?array $given, ?string $expected)
+    {
+        $this->assertEquals($expected, $this->transformer->transform($given));
+    }
+
+    public function dataProviderForTransform(): array
+    {
+        return [
+            [ null, null ],
+            [
+                [
+                    $this->createLocation(54),
+                    $this->createLocation(56),
+                    $this->createLocation(58),
+                ],
+                '54,56,58',
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransform
+     */
+    public function testReverseTransform(?string $given, ?array $expected)
+    {
+        $this->locationService
+            ->method('loadLocation')
+            ->willReturnCallback(function($id) {
+                return $this->createLocation($id);
+            });
+
+        $this->assertEquals($expected, $this->transformer->reverseTransform($given));
+    }
+
+    public function dataProviderForReverseTransform(): array
+    {
+        return [
+            [ null, null ],
+            [
+                '54,56,58',
+                [
+                    $this->createLocation(54),
+                    $this->createLocation(56),
+                    $this->createLocation(58),
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransformThrowsTransformationFailedException
+     */
+    public function testReverseTransformThrowsTransformationFailedException(string $exceptionClass)
+    {
+        $this->expectException(TransformationFailedException::class);
+
+        $this->locationService
+            ->expects($this->any())
+            ->method('loadLocation')
+            ->willThrowException(
+                $this->createMock($exceptionClass)
+            );
+
+        $this->transformer->reverseTransform('54,56,58');
+    }
+
+    public function dataProviderForReverseTransformThrowsTransformationFailedException(): array
+    {
+        return [
+            [NotFoundException::class],
+            [UnauthorizedException::class],
+        ];
+    }
+
+    private function createLocation($id): Location
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->method('__get')
+            ->with('id')
+            ->willReturn($id);
+
+        return $location;
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29849

## Description

Changes required to make Location object available during rendering edit form of the location based limitations.  

In the limitation template (e.g. `src/bundle/Resources/views/Limitation/udw_limitation_value.html.twig` in `ezplatform-admin-ui`) location instances are available using `form.limitationValues.vars.data`. The model/view format of data is not changed:

![zrzut ekranu z 2019-01-14 20-32-00](https://user-images.githubusercontent.com/211967/51135967-a1e83e80-183b-11e9-8bd0-c66efb06057e.png)
 

