### PR TITLE
EZP-30344: Implemented Translation Limitation Mapper

### DIFF
--- a/bundle/Resources/config/role.yml
+++ b/bundle/Resources/config/role.yml
@@ -172,6 +172,13 @@ services:
             - { name: ez.limitation.formMapper, limitationType: Language }
             - { name: ez.limitation.valueMapper, limitationType: Language }
 
+    EzSystems\RepositoryForms\Limitation\Mapper\TranslationLimitationMapper:
+        parent: ezrepoforms.limitation.form_mapper.multiple_selection
+        arguments: ["@ezpublish.api.service.language"]
+        tags:
+            - { name: ez.limitation.formMapper, limitationType: Translation }
+            - { name: ez.limitation.valueMapper, limitationType: Translation }
+
     ezrepoforms.limitation.form_mapper.owner:
         parent: ezrepoforms.limitation.form_mapper.multiple_selection
         class: "%ezrepoforms.limitation.form_mapper.owner.class%"

--- a/bundle/Resources/translations/ezrepoforms_policies.en.xlf
+++ b/bundle/Resources/translations/ezrepoforms_policies.en.xlf
@@ -81,6 +81,11 @@
         <target>Subtree of Location</target>
         <note>key: policy.limitation.identifier.subtree</note>
       </trans-unit>
+      <trans-unit id="02acf5d15c39735f2588b47274fbc987cddd1c86" resname="policy.limitation.identifier.translation">
+        <source>Translation</source>
+        <target>Translation</target>
+        <note>key: policy.limitation.identifier.translation</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/bundle/Resources/views/limitation_values.html.twig
+++ b/bundle/Resources/views/limitation_values.html.twig
@@ -21,6 +21,14 @@
 {% endspaceless %}
 {% endblock %}
 
+{% block ez_limitation_translation_value %}
+{% spaceless %}
+    {% for value in values %}
+        {{ value.name }}{% if not loop.last %},{% else %}{% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}
+
 {% block ez_limitation_node_value %}
 {% spaceless %}
     {% for path in values %}

--- a/lib/Limitation/Mapper/TranslationLimitationMapper.php
+++ b/lib/Limitation/Mapper/TranslationLimitationMapper.php
@@ -12,6 +12,11 @@ use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
 
+/**
+ * Map possible or selected Translation Limitation values to a multiple selection form input.
+ *
+ * @see \eZ\Publish\API\Repository\Values\User\Limitation\TranslationLimitation
+ */
 class TranslationLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /**
@@ -44,7 +49,7 @@ class TranslationLimitationMapper extends MultipleSelectionBasedMapper implement
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language[]
      */
-    public function mapLimitationValue(Limitation $limitation)
+    public function mapLimitationValue(Limitation $limitation): array
     {
         $languages = $this->languageService->loadLanguageListByCode($limitation->limitationValues);
 

--- a/lib/Limitation/Mapper/TranslationLimitationMapper.php
+++ b/lib/Limitation/Mapper/TranslationLimitationMapper.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\RepositoryForms\Limitation\Mapper;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+
+class TranslationLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LanguageService
+     */
+    private $languageService;
+
+    public function __construct(LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+
+    /**
+     * Get list of all possible translations.
+     *
+     * @return string[]
+     */
+    protected function getSelectionChoices(): array
+    {
+        $choices = [];
+        foreach ($this->languageService->loadLanguages() as $language) {
+            $choices[$language->languageCode] = $language->name;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Language[]
+     */
+    public function mapLimitationValue(Limitation $limitation)
+    {
+        $languages = $this->languageService->loadLanguageListByCode($limitation->limitationValues);
+
+        return array_values($languages);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30344](https://jira.ez.no/browse/EZP-30344)
| **Requires** | ezsystems/ezpublish-kernel#2585
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.5` for eZ Platform `2.5 LTS`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | yes

This PR implements Translation Limitation aimed to limit ability of a user to create, edit and publish content only when modifying one of the translations give by limitation values.

**TODO**:
- [x] Implement `TranslationLimitationMapper` for `Translation` Limitation.
- [x] Add default translation for the label shown for `Translation` choices.
- [x] Fix new code according to Coding Standards (`$ composer fix`).
- [x] Ask for Code Review.
