### PR TITLE
[Travis] Set Docker PHP image used for installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env:
         - BEHAT_OPTS="--mode=behat --profile=repository-forms --non-strict"
         - PHP_IMAGE=ezsystems/php:7.1-v1
+        # This env variable is actually used when installing dependencies
+        - PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
     # 7.2
     - name: "[PHP 7.2] PHP Unit tests"
       php: 7.2


### PR DESCRIPTION
Target version: **2.5**

While Behat Scenarios are executed inside a Docker container which relies on `$PHP_IMAGE` for Docker PHP image, the dependencies are installed relying on `$PHP_IMAGE_DEV`. For PHP 7.1 it should be set to `ezsystems/php:7.1-v1-dev`.

**TODO**
- [x] See if Travis passes