### PR TITLE
EZP-31449: Adapted TranslatablePropertyTransformer to properly handle nulls

### DIFF
--- a/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
+++ b/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
@@ -29,7 +29,7 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function transform($valueAsHash)
     {
-        if (!($valueAsHash && \is_array($valueAsHash) && isset($valueAsHash[$this->languageCode]))) {
+        if (!($valueAsHash && is_array($valueAsHash) && isset($valueAsHash[$this->languageCode]))) {
             return null;
         }
 
@@ -38,9 +38,7 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
-        if (false === $value || [] === $value) {
-            return [$this->languageCode => null];
-        }
+        $value = (false === $value || [] === $value) ? null : $value;
 
         return [$this->languageCode => $value];
     }

--- a/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
+++ b/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
@@ -29,7 +29,7 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function transform($valueAsHash)
     {
-        if (!($valueAsHash && is_array($valueAsHash) && isset($valueAsHash[$this->languageCode]))) {
+        if (!($valueAsHash && \is_array($valueAsHash) && isset($valueAsHash[$this->languageCode]))) {
             return null;
         }
 
@@ -38,6 +38,10 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
+        if (false === $value || [] === $value) {
+            return [$this->languageCode => null];
+        }
+
         return [$this->languageCode => $value];
     }
 }

--- a/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
+++ b/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
@@ -38,10 +38,6 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
-        if (!$value) {
-            return null;
-        }
-
         return [$this->languageCode => $value];
     }
 }

--- a/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
+++ b/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
@@ -62,8 +62,8 @@ class TranslatablePropertyTransformerTest extends TestCase
     public function reverseTransformProvider()
     {
         return [
-            [false, 'fre-FR', null],
-            [null, 'fre-FR', null],
+            [false, 'fre-FR', ['fre-FR' => false]],
+            [null, 'fre-FR', ['fre-FR' => null]],
             ['français', 'fre-FR', ['fre-FR' => 'français']],
             ['english', 'eng-GB', ['eng-GB' => 'english']],
             ['norsk', 'nor-NO', ['nor-NO' => 'norsk']],

--- a/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
+++ b/tests/RepositoryForms/Form/DataTransformer/TranslatablePropertyTransformerTest.php
@@ -62,7 +62,7 @@ class TranslatablePropertyTransformerTest extends TestCase
     public function reverseTransformProvider()
     {
         return [
-            [false, 'fre-FR', ['fre-FR' => false]],
+            [false, 'fre-FR', ['fre-FR' => null]],
             [null, 'fre-FR', ['fre-FR' => null]],
             ['français', 'fre-FR', ['fre-FR' => 'français']],
             ['english', 'eng-GB', ['eng-GB' => 'english']],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31449](https://jira.ez.no/browse/EZP-31449)
| **Bug**| yes
| **New feature**    | no
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     | no

Reverse transformation in `TranslatablePropertyTransformer` was adapted to properly handle `ContentType` and `ContentType's`  fieldtype translatable fields when the empty value was provided in form.

Original kernel PR and discussion: https://github.com/ezsystems/ezpublish-kernel/pull/2988 -> closed right now.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
