### PR TITLE
[EZP-32397] Added 'isEditView' variable to DateFieldType View

### DIFF
--- a/lib/Form/Type/FieldType/DateFieldType.php
+++ b/lib/Form/Type/FieldType/DateFieldType.php
@@ -9,12 +9,23 @@ use EzSystems\RepositoryForms\FieldType\DataTransformer\DateValueTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Form Type representing ezdate field type.
  */
 class DateFieldType extends AbstractType
 {
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
     public function getName()
     {
         return $this->getBlockPrefix();
@@ -34,5 +45,15 @@ class DateFieldType extends AbstractType
     {
         $builder
             ->addModelTransformer(new DateValueTransformer());
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $isEditView =
+            $request->attributes->get('_route') === 'ez_content_draft_edit' ||
+            $request->attributes->get('_route') === 'ezplatform.content.translate';
+
+        $view->vars['attr']['data-action-type'] = $isEditView ? 'edit' : 'create';
     }
 }

--- a/lib/Form/Type/FieldType/DateFieldType.php
+++ b/lib/Form/Type/FieldType/DateFieldType.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class DateFieldType extends AbstractType
 {
+    private const EDIT_VIEWS = ['ez_content_draft_edit', 'ezplatform.content.translate'];
+
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
 
@@ -50,10 +52,7 @@ class DateFieldType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $request = $this->requestStack->getCurrentRequest();
-        $isEditView = \in_array(
-            $request->attributes->get('_route'),
-            ['ez_content_draft_edit', 'ezplatform.content.translate']
-        );
+        $isEditView = \in_array($request->attributes->get('_route'), self::EDIT_VIEWS);
 
         $view->vars['attr']['data-action-type'] = $isEditView ? 'edit' : 'create';
         $view->vars['attr']['class'] = 'ez-data-source__input';

--- a/lib/Form/Type/FieldType/DateFieldType.php
+++ b/lib/Form/Type/FieldType/DateFieldType.php
@@ -50,9 +50,10 @@ class DateFieldType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $request = $this->requestStack->getCurrentRequest();
-        $isEditView =
-            $request->attributes->get('_route') === 'ez_content_draft_edit' ||
-            $request->attributes->get('_route') === 'ezplatform.content.translate';
+        $isEditView = \in_array(
+            $request->attributes->get('_route'),
+            ['ez_content_draft_edit', 'ezplatform.content.translate']
+        );
 
         $view->vars['attr']['data-action-type'] = $isEditView ? 'edit' : 'create';
         $view->vars['attr']['class'] = 'ez-data-source__input';

--- a/lib/Form/Type/FieldType/DateFieldType.php
+++ b/lib/Form/Type/FieldType/DateFieldType.php
@@ -55,5 +55,7 @@ class DateFieldType extends AbstractType
             $request->attributes->get('_route') === 'ezplatform.content.translate';
 
         $view->vars['attr']['data-action-type'] = $isEditView ? 'edit' : 'create';
+        $view->vars['attr']['class'] = 'ez-data-source__input';
+        $view->vars['attr']['hidden'] = 'hidden';
     }
 }

--- a/lib/Form/Type/FieldType/DateFieldType.php
+++ b/lib/Form/Type/FieldType/DateFieldType.php
@@ -52,10 +52,6 @@ class DateFieldType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $request = $this->requestStack->getCurrentRequest();
-        $isEditView = \in_array($request->attributes->get('_route'), self::EDIT_VIEWS);
-
-        $view->vars['attr']['data-action-type'] = $isEditView ? 'edit' : 'create';
-        $view->vars['attr']['class'] = 'ez-data-source__input';
-        $view->vars['attr']['hidden'] = 'hidden';
+        $view->vars['isEditView'] = \in_array($request->attributes->get('_route'), self::EDIT_VIEWS);
     }
 }


### PR DESCRIPTION
JIRA issue: https://issues.ibexa.co/browse/EZP-32397
The second part of fix: https://github.com/ezsystems/ezplatform-admin-ui/pull/1729

This PR moves some logic from the template https://github.com/ezsystems/ezplatform-admin-ui/blob/v1.5.17/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig#L10 to the `lib/Form/Type/FieldType/DateFieldType.php` and adds an additional check for the Content Translate view.