### PR TITLE
EZP-30828: Replaced \Symfony\Component\EventDispatcher\Event usage in favor of Symfony\Contracts\EventDispatcher\Event

### DIFF
--- a/lib/Event/FieldDefinitionMappingEvent.php
+++ b/lib/Event/FieldDefinitionMappingEvent.php
@@ -11,7 +11,7 @@ namespace EzSystems\RepositoryForms\Event;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\RepositoryForms\Data\FieldDefinitionData;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class FieldDefinitionMappingEvent extends Event
 {


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30828

## Description

Replaced `\Symfony\Component\EventDispatcher\Event` usage in favor of `Symfony\Contracts\EventDispatcher\Event`. 