### PR TITLE
EZP-30985: Removed deprecated choices_as_values Symfony form option

### DIFF
--- a/lib/FieldType/Mapper/AuthorFormMapper.php
+++ b/lib/FieldType/Mapper/AuthorFormMapper.php
@@ -39,7 +39,6 @@ class AuthorFormMapper implements FieldDefinitionFormMapperInterface, FieldValue
                         'field_definition.ezauthor.default_user_empty' => Type::DEFAULT_VALUE_EMPTY,
                         'field_definition.ezauthor.default_user_current' => Type::DEFAULT_CURRENT_USER,
                     ],
-                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'property_path' => 'fieldSettings[defaultAuthor]',

--- a/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/lib/FieldType/Mapper/CountryFormMapper.php
@@ -38,7 +38,6 @@ class CountryFormMapper implements FieldDefinitionFormMapperInterface, FieldValu
                     ->create(
                         'defaultValue',
                         CountryFieldType::class, [
-                            'choices_as_values' => true,
                             'multiple' => true,
                             'expanded' => false,
                             'required' => false,

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -35,7 +35,6 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         'field_definition.ezdate.default_type_empty' => Type::DEFAULT_EMPTY,
                         'field_definition.ezdate.default_type_current' => Type::DEFAULT_CURRENT_DATE,
                     ],
-                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'property_path' => 'fieldSettings[defaultType]',

--- a/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -41,7 +41,6 @@ class DateTimeFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
                     'field_definition.ezdatetime.default_type_current' => Type::DEFAULT_CURRENT_DATE,
                     'field_definition.ezdatetime.default_type_adjusted' => Type::DEFAULT_CURRENT_DATE_ADJUSTED,
                 ],
-                'choices_as_values' => true,
                 'expanded' => true,
                 'required' => true,
                 'property_path' => 'fieldSettings[defaultType]',

--- a/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/lib/FieldType/Mapper/MediaFormMapper.php
@@ -69,7 +69,6 @@ class MediaFormMapper implements FieldDefinitionFormMapperInterface, FieldValueF
                     'field_definition.ezmedia.type_windows_media_player' => Type::TYPE_WINDOWSMEDIA,
                     'field_definition.ezmedia.type_html5_audio' => Type::TYPE_HTML5_AUDIO,
                 ],
-                'choices_as_values' => true,
                 'required' => true,
                 'property_path' => 'fieldSettings[mediaType]',
                 'label' => 'field_definition.ezmedia.media_type',

--- a/lib/FieldType/Mapper/PageFormMapper.php
+++ b/lib/FieldType/Mapper/PageFormMapper.php
@@ -38,7 +38,6 @@ class PageFormMapper implements FieldDefinitionFormMapperInterface
         $fieldDefinitionForm
             ->add('defaultLayout', ChoiceType::class, [
                 'choices' => array_combine($availableLayouts, $availableLayouts),
-                'choices_as_values' => true,
                 'multiple' => false,
                 'expanded' => false,
                 'required' => false,

--- a/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/lib/FieldType/Mapper/RelationFormMapper.php
@@ -29,7 +29,6 @@ class RelationFormMapper extends AbstractRelationFormMapper
             ])
             ->add('selectionContentTypes', ChoiceType::class, [
                 'choices' => $this->getContentTypesHash(),
-                'choices_as_values' => true,
                 'expanded' => false,
                 'multiple' => true,
                 'required' => false,

--- a/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -31,7 +31,6 @@ class RelationListFormMapper extends AbstractRelationFormMapper
             ])
             ->add('selectionContentTypes', ChoiceType::class, [
                 'choices' => $this->getContentTypesHash(),
-                'choices_as_values' => true,
                 'expanded' => false,
                 'multiple' => true,
                 'required' => false,

--- a/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/lib/FieldType/Mapper/TimeFormMapper.php
@@ -46,7 +46,6 @@ class TimeFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         'field_definition.eztime.default_type_empty' => Type::DEFAULT_EMPTY,
                         'field_definition.eztime.default_type_current' => Type::DEFAULT_CURRENT_TIME,
                     ],
-                    'choices_as_values' => true,
                     'expanded' => true,
                     'required' => true,
                     'property_path' => 'fieldSettings[defaultType]',

--- a/lib/Form/Type/ContentType/FieldTypeChoiceType.php
+++ b/lib/Form/Type/ContentType/FieldTypeChoiceType.php
@@ -43,7 +43,6 @@ class FieldTypeChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->getFieldTypeChoices(),
-            'choices_as_values' => true,
         ]);
     }
 

--- a/lib/Form/Type/ContentType/SortFieldChoiceType.php
+++ b/lib/Form/Type/ContentType/SortFieldChoiceType.php
@@ -37,7 +37,6 @@ class SortFieldChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->getSortFieldChoices(),
-            'choices_as_values' => true,
         ]);
     }
 

--- a/lib/Form/Type/ContentType/SortOrderChoiceType.php
+++ b/lib/Form/Type/ContentType/SortOrderChoiceType.php
@@ -37,7 +37,6 @@ class SortOrderChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->getSortOrderChoices(),
-            'choices_as_values' => true,
         ]);
     }
 

--- a/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
+++ b/lib/Form/Type/FieldDefinition/FieldDefinitionType.php
@@ -115,7 +115,6 @@ class FieldDefinitionType extends AbstractType
             ->add(
                 'fieldGroup', ChoiceType::class, [
                     'choices' => $fieldsGroups,
-                    'choices_as_values' => true,
                     'required' => false,
                     'label' => 'field_definition.field_group',
                     'disabled' => $isTranslation,

--- a/lib/Form/Type/FieldType/CountryFieldType.php
+++ b/lib/Form/Type/FieldType/CountryFieldType.php
@@ -57,7 +57,6 @@ class CountryFieldType extends AbstractType
         $resolver->setDefaults([
             'expanded' => false,
             'choices' => $this->getCountryChoices($this->countriesInfo),
-            'choices_as_values' => true,
         ]);
     }
 

--- a/lib/Form/Type/FieldType/SelectionFieldType.php
+++ b/lib/Form/Type/FieldType/SelectionFieldType.php
@@ -45,7 +45,6 @@ class SelectionFieldType extends AbstractType
     {
         $resolver->setDefaults([
             'expanded' => false,
-            'choices_as_values' => true,
         ]);
     }
 }

--- a/lib/Form/Type/Role/PolicyType.php
+++ b/lib/Form/Type/Role/PolicyType.php
@@ -95,7 +95,6 @@ class PolicyType extends AbstractType
         $builder
             ->add('moduleFunction', ChoiceType::class, [
                 'choices' => $this->policyChoices,
-                'choices_as_values' => true,
                 'label' => 'role.policy.type',
                 'placeholder' => 'role.policy.type.choose',
             ])

--- a/lib/Form/Type/URL/URLListType.php
+++ b/lib/Form/Type/URL/URLListType.php
@@ -47,7 +47,6 @@ class URLListType extends AbstractType
                 $this->translator->trans('url.status.invalid', [], 'ezrepoforms_url') => false,
                 $this->translator->trans('url.status.valid', [], 'ezrepoforms_url') => true,
             ],
-            'choices_as_values' => true,
             'placeholder' => $this->translator->trans('url.status.all', [], 'ezrepoforms_url'),
             'required' => false,
         ]);

--- a/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
+++ b/lib/Limitation/Mapper/MultipleSelectionBasedMapper.php
@@ -34,7 +34,7 @@ abstract class MultipleSelectionBasedMapper implements LimitationFormMapperInter
         ];
         $choices = $this->getSelectionChoices();
         asort($choices, SORT_NATURAL | SORT_FLAG_CASE);
-        $options += ['choices' => array_flip($choices), 'choices_as_values' => true];
+        $options += ['choices' => array_flip($choices)];
         $form->add('limitationValues', ChoiceType::class, $options);
     }
 


### PR DESCRIPTION
| Question          | Answer
| -------------------- | ------------------
| **JIRA issue**  | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Target version** | eZ Platform `2.5.x`

The `choices_as_values` Symfony form option has been deprecated since Symfony 3.1.

Ref: https://symfony.com/doc/3.4/reference/forms/types/choice.html#choices-as-values

### QA

- [ ] Sanity checks in AdminUI for the following Field Types:
  * Author,
  * Country,
  * Date,
  * DateTime,
  * Media (Image, BinaryFile).

- [ ] Sanity check for creating Content Type with randomly choosen Field Types.
  * Adding Field Type,
  * Updating Field Type,
  * Choosing sort Field Type,
  * Choosing sort order,
  * Setting Field Group,
  * Country FT: default values,
  * Selection FT: default values,
  * Roles: adding/updating of policies,
  * Policies: Limitations chosen from a list (Language, ContentType, etc.)
  * Link manager: status filtering.