### PR TITLE
EZP-31238: marked alternative image text as optional to ensure consistence with fieldtype

### DIFF
--- a/lib/Form/Type/FieldType/ImageFieldType.php
+++ b/lib/Form/Type/FieldType/ImageFieldType.php
@@ -38,6 +38,7 @@ class ImageFieldType extends AbstractType
                 TextType::class,
                 [
                     'label' => /** @Desc("Alternative text") */ 'content.field_type.ezimage.alternative_text',
+                    'required' => false,
                 ]
             );
     }


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-31238

According the `eZ/Publish/Core/FieldType/Image/Type.php:121` (https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Image/Type.php#L114) the alternative text is optinal.

Creating images without an alternative texts works fine using the repository services or the backend drag&drop image creation. Creating the image through the default content edit requires the alternative text is filled. The reasons for that is that the field is not marked as optional inside the form building: `EzSystems\RepositoryForms\Form\Type\FieldType\ImageFieldType:40`.

Already approved, discussed it in Slack:
> sylvainguittard:us:  1 day ago
Hi @daavidkllr!
Sorry for the late reply. I totally agree with you, it’s inconsistent and we should fix that.
Alternative text should be optional even if the image field is required.