### PR TITLE
EZP-30462: Change `ez.fieldFormMapper` tag to `ezplatform.field_type.form_mapper`

### DIFF
--- a/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -19,10 +19,10 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
     public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = 'ezrepoforms.field_type_form_mapper.dispatcher';
-    public const FIELD_FORM_MAPPER_VALUE = 'ez.fieldFormMapper.value';
-    public const FIELD_FORM_MAPPER_DEFINITION = 'ez.fieldFormMapper.definition';
-    public const EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE = 'ezplatform.field_type.form_mapper.value';
-    public const EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION = 'ezplatform.field_type.form_mapper.definition';
+    public const DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ez.fieldFormMapper.value';
+    public const DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ez.fieldFormMapper.definition';
+    public const FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ezplatform.field_type.form_mapper.value';
+    public const FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG = 'ezplatform.field_type.form_mapper.definition';
 
     public function process(ContainerBuilder $container)
     {
@@ -58,38 +58,38 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
      */
     private function findTaggedFormMapperServices(ContainerBuilder $container): array
     {
-        $ezFieldFormMapperValueTags = $container->findTaggedServiceIds(self::FIELD_FORM_MAPPER_VALUE);
-        $ezFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::FIELD_FORM_MAPPER_DEFINITION);
-        $ezplatformFieldFormMapperValueTags = $container->findTaggedServiceIds(self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE);
-        $ezplatformFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION);
+        $deprecatedFieldFormMapperValueTags = $container->findTaggedServiceIds(self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG);
+        $deprecatedFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG);
+        $fieldFormMapperValueTags = $container->findTaggedServiceIds(self::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG);
+        $fieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG);
 
-        foreach ($ezFieldFormMapperValueTags as $ezFieldFormMapperValueTag) {
+        foreach ($deprecatedFieldFormMapperValueTags as $ezFieldFormMapperValueTag) {
             @trigger_error(
                 sprintf(
                     '`%s` service tag is deprecated and will be removed in eZ Platform 4.0. Please use `%s` instead.',
-                    self::FIELD_FORM_MAPPER_VALUE,
-                    self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE
+                    self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG,
+                    self::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG
                 ),
                 E_USER_DEPRECATED
             );
         }
 
-        foreach ($ezFieldFormMapperDefinitionTags as $ezFieldFormMapperValueTag) {
+        foreach ($deprecatedFieldFormMapperDefinitionTags as $ezFieldFormMapperValueTag) {
             @trigger_error(
                 sprintf(
                     '`%s` service tag is deprecated and will be removed in eZ Platform 4.0. Please use `%s` instead.',
-                    self::FIELD_FORM_MAPPER_DEFINITION,
-                    self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION
+                    self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG,
+                    self::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG
                 ),
                 E_USER_DEPRECATED
             );
         }
 
         return array_merge(
-            $ezFieldFormMapperValueTags,
-            $ezFieldFormMapperDefinitionTags,
-            $ezplatformFieldFormMapperValueTags,
-            $ezplatformFieldFormMapperDefinitionTags
+            $deprecatedFieldFormMapperValueTags,
+            $deprecatedFieldFormMapperDefinitionTags,
+            $fieldFormMapperValueTags,
+            $fieldFormMapperDefinitionTags
         );
     }
 }

--- a/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -18,7 +18,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
-    const FIELD_TYPE_FORM_MAPPER_DISPATCHER = 'ezrepoforms.field_type_form_mapper.dispatcher';
+    public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = 'ezrepoforms.field_type_form_mapper.dispatcher';
+    public const FIELD_FORM_MAPPER_VALUE = 'ez.fieldFormMapper.value';
+    public const FIELD_FORM_MAPPER_DEFINITION = 'ez.fieldFormMapper.definition';
+    public const EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE = 'ezplatform.field_type.form_mapper.value';
+    public const EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION = 'ezplatform.field_type.form_mapper.definition';
 
     public function process(ContainerBuilder $container)
     {
@@ -32,7 +36,7 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
             foreach ($tags as $tag) {
                 if (!isset($tag['fieldType'])) {
                     throw new LogicException(
-                        'ez.fieldFormMapper or ezplatform.field_type.form_mapper service tags need a "fieldType" attribute to identify which field type the mapper is for. None given.'
+                        '`ezplatform.field_type.form_mapper` or deprecated `ez.fieldFormMapper` service tags need a "fieldType" attribute to identify which field type the mapper is for. None given.'
                     );
                 }
 
@@ -43,8 +47,8 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 
     /**
      * Gathers services tagged as either
-     * - ez.fieldFormMapper.value
-     * - ez.fieldFormMapper.definition
+     * - ez.fieldFormMapper.value (deprecated)
+     * - ez.fieldFormMapper.definition (deprecated)
      * - ezplatform.field_type.form_mapper.value
      * - ezplatform.field_type.form_mapper.definition.
      *
@@ -54,17 +58,31 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
      */
     private function findTaggedFormMapperServices(ContainerBuilder $container): array
     {
-        $ezFieldFormMapperValueTags = $container->findTaggedServiceIds('ez.fieldFormMapper.value');
-        $ezFieldFormMapperDefinitionTags = $container->findTaggedServiceIds('ez.fieldFormMapper.definition');
-        $ezplatformFieldFormMapperValueTags = $container->findTaggedServiceIds('ezplatform.field_type.form_mapper.value');
-        $ezplatformFieldFormMapperDefinitionTags = $container->findTaggedServiceIds('ezplatform.field_type.form_mapper.definition');
+        $ezFieldFormMapperValueTags = $container->findTaggedServiceIds(self::FIELD_FORM_MAPPER_VALUE);
+        $ezFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::FIELD_FORM_MAPPER_DEFINITION);
+        $ezplatformFieldFormMapperValueTags = $container->findTaggedServiceIds(self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE);
+        $ezplatformFieldFormMapperDefinitionTags = $container->findTaggedServiceIds(self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION);
 
         foreach ($ezFieldFormMapperValueTags as $ezFieldFormMapperValueTag) {
-            @trigger_error('`ez.fieldFormMapper.value` service tag is deprecated and will be removed in version 9. Please use `ezplatform.field_type.form_mapper.value` instead.', E_USER_DEPRECATED);
+            @trigger_error(
+                sprintf(
+                    '`%s` service tag is deprecated and will be removed in eZ Platform 4.0. Please use `%s` instead.',
+                    self::FIELD_FORM_MAPPER_VALUE,
+                    self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE
+                ),
+                E_USER_DEPRECATED
+            );
         }
 
         foreach ($ezFieldFormMapperDefinitionTags as $ezFieldFormMapperValueTag) {
-            @trigger_error('`ez.fieldFormMapper.definition` service tag is deprecated and will be removed in version 9. Please use `ezplatform.field_type.form_mapper.definition` instead.', E_USER_DEPRECATED);
+            @trigger_error(
+                sprintf(
+                    '`%s` service tag is deprecated and will be removed in eZ Platform 4.0. Please use `%s` instead.',
+                    self::FIELD_FORM_MAPPER_DEFINITION,
+                    self::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION
+                ),
+                E_USER_DEPRECATED
+            );
         }
 
         return array_merge(

--- a/bundle/Resources/config/fieldtypes.yaml
+++ b/bundle/Resources/config/fieldtypes.yaml
@@ -25,63 +25,63 @@ services:
 
     EzSystems\RepositoryForms\FieldType\Mapper\AuthorFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezauthor }
-            - { name: ez.fieldFormMapper.value, fieldType: ezauthor }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezauthor }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezauthor }
 
     EzSystems\RepositoryForms\FieldType\Mapper\BinaryFileFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezbinaryfile }
-            - { name: ez.fieldFormMapper.value, fieldType: ezbinaryfile }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezbinaryfile }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezbinaryfile }
 
     EzSystems\RepositoryForms\FieldType\Mapper\CheckboxFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezboolean }
-            - { name: ez.fieldFormMapper.value, fieldType: ezboolean }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezboolean }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezboolean }
 
     EzSystems\RepositoryForms\FieldType\Mapper\SelectionFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezselection }
-            - { name: ez.fieldFormMapper.value, fieldType: ezselection }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezselection }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezselection }
 
     EzSystems\RepositoryForms\FieldType\Mapper\CountryFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezcountry }
-            - { name: ez.fieldFormMapper.value, fieldType: ezcountry }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezcountry }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezcountry }
 
     EzSystems\RepositoryForms\FieldType\Mapper\DateFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezdate }
-            - { name: ez.fieldFormMapper.value, fieldType: ezdate }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezdate }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezdate }
 
     EzSystems\RepositoryForms\FieldType\Mapper\DateTimeFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezdatetime }
-            - { name: ez.fieldFormMapper.value, fieldType: ezdatetime }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezdatetime }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezdatetime }
 
     EzSystems\RepositoryForms\FieldType\Mapper\FloatFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezfloat }
-            - { name: ez.fieldFormMapper.value, fieldType: ezfloat }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezfloat }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezfloat }
 
     EzSystems\RepositoryForms\FieldType\Mapper\ImageFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezimage }
-            - { name: ez.fieldFormMapper.value, fieldType: ezimage }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezimage }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezimage }
 
     EzSystems\RepositoryForms\FieldType\Mapper\IntegerFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezinteger }
-            - { name: ez.fieldFormMapper.value, fieldType: ezinteger }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezinteger }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezinteger }
 
     EzSystems\RepositoryForms\FieldType\Mapper\ISBNFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezisbn }
-            - { name: ez.fieldFormMapper.value, fieldType: ezisbn }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezisbn }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezisbn }
 
     EzSystems\RepositoryForms\FieldType\Mapper\MediaFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezmedia }
-            - { name: ez.fieldFormMapper.value, fieldType: ezmedia }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezmedia }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezmedia }
 
     EzSystems\RepositoryForms\FieldType\Mapper\AbstractRelationFormMapper:
         abstract: true
@@ -94,8 +94,8 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezobjectrelation }
-            - { name: ez.fieldFormMapper.value, fieldType: ezobjectrelation }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezobjectrelation }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezobjectrelation }
 
     EzSystems\RepositoryForms\FieldType\Mapper\RelationListFormMapper:
         parent: EzSystems\RepositoryForms\FieldType\Mapper\AbstractRelationFormMapper
@@ -103,43 +103,43 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezobjectrelationlist }
-            - { name: ez.fieldFormMapper.value, fieldType: ezobjectrelationlist }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezobjectrelationlist }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezobjectrelationlist }
 
     EzSystems\RepositoryForms\FieldType\Mapper\TextLineFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezstring }
-            - { name: ez.fieldFormMapper.value, fieldType: ezstring }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezstring }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezstring }
 
     EzSystems\RepositoryForms\FieldType\Mapper\TextBlockFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: eztext }
-            - { name: ez.fieldFormMapper.value, fieldType: eztext }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: eztext }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: eztext }
 
     EzSystems\RepositoryForms\FieldType\Mapper\TimeFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: eztime }
-            - { name: ez.fieldFormMapper.value, fieldType: eztime }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: eztime }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: eztime }
 
     EzSystems\RepositoryForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper:
         abstract: true
 
     EzSystems\RepositoryForms\FieldType\Mapper\UserAccountFieldValueFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: ezuser }
-            - { name: ez.fieldFormMapper.value, fieldType: ezuser }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: ezuser }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezuser }
 
     EzSystems\RepositoryForms\FieldType\Mapper\UrlFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.value, fieldType: ezurl }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezurl }
 
     EzSystems\RepositoryForms\FieldType\Mapper\MapLocationFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.value, fieldType: ezgmaplocation }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezgmaplocation }
 
     EzSystems\RepositoryForms\FieldType\Mapper\KeywordFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.value, fieldType: ezkeyword }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezkeyword }
 
     ezrepoforms.field_type.form_mapper.ezemail:
         parent: EzSystems\RepositoryForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper
@@ -147,10 +147,10 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ez.fieldFormMapper.value, fieldType: ezemail }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezemail }
         calls:
             - [setFormType, ['Symfony\Component\Form\Extension\Core\Type\EmailType']]
 
     EzSystems\RepositoryForms\FieldType\Mapper\ImageAssetFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.value, fieldType: ezimageasset }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezimageasset }

--- a/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RepositoryFormsBundle\Tests\DependencyInjection\Compiler;
+
+use EzSystems\RepositoryForms\Limitation\LimitationValueMapperInterface;
+use EzSystems\RepositoryFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setDefinition(FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_DISPATCHER, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
+    }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testRegisterMappers(string $tag)
+    {
+        $fieldTypeIdentifier = 'field_type_identifier';
+        $serviceId = 'service_id';
+        $def = new Definition();
+        $def->addTag($tag, ['fieldType' => $fieldTypeIdentifier]);
+//        $def->setClass(\get_class($this->createMock(LimitationValueMapperInterface::class)));
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_DISPATCHER,
+            'addMapper',
+            [new Reference($serviceId), $fieldTypeIdentifier]
+        );
+    }
+
+    public function tagsProvider(): array
+    {
+        return [
+            ['ez.fieldFormMapper.value'],
+            ['ez.fieldFormMapper.definition'],
+            ['ezplatform.field_type.form_mapper.value'],
+            ['ezplatform.field_type.form_mapper.definition'],
+        ];
+    }
+}

--- a/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -17,14 +17,14 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->setDefinition(FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_DISPATCHER, new Definition());
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new FieldTypeFormMapperDispatcherPass());
     }
@@ -52,10 +52,10 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
     public function tagsProvider(): array
     {
         return [
-            [FieldTypeFormMapperDispatcherPass::FIELD_FORM_MAPPER_VALUE],
-            [FieldTypeFormMapperDispatcherPass::FIELD_FORM_MAPPER_DEFINITION],
-            [FieldTypeFormMapperDispatcherPass::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE],
-            [FieldTypeFormMapperDispatcherPass::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION],
+            [FieldTypeFormMapperDispatcherPass::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG],
+            [FieldTypeFormMapperDispatcherPass::DEPRECATED_FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG],
+            [FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG],
+            [FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_DEFINITION_SERVICE_TAG],
         ];
     }
 }

--- a/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/RepositoryFormsBundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -38,7 +38,6 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
         $serviceId = 'service_id';
         $def = new Definition();
         $def->addTag($tag, ['fieldType' => $fieldTypeIdentifier]);
-//        $def->setClass(\get_class($this->createMock(LimitationValueMapperInterface::class)));
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -53,10 +52,10 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
     public function tagsProvider(): array
     {
         return [
-            ['ez.fieldFormMapper.value'],
-            ['ez.fieldFormMapper.definition'],
-            ['ezplatform.field_type.form_mapper.value'],
-            ['ezplatform.field_type.form_mapper.definition'],
+            [FieldTypeFormMapperDispatcherPass::FIELD_FORM_MAPPER_VALUE],
+            [FieldTypeFormMapperDispatcherPass::FIELD_FORM_MAPPER_DEFINITION],
+            [FieldTypeFormMapperDispatcherPass::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_VALUE],
+            [FieldTypeFormMapperDispatcherPass::EZPLATFORM_FIELD_TYPE_FORM_MAPPER_DEFINITION],
         ];
     }
 }


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-30462

Tags used to register Field Type features in the dependency injection container should be consistent and follow Symfony convention (snake case)

Relates to:
[https://github.com/ezsystems/ezpublish-kernel/pull/2653](https://github.com/ezsystems/ezpublish-kernel/pull/2653)
[https://github.com/ezsystems/ezplatform-matrix-fieldtype/pull/15](https://github.com/ezsystems/ezplatform-matrix-fieldtype/pull/15)

```
ez.fieldFormMapper.value => ezplatform.field_type.form_mapper.value
ez.fieldFormMapper.definition => ezplatform.field_type.form_mapper.definition
```