### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-dist: focal
+dist: trusty
 sudo: required
 language: php
 
 env:
   global:
-    # For functional tests
+    #A For functional tests
     - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - SYMFONY_ENV=behat
     - SYMFONY_DEBUG=1
@@ -12,7 +12,7 @@ env:
 
 matrix:
   include:
-    # 7.1
+    #A 7.1
     - name: "[PHP 7.1] PHP Unit tests"
       php: 7.1
       env: TEST_CONFIG="phpunit.xml.dist"
@@ -21,50 +21,52 @@ matrix:
       env:
         - BEHAT_OPTS="--mode=behat --profile=repository-forms --non-strict"
         - PHP_IMAGE=ezsystems/php:7.1-v1
-        # This env variable is actually used when installing dependencies
+        #A This env variable is actually used when installing dependencies
         - PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev
-    # 7.2
+    #A 7.2
     - name: "[PHP 7.2] PHP Unit tests"
       php: 7.2
       env: TEST_CONFIG="phpunit.xml.dist"
-    # 7.4
+    #A 7.4
     - name: "[PHP 7.4] PHP Unit tests"
       php: 7.4
       env: TEST_CONFIG="phpunit.xml.dist"
 
-# test only master (+ Pull requests)
+#A test only master (+ Pull requests)
 branches:
   only:
     - master
     - /^\d.\d+$/
     - "/^feature-/"
 
-# reduce depth (history) of git checkout
+#A reduce depth (history) of git checkout
 git:
   depth: 30
 
-# disable mail notifications
+#A disable mail notifications
 notifications:
   email: false
 
 before_install:
-  # Disable XDebug for performance
+  #A Disable XDebug for performance
   - phpenv config-rm xdebug.ini
-  # Get latest composer build
+  #A Disable expired certificate
+  - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
+  #A Get latest composer build
   - travis_retry composer selfupdate
-  # Avoid memory issues on composer install
+  #A Avoid memory issues on composer install
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Detecting timezone issues by testing on random timezone
+  #A Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
-# setup requirements for running unit/behat tests
+#A setup requirements for running unit/behat tests
 install:
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ]; then ./bin/.travis/prepare_ezplatform.sh ; fi
 
-# execute phpunit or behat as the script command
+#A execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -c $TEST_CONFIG ; fi
-  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 sudo: required
 language: php
 
@@ -66,5 +66,5 @@ install:
 # execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -c $TEST_CONFIG ; fi
-  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
 

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -3,7 +3,9 @@
 # File for setting up system for unit/integration testing
 
 # Disable xdebug to speed things up as we don't currently generate coverge on travis
-if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] ; then phpenv config-rm xdebug.ini ; fi
+if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] ; then phpenv config-rm xdebug.ini
+  # Disable expired certificate
+. - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose ; fi
 
 # Update composer to newest version
 # disabled, issues with packagist/github, something..


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.