### PR TITLE
Remove dot from Content Type identifier

### DIFF
--- a/features/Context/ContentType.php
+++ b/features/Context/ContentType.php
@@ -94,7 +94,7 @@ final class ContentType extends RawMinkContext implements Context, SnippetAccept
     public function newContentTypeCreateStruct($identifier = null)
     {
         return $this->contentTypeService->newContentTypeCreateStruct(
-            $identifier ?: $identifier = uniqid('content_type_', true)
+            $identifier ?: $identifier = str_replace('.', '', uniqid('content_type_', true))
         );
     }
 


### PR DESCRIPTION
Similar as in https://github.com/ezsystems/BehatBundle/pull/73 - the dot cannot be used in Content Type identifier.

