### PR TITLE
EZP-31557: Added timezone offset to ezdate field form value

### DIFF
--- a/lib/FieldType/DataTransformer/DateValueTransformer.php
+++ b/lib/FieldType/DataTransformer/DateValueTransformer.php
@@ -41,7 +41,7 @@ class DateValueTransformer implements DataTransformerInterface
             return null;
         }
 
-        return $value->date->getTimestamp();
+        return $value->date->getTimestamp() + $value->date->getOffset();
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31557
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no

The offset should be added to the final timestamp to convert it to the GMT time. Right now the server could be located in `America\Chicago` and the end-user with local time in Asia which in some conditions would show discrepancies in shown date. The final date during the publishing is converted to GMT time either way.

Related `admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1350

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
