### PR TITLE
Adjusted tests for changes in templates path

### DIFF
--- a/lib/Behat/Context/PagelayoutContext.php
+++ b/lib/Behat/Context/PagelayoutContext.php
@@ -61,8 +61,8 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
             case InstallType::PLATFORM_DEMO:
             case InstallType::ENTERPRISE_DEMO:
                 return $this->configResolver->hasParameter('page_layout')
-                    ? str_replace('@ezdesign', 'app/Resources/views/themes/tastefulplanet', $this->configResolver->getParameter('page_layout', null, 'site'))
-                    : str_replace('@ezdesign', 'app/Resources/views/themes/tastefulplanet', $this->configResolver->getParameter('pagelayout', null, 'site'));
+                    ? str_replace('@ezdesign', 'templates/themes/tastefulplanet', $this->configResolver->getParameter('page_layout', null, 'site'))
+                    : str_replace('@ezdesign', 'templates/themes/tastefulplanet', $this->configResolver->getParameter('pagelayout', null, 'site'));
             default:
                 throw new \Exception('Unrecognised install type');
         }


### PR DESCRIPTION
In SF4 the templates path changes from `app/Resources/views/` to `templates/`(https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md)

Adjusting tests for that. Issue detected in https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/224288223

