### PR TITLE
EZP-31317: Loaded ContentType using preferred language in UserController

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -274,6 +274,7 @@ services:
             - "@ezpublish.api.service.language"
             - "@ezrepoforms.action_dispatcher.user"
             - '@eZ\Publish\API\Repository\PermissionResolver'
+            - '@eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider'
         parent: ezpublish.controller.base
 
     ezrepoforms.controller.user_register:


### PR DESCRIPTION
|     |     |
| --- | --- |
| **JIRA issue** | [EZP-31317](https://jira.ez.no/browse/EZP-31317) |
| **Type** | Bug
| **Target version** | 2.5

User Content create & edit actions need to load Content Type in current user's preferred language so Field Definition names used to display labels in create & edit forms are displayed in a proper language.
For full description and steps to reproduce please refer to [EZP-31317](https://jira.ez.no/browse/EZP-31317).

Merge up: since in eZ Platform 3.0 we use SA-aware layer, I expect this issue does not exist there, but we need to check that (not sure if SA-aware layer has user preferred language set).

**TODO**:
- [ ] Provide behat coverage (as a follow-up?)