### PR TITLE
Fixed ez_policy_limitation translation extractor for no limitations case

### DIFF
--- a/lib/Translation/LimitationTranslationExtractor.php
+++ b/lib/Translation/LimitationTranslationExtractor.php
@@ -62,6 +62,10 @@ class LimitationTranslationExtractor implements ExtractorInterface
         $limitationTypes = [];
         foreach ($this->policyMap as $module) {
             foreach ($module as $policy) {
+                if (null === $policy) {
+                    continue;
+                }
+
                 foreach (array_keys($policy) as $limitationType) {
                     if (!in_array($limitationType, $limitationTypes)) {
                         $limitationTypes[] = $limitationType;

--- a/tests/RepositoryForms/Translation/LimitationTranslationExtractorTest.php
+++ b/tests/RepositoryForms/Translation/LimitationTranslationExtractorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Tests\Translation;
+
+use EzSystems\RepositoryForms\Translation\LimitationTranslationExtractor;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Test extracting translation messages for eZ Platform permission system policy map.
+ */
+class LimitationTranslationExtractorTest extends TestCase
+{
+    /**
+     * Test extracting messages.
+     */
+    public function testExtract()
+    {
+        $policyMap = Yaml::parseFile(__DIR__ . '/fixtures/input_policies.yaml');
+
+        $extractor = new LimitationTranslationExtractor($policyMap);
+
+        $actualMessageCatalogue = $extractor->extract();
+
+        self::assertEquals($this->getExpectedMessageCatalogue(), $actualMessageCatalogue);
+    }
+
+    /**
+     * Get expected MessageCatalogue object created by the extractor.
+     *
+     * @return \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    private function getExpectedMessageCatalogue(): MessageCatalogue
+    {
+        $messageCatalogue = new MessageCatalogue();
+
+        // create artificial set of messages which is aligned with what gets extracted from the input fixture
+        for ($i = 1; $i <= 5; ++$i) {
+            $id = "policy.limitation.identifier.limitation{$i}";
+            $translated = "Limitation{$i}";
+
+            $message = new Message\XliffMessage($id, 'ezrepoforms_policies');
+            $message->setNew(false);
+            $message->setMeaning($translated);
+            $message->setDesc($translated);
+            $message->setLocaleString($translated);
+            $message->addNote('key: ' . $id);
+
+            $messageCatalogue->add($message);
+        }
+
+        return $messageCatalogue;
+    }
+}

--- a/tests/RepositoryForms/Translation/fixtures/input_policies.yaml
+++ b/tests/RepositoryForms/Translation/fixtures/input_policies.yaml
@@ -1,0 +1,9 @@
+module1:
+    function1: { Limitation1: true }
+    function2: { Limitation2: true, Limitation3: true }
+    function3: { Limitation1: true, Limitation2: true }
+    function4: ~
+
+module2:
+    function1: ~
+    function2: { Limitation4: false, Limitation5: true }


### PR DESCRIPTION
| Question | Answer
| --- | ---
| **Bug** | yes
| **Target version** | `2.3` and up

There are [some policies which don't have any limitation defined](https://github.com/ezsystems/ezpublish-kernel/blob/v7.3.5/eZ/Publish/Core/settings/policies.yml#L17-L21), which results in `ez_policy_limitation` translation extractor crashing when trying to generate translations for new limitations.

Steps to reproduce: 
1. Clone eZ Platform meta repository.
2. Execute:
```bash
./bin/console translation:extract --enable-extractor=ez_policy_limitation --domain=ezrepoforms_policies --output-format=xlf --output-dir=./vendor/ezsystems/repository-forms/bundle/Resources/translations/  --dir=./vendor/ezsystems/repository-forms/bundle
```
3. Observe the following error:
```bash
In LimitationTranslationExtractor.php line 73:
                                                                     
  Warning: array_keys() expects parameter 1 to be array, null given  
                                                                     
```

**TODO**:
- [x] Take into the account policies without limitations.
- [x] Implement test covering the `LimitationTranslationExtractor`