### PR TITLE
EZP-30813: Stop using deprecated '_ezpublishLocation' route

### DIFF
--- a/lib/Form/Processor/ContentFormProcessor.php
+++ b/lib/Form/Processor/ContentFormProcessor.php
@@ -125,7 +125,7 @@ class ContentFormProcessor implements EventSubscriberInterface
         $event->setPayload('is_new', $draft->contentInfo->isDraft());
 
         $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->router->generate(
-            '_ezpublishLocation', [
+            'ez_urlalias', [
                 'locationId' => $content->contentInfo->mainLocationId,
             ]
         );
@@ -146,7 +146,7 @@ class ContentFormProcessor implements EventSubscriberInterface
 
         if ($data->isNew()) {
             $response = new RedirectResponse($this->router->generate(
-                '_ezpublishLocation',
+                'ez_urlalias',
                 ['locationId' => $data->getLocationStructs()[0]->parentLocationId]
             ));
             $event->setResponse($response);
@@ -171,7 +171,7 @@ class ContentFormProcessor implements EventSubscriberInterface
         }
 
         $url = $this->router->generate(
-            '_ezpublishLocation',
+            'ez_urlalias',
             ['locationId' => $redirectionLocationId],
             UrlGeneratorInterface::ABSOLUTE_URL
         );

--- a/lib/Form/Processor/User/UserCancelFormProcessor.php
+++ b/lib/Form/Processor/User/UserCancelFormProcessor.php
@@ -50,7 +50,7 @@ class UserCancelFormProcessor implements EventSubscriberInterface
             ? $data->getParentGroups()[0]->contentInfo->mainLocationId
             : $data->user->contentInfo->mainLocationId;
 
-        $response = new RedirectResponse($this->urlGenerator->generate('_ezpublishLocation', [
+        $response = new RedirectResponse($this->urlGenerator->generate('ez_urlalias', [
             'locationId' => $locationId,
         ]));
         $event->setResponse($response);

--- a/lib/Form/Processor/User/UserCreateFormProcessor.php
+++ b/lib/Form/Processor/User/UserCreateFormProcessor.php
@@ -62,7 +62,7 @@ class UserCreateFormProcessor implements EventSubscriberInterface
         $user = $this->userService->createUser($data, $data->getParentGroups());
 
         $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->urlGenerator->generate(
-            '_ezpublishLocation',
+            'ez_urlalias',
             ['locationId' => $user->contentInfo->mainLocationId],
             UrlGeneratorInterface::ABSOLUTE_URL
         );

--- a/lib/Form/Processor/User/UserUpdateFormProcessor.php
+++ b/lib/Form/Processor/User/UserUpdateFormProcessor.php
@@ -64,7 +64,7 @@ class UserUpdateFormProcessor implements EventSubscriberInterface
         $user = $this->userService->updateUser($data->user, $data);
 
         $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->urlGenerator->generate(
-            '_ezpublishLocation',
+            'ez_urlalias',
             ['locationId' => $user->contentInfo->mainLocationId],
             UrlGeneratorInterface::ABSOLUTE_URL
         );


### PR DESCRIPTION
Repository forms uses '_ezpublishLocation' route which is deprecated.

If using repository forms on front end it causes a redirect to a page which the front end cannot access.

Instead using '_ezpublishLocation' we should use it's replacement or 'ez_urlalias' so the redirect after publish goes the to expected location for the siteaccess