### PR TITLE
EZP-28900: Removed view transformer from FloatFieldType

### DIFF
--- a/lib/Form/Type/FieldType/FloatFieldType.php
+++ b/lib/Form/Type/FieldType/FloatFieldType.php
@@ -45,6 +45,8 @@ class FloatFieldType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezfloat')));
+
+        // Removes NumberToLocalizedStringTransformer which breaks "number" type HTML input
         $builder->resetViewTransformers();
     }
 

--- a/lib/Form/Type/FieldType/FloatFieldType.php
+++ b/lib/Form/Type/FieldType/FloatFieldType.php
@@ -45,6 +45,7 @@ class FloatFieldType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezfloat')));
+        $builder->resetViewTransformers();
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-28900

The root of the issue is that our `FloatFieldType` uses view transformer : `NumberToLocalizedStringTransformer`. This transformer is not set explicitly but it is inherited from symfony's `NumberType`. Symfony NumberType needs this transformer because  default `form_fields.html.twig` use `<input type='text">`  to display `number_widget`. AdminUI overwrites symfony's `form_fields.html.twig` including `number_widget` and number are displayed as `<input type="number"`. So this transformer is no needed and causes problems described in the ticket.  

related to : https://github.com/ezsystems/ezpublish-kernel/pull/2849