### PR TITLE
EZP-30181: Editor is not able to select any item in the ezobjectrelation/ezobjectrelationlist FTs if starting location is not accessible

### DIFF
--- a/lib/FieldType/Mapper/AbstractRelationFormMapper.php
+++ b/lib/FieldType/Mapper/AbstractRelationFormMapper.php
@@ -9,22 +9,33 @@
 namespace EzSystems\RepositoryForms\FieldType\Mapper;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\RepositoryForms\FieldType\FieldValueFormMapperInterface;
 
 abstract class AbstractRelationFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFormMapperInterface
 {
     /**
-     * @var ContentTypeService Used to fetch list of available content types
+     * @var \eZ\Publish\API\Repository\ContentTypeService Used to fetch list of available content types
      */
     protected $contentTypeService;
 
     /**
-     * @param ContentTypeService $contentTypeService
+     * @var \eZ\Publish\API\Repository\LocationService Used to fetch selection root
      */
-    public function __construct(ContentTypeService $contentTypeService)
+    protected $locationService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     */
+    public function __construct(ContentTypeService $contentTypeService, LocationService $locationService)
     {
         $this->contentTypeService = $contentTypeService;
+        $this->locationService = $locationService;
     }
 
     /**
@@ -43,5 +54,24 @@ abstract class AbstractRelationFormMapper implements FieldDefinitionFormMapperIn
         ksort($contentTypeHash);
 
         return $contentTypeHash;
+    }
+
+    /**
+     * Loads location which is starting point for selecting destination content object.
+     *
+     * @param null $defaultLocationId
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
+     */
+    protected function loadDefaultLocationForSelection($defaultLocationId = null): ?Location
+    {
+        if (!empty($defaultLocationId)) {
+            try {
+                return $this->locationService->loadLocation((int)$defaultLocationId);
+            } catch (NotFoundException|UnauthorizedException $e) {
+            }
+        }
+
+        return null;
     }
 }

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -50,6 +50,9 @@ class RelationFormMapper extends AbstractRelationFormMapper
                     ->create('value', RelationFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
                         'label' => $label,
+                        'default_location' => $this->loadDefaultLocationForSelection(
+                            $fieldDefinition->getFieldSettings()['selectionRoot']
+                        ),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -60,6 +60,9 @@ class RelationListFormMapper extends AbstractRelationFormMapper
                         [
                             'required' => $fieldDefinition->isRequired,
                             'label' => $label,
+                            'default_location' => $this->loadDefaultLocationForSelection(
+                                $fieldDefinition->getFieldSettings()['selectionDefaultLocation']
+                            ),
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/Form/Type/FieldType/RelationFieldType.php
+++ b/lib/Form/Type/FieldType/RelationFieldType.php
@@ -7,6 +7,7 @@ namespace EzSystems\RepositoryForms\Form\Type\FieldType;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\FieldType\Relation\Value;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\RelationValueTransformer;
 use Symfony\Component\Form\AbstractType;
@@ -60,6 +61,7 @@ class RelationFieldType extends AbstractType
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['relations'] = [];
+        $view->vars['default_location'] = $options['default_location'];
 
         /** @var Value $data */
         $data = $form->getData();
@@ -84,6 +86,9 @@ class RelationFieldType extends AbstractType
                 'min' => 1,
                 'step' => 1,
             ],
+            'default_location' => null,
         ]);
+
+        $resolver->setAllowedTypes('default_location', ['null', Location::class]);
     }
 }

--- a/lib/Form/Type/FieldType/RelationListFieldType.php
+++ b/lib/Form/Type/FieldType/RelationListFieldType.php
@@ -7,6 +7,7 @@ namespace EzSystems\RepositoryForms\Form\Type\FieldType;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\FieldType\RelationList\Value;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\RelationListValueTransformer;
 use Symfony\Component\Form\AbstractType;
@@ -14,6 +15,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Form Type representing ezobjectrelationlist field type.
@@ -59,6 +61,7 @@ class RelationListFieldType extends AbstractType
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['relations'] = [];
+        $view->vars['default_location'] = $options['default_location'];
 
         /** @var Value $data */
         $data = $form->getData();
@@ -76,5 +79,17 @@ class RelationListFieldType extends AbstractType
                 'contentType' => $contentType,
             ];
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'default_location' => null,
+        ]);
+
+        $resolver->setAllowedTypes('default_location', ['null', Location::class]);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30181

## Description 

Follow up for https://github.com/ezsystems/repository-forms/pull/279. Editor is not able to select any content item as value of the `ezobjectrelation`/`ezobjectrelationlist` field if the starting location is not accessible for some reason (location was trashed or because of lack of permission). In such case we will fallback starting location to null witch is technically content tree root. 

In such case we assume that content tree root should be used as starting point for selection.  
