### PR TITLE
EZP-30918: Added information to relations about restricted access

### DIFF
--- a/lib/Form/Type/FieldType/RelationFieldType.php
+++ b/lib/Form/Type/FieldType/RelationFieldType.php
@@ -67,11 +67,10 @@ class RelationFieldType extends AbstractType
         /** @var Value $data */
         $data = $form->getData();
 
-        $contentId = $data->destinationContentId;
-        if (!$data instanceof Value || null === $contentId) {
+        if (!$data instanceof Value || null === $data->destinationContentId) {
             return;
         }
-
+        $contentId = $data->destinationContentId;
         $contentInfo = null;
         $contentType = null;
         $unauthorized = false;

--- a/lib/Form/Type/FieldType/RelationListFieldType.php
+++ b/lib/Form/Type/FieldType/RelationListFieldType.php
@@ -7,6 +7,7 @@ namespace EzSystems\RepositoryForms\Form\Type\FieldType;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\FieldType\RelationList\Value;
 use EzSystems\RepositoryForms\FieldType\DataTransformer\RelationListValueTransformer;
@@ -71,12 +72,22 @@ class RelationListFieldType extends AbstractType
         }
 
         foreach ($data->destinationContentIds as $contentId) {
-            $contentInfo = $this->contentService->loadContentInfo($contentId);
-            $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+            $contentInfo = null;
+            $contentType = null;
+            $unauthorized = false;
+
+            try {
+                $contentInfo = $this->contentService->loadContentInfo($contentId);
+                $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+            } catch (UnauthorizedException $e) {
+                $unauthorized = true;
+            }
 
             $view->vars['relations'][$contentId] = [
                 'contentInfo' => $contentInfo,
                 'contentType' => $contentType,
+                'unauthorized' => $unauthorized,
+                'contentId' => $contentId,
             ];
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30918
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Needs?    | https://github.com/ezsystems/ezplatform-admin-ui/pull/1135
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR introduces new Relation View to display content's relations. When a user has no access to see restricted relation then proper information will be displayed. 

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1135

Location view:
![Screen Shot 2019-11-18 at 11 23 13 AM](https://user-images.githubusercontent.com/1654712/69044796-de556f80-09f5-11ea-8152-4500f5c9f0fb.png)

Edit view:
![Screen Shot 2019-11-18 at 11 24 06 AM](https://user-images.githubusercontent.com/1654712/69044845-f5945d00-09f5-11ea-8d3c-2c9d8be9bc20.png)