### PR TITLE
EZP-30812: Fixed deprecated use of Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch method

### DIFF
--- a/lib/Data/Mapper/ContentTypeDraftMapper.php
+++ b/lib/Data/Mapper/ContentTypeDraftMapper.php
@@ -85,10 +85,7 @@ class ContentTypeDraftMapper implements FormDataMapperInterface
                 $language
             );
 
-            $this->eventDispatcher->dispatch(
-                FieldDefinitionMappingEvent::NAME,
-                $event
-            );
+            $this->eventDispatcher->dispatch($event, FieldDefinitionMappingEvent::NAME);
 
             $contentTypeData->addFieldDefinitionData($event->getFieldDefinitionData());
         }

--- a/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
+++ b/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
@@ -74,7 +74,7 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
      */
     protected function dispatchDefaultAction($defaultActionEventName, FormActionEvent $event)
     {
-        $this->eventDispatcher->dispatch($defaultActionEventName, $event);
+        $this->eventDispatcher->dispatch($event, $defaultActionEventName);
     }
 
     /**
@@ -83,7 +83,7 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
      */
     protected function dispatchAction($actionEventName, FormActionEvent $event)
     {
-        $this->eventDispatcher->dispatch($actionEventName, $event);
+        $this->eventDispatcher->dispatch($event, $actionEventName);
     }
 
     public function getResponse()

--- a/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
+++ b/tests/RepositoryForms/Data/Mapper/ContentTypeDraftMapperTest.php
@@ -167,8 +167,8 @@ class ContentTypeDraftMapperTest extends TestCase
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcherMock
             ->method('dispatch')
-            ->with(FieldDefinitionMappingEvent::NAME, $this->isInstanceOf(FieldDefinitionMappingEvent::class))
-            ->willReturnCallback(function (string $eventName, FieldDefinitionMappingEvent $event) {
+            ->with($this->isInstanceOf(FieldDefinitionMappingEvent::class), FieldDefinitionMappingEvent::NAME)
+            ->willReturnCallback(function (FieldDefinitionMappingEvent $event, string $eventName) {
                 $fieldDefinitionData = $event->getFieldDefinitionData();
                 $fieldDefinition = $event->getFieldDefinition();
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30812

## Description 

Fixed the following deprecation message:

```
Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
```

by swapping argument order in  `Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()` method calls.  
