### PR TITLE
EZP-30313 As an editor I want to add more than 3 digits after decimal…

### DIFF
--- a/lib/Form/Type/FieldType/FloatFieldType.php
+++ b/lib/Form/Type/FieldType/FloatFieldType.php
@@ -65,7 +65,7 @@ class FloatFieldType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setDefaults(['min' => null, 'max' => null])
+            ->setDefaults(['min' => null, 'max' => null, 'scale' => 20])
             ->setAllowedTypes('min', ['float', 'integer', 'null'])
             ->setAllowedTypes('max', ['float', 'integer', 'null']);
     }


### PR DESCRIPTION
… point in a float field type

The NumberType symfony scale value is 3 by default. We can allow 20 decimal by default to avoid losing decimals.