### PR TITLE
Make default password pass requirements

### DIFF
--- a/lib/Behat/Context/UserRegistrationContext.php
+++ b/lib/Behat/Context/UserRegistrationContext.php
@@ -31,7 +31,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /** @var string Regex matching the way the Twig template name is inserted in debug mode */
     const TWIG_DEBUG_STOP_REGEX = '<!-- STOP .*%s.* -->';
 
-    private static $password = 'publish';
+    private static $password = 'PassWord42';
 
     private static $language = 'eng-GB';
 


### PR DESCRIPTION
After https://github.com/ezsystems/ezpublish-kernel/pull/2570 the repository-forms tests started failing with:
```
  Scenario: Registration is disabled for users who do not have the "user/register" policy # vendor/ezsystems/repository-forms/features/User/Registration/user_registration.feature:6
    Given I do not have the user/register policy                                          # EzSystems\RepositoryForms\Behat\Context\UserRegistrationContext::loginAsUserWithoutRegisterPolicy()
      eZ\Publish\Core\Base\Exceptions\UserPasswordValidationException: Argument 'password' is invalid: Password doesn't match the following rules: User password must be at least 10 characters long, User password must include at least one upper case letter, User password must include at least one number in vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/UserService.php:426
      Stack trace:
```
(https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/186837637)

as the `publish` password does not meet the requirements. Adjusting it so that it passes.

