### PR TITLE
EZP-31013: Use readonly instead of disabled for username form

### DIFF
--- a/lib/Form/Type/FieldType/UserAccountFieldType.php
+++ b/lib/Form/Type/FieldType/UserAccountFieldType.php
@@ -37,7 +37,7 @@ class UserAccountFieldType extends AbstractType
             ->add('username', TextType::class, [
                 'label' => /** @Desc("Username") */ 'content.field_type.ezuser.username',
                 'required' => true,
-                'attr' => $isUpdateForm ? ['disabled' => 'disabled'] : [],
+                'attr' => $isUpdateForm ? ['readonly' => 'readonly'] : [],
             ])
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,


### PR DESCRIPTION
This is a backport of fix introduced here:
https://github.com/ezsystems/ezplatform-content-forms/pull/17/