### PR TITLE
EZP-31277: Added server timezone offset attr to ezdate form field

### DIFF
--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -60,7 +60,7 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         [
                             'required' => $fieldDefinition->isRequired,
                             'label' => $fieldDefinition->getName(),
-                            'attr' => ['data-timezone_offset' => $timezoneOffsetSeconds]
+                            'attr' => ['data-timezone-offset' => $timezoneOffsetSeconds]
                         ]
                     )
                     ->setAutoInitialize(false)

--- a/lib/FieldType/Mapper/DateFormMapper.php
+++ b/lib/FieldType/Mapper/DateFormMapper.php
@@ -49,6 +49,7 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
+        $timezoneOffsetSeconds = $data->value->date->getTimezone()->getOffset($data->value->date);
 
         $fieldForm
             ->add(
@@ -59,6 +60,7 @@ class DateFormMapper implements FieldDefinitionFormMapperInterface, FieldValueFo
                         [
                             'required' => $fieldDefinition->isRequired,
                             'label' => $fieldDefinition->getName(),
+                            'attr' => ['data-timezone_offset' => $timezoneOffsetSeconds]
                         ]
                     )
                     ->setAutoInitialize(false)


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-31277

flatpickr widget is instantiating with the wrong timezone offset, it should be server's timezone, not browser's one. Such configuration may result in an invalid default date for _ezdate_ field.

Added additional timezone offset attribute to _ezdate_ field in order to get this data later by flatpickr widget.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1185